### PR TITLE
fix error handling in fetchUsers

### DIFF
--- a/clienter_mock.go
+++ b/clienter_mock.go
@@ -113,19 +113,19 @@ func (mr *mockClienterMockRecorder) GetFile(downloadURL, writer interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*mockClienter)(nil).GetFile), downloadURL, writer)
 }
 
-// GetUsers mocks base method.
-func (m *mockClienter) GetUsers() ([]slack.User, error) {
+// GetUsersContext mocks base method.
+func (m *mockClienter) GetUsersContext(ctx context.Context) ([]slack.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUsers")
+	ret := m.ctrl.Call(m, "GetUsersContext", ctx)
 	ret0, _ := ret[0].([]slack.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetUsers indicates an expected call of GetUsers.
-func (mr *mockClienterMockRecorder) GetUsers() *gomock.Call {
+// GetUsersContext indicates an expected call of GetUsersContext.
+func (mr *mockClienterMockRecorder) GetUsersContext(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsers", reflect.TypeOf((*mockClienter)(nil).GetUsers))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersContext", reflect.TypeOf((*mockClienter)(nil).GetUsersContext), ctx)
 }
 
 // MockReporter is a mock of Reporter interface.

--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"github.com/rusq/slackdump"
 	"github.com/rusq/slackdump/internal/app"
 	"github.com/rusq/slackdump/internal/tracer"
+	"github.com/slack-go/slack"
 
 	"github.com/joho/godotenv"
 	"github.com/rusq/dlog"
@@ -107,6 +109,10 @@ func run(ctx context.Context, p params) error {
 
 	if err := application.Run(ctx); err != nil {
 		trace.Logf(ctx, "error", "app.Run: %s", err.Error())
+		var ser slack.SlackErrorResponse
+		if errors.As(err, &ser) && ser.Err == "invalid_auth" {
+			return fmt.Errorf("%w: failed to authenticate:  please double check that token/cookie value are correct", ser)
+		}
 		return err
 	}
 	return nil

--- a/slackdump.go
+++ b/slackdump.go
@@ -40,7 +40,7 @@ type clienter interface {
 	GetConversationRepliesContext(ctx context.Context, params *slack.GetConversationRepliesParameters) (msgs []slack.Message, hasMore bool, nextCursor string, err error)
 	GetConversationsContext(ctx context.Context, params *slack.GetConversationsParameters) (channels []slack.Channel, nextCursor string, err error)
 	GetFile(downloadURL string, writer io.Writer) error
-	GetUsers() ([]slack.User, error)
+	GetUsersContext(ctx context.Context) ([]slack.User, error)
 }
 
 // tier represents rate limit tier:
@@ -88,7 +88,7 @@ func NewWithOptions(ctx context.Context, token string, cookie string, opts Optio
 	dlog.Println("> checking user cache...")
 	users, err := sd.GetUsers(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching users: %s", err)
+		return nil, fmt.Errorf("error fetching users: %w", err)
 	}
 
 	sd.Users = users

--- a/users_test.go
+++ b/users_test.go
@@ -238,7 +238,7 @@ func TestSlackDumper_fetchUsers(t *testing.T) {
 			fields{},
 			args{context.Background()},
 			func(mc *mockClienter) {
-				mc.EXPECT().GetUsers().Return([]slack.User(testUsers), nil)
+				mc.EXPECT().GetUsersContext(gomock.Any()).Return([]slack.User(testUsers), nil)
 			},
 			testUsers,
 			false,
@@ -248,7 +248,7 @@ func TestSlackDumper_fetchUsers(t *testing.T) {
 			fields{},
 			args{context.Background()},
 			func(mc *mockClienter) {
-				mc.EXPECT().GetUsers().Return(nil, errors.New("i don't think so"))
+				mc.EXPECT().GetUsersContext(gomock.Any()).Return(nil, errors.New("i don't think so"))
 			},
 			nil,
 			true,
@@ -258,7 +258,7 @@ func TestSlackDumper_fetchUsers(t *testing.T) {
 			fields{},
 			args{context.Background()},
 			func(mc *mockClienter) {
-				mc.EXPECT().GetUsers().Return([]slack.User{}, nil)
+				mc.EXPECT().GetUsersContext(gomock.Any()).Return([]slack.User{}, nil)
 			},
 			nil,
 			true,
@@ -313,7 +313,7 @@ func TestSlackDumper_GetUsers(t *testing.T) {
 			}},
 			args{context.Background()},
 			func(mc *mockClienter) {
-				mc.EXPECT().GetUsers().Return([]slack.User(testUsers), nil)
+				mc.EXPECT().GetUsersContext(gomock.Any()).Return([]slack.User(testUsers), nil)
 			},
 			testUsers,
 			false,


### PR DESCRIPTION
- better wording for invalid_auth error, should it occur.
- there was no error checking when fetching users, hence the invalid_auth was ignored and we failed on len(users) being 0.