### PR TITLE
Error in parsing thread URL: fix formatSlackTS calculation error

### DIFF
--- a/slacktime.go
+++ b/slacktime.go
@@ -43,6 +43,6 @@ func parseSlackTS(timestamp string) (time.Time, error) {
 
 func formatSlackTS(ts time.Time) string {
 	hi := ts.Unix()
-	lo := ts.UnixNano() % 100000
+	lo := ts.UnixNano() % 1000000
 	return fmt.Sprintf("%d.%06d", hi, lo)
 }

--- a/slacktime_test.go
+++ b/slacktime_test.go
@@ -18,6 +18,7 @@ func Test_parseSlackTS(t *testing.T) {
 	}{
 		{"valid time", args{"1534552745.065949"}, time.Date(2018, 8, 18, 0, 39, 05, 65949, time.UTC), false},
 		{"another valid time", args{"1638494510.037400"}, time.Date(2021, 12, 3, 1, 21, 50, 37400, time.UTC), false},
+		{"the time when I slipped", args{"1645551829.244659"}, time.Date(2022, 2, 22, 17, 43, 49, 244659, time.UTC), false},
 		{"time without millis", args{"0"}, time.Date(1970, 1, 1, 0, 00, 00, 0, time.UTC), false},
 		{"invalid time", args{"x"}, time.Time{}, true},
 		{"invalid time", args{"x.x"}, time.Time{}, true},

--- a/url_parse_test.go
+++ b/url_parse_test.go
@@ -87,6 +87,12 @@ func TestParseURL(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:    "thread",
+			args:    args{"https://xxxxxx.slack.com/archives/CHANNEL/p1645551829244659"},
+			want:    &urlInfo{Channel: "CHANNEL", ThreadTS: "1645551829.244659"},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
* Were modulating with invalid modulator in formatSlackTS. Switch the modulo to modulate modularly.

<img src="https://media4.giphy.com/media/l41lWFYQVe9uxq6Ws/giphy.gif"/>