### PR TITLE
Minor tweaks and UI (ahem) improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -322,6 +322,12 @@ Command line flags are described as of version ``v1.3.1``.
    list users and their IDs.  The default output format is "text".
    Use ``-r json`` to output as JSON.
 
+\-no-user-cache
+   skip fetching users.  If this flag is specified, users won't be fetched
+   during startup.  This disables the username resolving for the text
+   output, I don't know why someone would use this flag, but it's there
+   if you must.
+
 \-o
    output filename for users and channels.  Use '-' for standard
    output. (default "-")

--- a/channels.go
+++ b/channels.go
@@ -30,7 +30,7 @@ func (sd *SlackDumper) getChannels(ctx context.Context, chanTypes []string) (Cha
 		chanTypes = allChanTypes
 	}
 
-	params := &slack.GetConversationsParameters{Types: chanTypes}
+	params := &slack.GetConversationsParameters{Types: chanTypes, Limit: sd.options.ChannelsPerReq}
 	allChannels := make([]slack.Channel, 0, 50)
 	for {
 		var (

--- a/channels.go
+++ b/channels.go
@@ -10,7 +10,9 @@ import (
 	"runtime/trace"
 	"strings"
 	"text/tabwriter"
+	"time"
 
+	"github.com/rusq/dlog"
 	"github.com/slack-go/slack"
 )
 
@@ -32,15 +34,17 @@ func (sd *SlackDumper) getChannels(ctx context.Context, chanTypes []string) (Cha
 
 	params := &slack.GetConversationsParameters{Types: chanTypes, Limit: sd.options.ChannelsPerReq}
 	allChannels := make([]slack.Channel, 0, 50)
-	for {
+	fetchStart := time.Now()
+	for i := 1; ; i++ {
 		var (
 			chans   []slack.Channel
 			nextcur string
 		)
+		reqStart := time.Now()
 		if err := withRetry(ctx, limiter, sd.options.Tier3Retries, func() error {
 			var err error
 			trace.WithRegion(ctx, "GetConversations", func() {
-				chans, nextcur, err = sd.client.GetConversations(params)
+				chans, nextcur, err = sd.client.GetConversationsContext(ctx, params)
 			})
 			return err
 
@@ -48,9 +52,18 @@ func (sd *SlackDumper) getChannels(ctx context.Context, chanTypes []string) (Cha
 			return nil, err
 		}
 		allChannels = append(allChannels, chans...)
+
+		dlog.Printf("channels request #%5d, fetched: %4d, total: %8d (speed: %6.2f/sec, avg: %6.2f/sec)\n",
+			i, len(chans), len(allChannels),
+			float64(len(chans))/float64(time.Since(reqStart).Seconds()),
+			float64(len(allChannels))/float64(time.Since(fetchStart).Seconds()),
+		)
+
 		if nextcur == "" {
+			dlog.Printf("channels fetch complete, total: %d channels", len(allChannels))
 			break
 		}
+
 		params.Cursor = nextcur
 		limiter.Wait(ctx)
 	}

--- a/channels_test.go
+++ b/channels_test.go
@@ -36,7 +36,7 @@ func TestSlackDumper_getChannels(t *testing.T) {
 				allChanTypes,
 			},
 			func(mc *mockClienter) {
-				mc.EXPECT().GetConversations(&slack.GetConversationsParameters{
+				mc.EXPECT().GetConversationsContext(context.Background(), &slack.GetConversationsParameters{
 					Types: allChanTypes,
 				}).Return(Channels{
 					slack.Channel{GroupConversation: slack.GroupConversation{
@@ -58,7 +58,7 @@ func TestSlackDumper_getChannels(t *testing.T) {
 				allChanTypes,
 			},
 			func(mc *mockClienter) {
-				mc.EXPECT().GetConversations(&slack.GetConversationsParameters{
+				mc.EXPECT().GetConversationsContext(context.Background(), &slack.GetConversationsParameters{
 					Types: allChanTypes,
 				}).Return(
 					nil,

--- a/channels_test.go
+++ b/channels_test.go
@@ -36,7 +36,7 @@ func TestSlackDumper_getChannels(t *testing.T) {
 				allChanTypes,
 			},
 			func(mc *mockClienter) {
-				mc.EXPECT().GetConversationsContext(context.Background(), &slack.GetConversationsParameters{
+				mc.EXPECT().GetConversationsContext(gomock.Any(), &slack.GetConversationsParameters{
 					Types: allChanTypes,
 				}).Return(Channels{
 					slack.Channel{GroupConversation: slack.GroupConversation{
@@ -58,7 +58,7 @@ func TestSlackDumper_getChannels(t *testing.T) {
 				allChanTypes,
 			},
 			func(mc *mockClienter) {
-				mc.EXPECT().GetConversationsContext(context.Background(), &slack.GetConversationsParameters{
+				mc.EXPECT().GetConversationsContext(gomock.Any(), &slack.GetConversationsParameters{
 					Types: allChanTypes,
 				}).Return(
 					nil,

--- a/clienter_mock.go
+++ b/clienter_mock.go
@@ -83,20 +83,20 @@ func (mr *mockClienterMockRecorder) GetConversationRepliesContext(ctx, params in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConversationRepliesContext", reflect.TypeOf((*mockClienter)(nil).GetConversationRepliesContext), ctx, params)
 }
 
-// GetConversations mocks base method.
-func (m *mockClienter) GetConversations(params *slack.GetConversationsParameters) ([]slack.Channel, string, error) {
+// GetConversationsContext mocks base method.
+func (m *mockClienter) GetConversationsContext(ctx context.Context, params *slack.GetConversationsParameters) ([]slack.Channel, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConversations", params)
+	ret := m.ctrl.Call(m, "GetConversationsContext", ctx, params)
 	ret0, _ := ret[0].([]slack.Channel)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetConversations indicates an expected call of GetConversations.
-func (mr *mockClienterMockRecorder) GetConversations(params interface{}) *gomock.Call {
+// GetConversationsContext indicates an expected call of GetConversationsContext.
+func (mr *mockClienterMockRecorder) GetConversationsContext(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConversations", reflect.TypeOf((*mockClienter)(nil).GetConversations), params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConversationsContext", reflect.TypeOf((*mockClienter)(nil).GetConversationsContext), ctx, params)
 }
 
 // GetFile mocks base method.

--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -156,6 +156,8 @@ func parseCmdLine(args []string) (params, error) {
 	fs.UintVar(&p.appCfg.Options.Tier2Burst, "t2-burst", slackdump.DefOptions.Tier2Burst, "Tier-2 limiter burst in `events` (affects users and channels).")
 	fs.StringVar(&p.appCfg.Options.UserCacheFilename, "user-cache-file", slackdump.DefOptions.UserCacheFilename, "user cache file`name`.")
 	fs.DurationVar(&p.appCfg.Options.MaxUserCacheAge, "user-cache-age", slackdump.DefOptions.MaxUserCacheAge, "user cache lifetime `duration`. Set this to 0 to disable cache.")
+	fs.BoolVar(&p.appCfg.Options.NoUserCache, "no-user-cache", slackdump.DefOptions.NoUserCache, "skip fetching users")
+
 	fs.Var(&p.appCfg.Oldest, "dump-from", "`timestamp` of the oldest message to fetch from (i.e. 2020-12-31T23:59:59)")
 	fs.Var(&p.appCfg.Latest, "dump-to", "`timestamp` of the latest message to fetch to (i.e. 2020-12-31T23:59:59)")
 

--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/trace"
+	"syscall"
 
 	"github.com/rusq/slackdump"
 	"github.com/rusq/slackdump/internal/app"
@@ -56,7 +57,7 @@ func main() {
 		dlog.SetDebug(true)
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	if err := run(ctx, params); err != nil {

--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -149,6 +149,7 @@ func parseCmdLine(args []string) (params, error) {
 	fs.IntVar(&p.appCfg.Options.Tier2Retries, "t2-retries", slackdump.DefOptions.Tier2Retries, "rate limit retries for channel listing.")
 	fs.IntVar(&p.appCfg.Options.DownloadRetries, "dl-retries", slackdump.DefOptions.DownloadRetries, "rate limit retries for file downloads.")
 	fs.IntVar(&p.appCfg.Options.ConversationsPerReq, "cpr", slackdump.DefOptions.ConversationsPerReq, "number of conversation `items` per request.")
+	fs.IntVar(&p.appCfg.Options.ChannelsPerReq, "npr", slackdump.DefOptions.ChannelsPerReq, "number of `channels` per request.")
 	fs.UintVar(&p.appCfg.Options.Tier3Boost, "limiter-boost", slackdump.DefOptions.Tier3Boost, "same as -t3-boost.")
 	fs.UintVar(&p.appCfg.Options.Tier3Boost, "t3-boost", slackdump.DefOptions.Tier3Boost, "Tier-3 rate limiter boost in `events` per minute, will be added to the\nbase slack tier event per minute value.")
 	fs.UintVar(&p.appCfg.Options.Tier3Burst, "limiter-burst", slackdump.DefOptions.Tier3Burst, "same as -t3-burst.")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/rusq/dlog v1.3.3
-	github.com/slack-go/slack v0.9.5
+	github.com/slack-go/slack v0.10.2
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11
 )

--- a/go.mod
+++ b/go.mod
@@ -19,4 +19,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 
-replace github.com/slack-go/slack => github.com/rusq/slack v0.9.6
+replace github.com/slack-go/slack => github.com/rusq/slack v0.10.2

--- a/go.sum
+++ b/go.sum
@@ -9,15 +9,14 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
 github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rusq/dlog v1.3.3 h1:Q9fZW1H/YEnlDg3Ph1k/BRSBfi/q5ezI+8Metws9tTI=
 github.com/rusq/dlog v1.3.3/go.mod h1:kjZAEvBu7m3+mnJQKoIeLul1YB3kJq/6lZBdDTZmpzA=
-github.com/rusq/slack v0.9.6 h1:fBblymtg++O61HcjvAa39fu4CqkD/ovZ4xxLzQD/3pI=
-github.com/rusq/slack v0.9.6/go.mod h1:wWL//kk0ho+FcQXcBTmEafUI5dz4qz5f4mMk8oIkioQ=
+github.com/rusq/slack v0.10.2 h1:EcWxQu6VytSCbjIuhyUwqpDuKWPotd4qjJDEiBlMnd4=
+github.com/rusq/slack v0.10.2/go.mod h1:5FLdBRv7VW/d9EBxx/eEktOptWygbA9K2QK/KW7ds1s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -65,7 +65,7 @@ func (app *App) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		dlog.Printf("job finished, dumped %d channels", n)
+		dlog.Printf("job finished, dumped %d item(s)", n)
 	}
 	return nil
 }

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -75,8 +75,9 @@ func (out Output) IsText() bool {
 }
 
 type SlackCreds struct {
-	Token  string
-	Cookie string
+	Token         string
+	Cookie        string
+	SSBInstanceID string
 }
 
 func (c SlackCreds) Valid() bool {

--- a/options.go
+++ b/options.go
@@ -20,9 +20,11 @@ type Options struct {
 	Tier3Boost          uint          // tier-3 limiter boost allows to increase or decrease the slack tier req/min rate.  Affects all tiers.
 	Tier3Burst          uint          // tier-3 limiter burst allows to set the limiter burst in req/sec.  Default of 1 is safe.
 	Tier3Retries        int           // number of retries to do when getting 429 on conversation fetch
-	ConversationsPerReq int           // number of messages we get per 1 api request. bigger the number, less requests, but they become more beefy.
+	ConversationsPerReq int           // number of messages we get per 1 API request. bigger the number, less requests, but they become more beefy.
+	ChannelsPerReq      int           // number of channels to fetch per 1 API request.
 	UserCacheFilename   string        // user cache filename
 	MaxUserCacheAge     time.Duration // how long the user cache is valid for.
+	NoUserCache         bool          // sometimes slack disallows user access, so we need a way to overcome that.
 }
 
 // DefOptions is the default options used when initialising slackdump instance.
@@ -37,6 +39,7 @@ var DefOptions = Options{
 	Tier3Burst:          1,             // safe value, who would ever want to modify it? I don't know.
 	Tier3Retries:        3,             // on tier 3 this was never a problem, even with limiter-boost=120
 	ConversationsPerReq: 200,           // this is the recommended value by Slack. But who listens to them anyway.
+	ChannelsPerReq:      500,           // channels are tier2 rate limited. We need to get as much per request as possible.
 	UserCacheFilename:   "users.json",  // seems logical
 	MaxUserCacheAge:     4 * time.Hour, // quick math:  that's 1/6th of a day, how's that, huh?
 }

--- a/options.go
+++ b/options.go
@@ -32,14 +32,14 @@ var DefOptions = Options{
 	DumpFiles:           false,
 	Workers:             defNumWorkers, // number of workers doing the file download
 	DownloadRetries:     3,             // this shouldn't even happen, as we have no limiter on files download.
-	Tier2Boost:          0,             // slack is being difficult, so no boost for tier 2.
+	Tier2Boost:          20,            // seems to work fine with this boost
 	Tier2Burst:          1,             // limiter will wait indefinitely if it is less than 1.
 	Tier2Retries:        20,            // see #28, sometimes slack is being difficult
 	Tier3Boost:          120,           // playing safe there, but generally value of 120 is fine.
 	Tier3Burst:          1,             // safe value, who would ever want to modify it? I don't know.
 	Tier3Retries:        3,             // on tier 3 this was never a problem, even with limiter-boost=120
 	ConversationsPerReq: 200,           // this is the recommended value by Slack. But who listens to them anyway.
-	ChannelsPerReq:      500,           // channels are tier2 rate limited. We need to get as much per request as possible.
+	ChannelsPerReq:      100,           // channels are tier2 rate limited. Slack is greedy and never returns more than 100 per call.
 	UserCacheFilename:   "users.json",  // seems logical
 	MaxUserCacheAge:     4 * time.Hour, // quick math:  that's 1/6th of a day, how's that, huh?
 }

--- a/slackdump.go
+++ b/slackdump.go
@@ -38,7 +38,7 @@ type clienter interface {
 	GetConversationInfoContext(ctx context.Context, channelID string, includeLocale bool) (*slack.Channel, error)
 	GetConversationHistoryContext(ctx context.Context, params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
 	GetConversationRepliesContext(ctx context.Context, params *slack.GetConversationRepliesParameters) (msgs []slack.Message, hasMore bool, nextCursor string, err error)
-	GetConversations(params *slack.GetConversationsParameters) (channels []slack.Channel, nextCursor string, err error)
+	GetConversationsContext(ctx context.Context, params *slack.GetConversationsParameters) (channels []slack.Channel, nextCursor string, err error)
 	GetFile(downloadURL string, writer io.Writer) error
 	GetUsers() ([]slack.User, error)
 }
@@ -130,7 +130,7 @@ func withRetry(ctx context.Context, l *rate.Limiter, maxAttempts int, fn func() 
 
 		msg := fmt.Sprintf("got rate limited, sleeping %s", rle.RetryAfter)
 		trace.Log(ctx, "info", msg)
-		dlog.Debug(msg)
+		dlog.Print(msg)
 
 		time.Sleep(rle.RetryAfter)
 	}

--- a/slackdump.go
+++ b/slackdump.go
@@ -77,7 +77,11 @@ func New(ctx context.Context, token string, cookie string, opts ...Option) (*Sla
 
 func NewWithOptions(ctx context.Context, token string, cookie string, opts Options) (*SlackDumper, error) {
 	sd := &SlackDumper{
-		client:  slack.New(token, slack.OptionCookie(cookie)),
+		client: slack.New(
+			token,
+			slack.OptionAuthCookie(cookie),
+			slack.OptionCookie("d-s", fmt.Sprintf("%d", time.Now().Unix()-10)),
+		),
 		options: opts,
 	}
 

--- a/users.go
+++ b/users.go
@@ -27,6 +27,10 @@ func (sd *SlackDumper) GetUsers(ctx context.Context) (Users, error) {
 	ctx, task := trace.NewTask(ctx, "GetUsers")
 	defer task.End()
 
+	if sd.options.NoUserCache {
+		return Users{}, nil
+	}
+
 	users, err := sd.loadUserCache(sd.options.UserCacheFilename, sd.options.MaxUserCacheAge)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
* progress report on channels and threads
* speed and average speed
* same output style for messages, channels, and threads
* tweak the tier-2 boost
* fetch channels with context to enable ^C termination
* -no-user-cache parameter