### PR TITLE
Add Team.ID as a suffix to the user cache filename

### DIFF
--- a/clienter_mock.go
+++ b/clienter_mock.go
@@ -113,6 +113,21 @@ func (mr *mockClienterMockRecorder) GetFile(downloadURL, writer interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*mockClienter)(nil).GetFile), downloadURL, writer)
 }
 
+// GetTeamInfo mocks base method.
+func (m *mockClienter) GetTeamInfo() (*slack.TeamInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeamInfo")
+	ret0, _ := ret[0].(*slack.TeamInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamInfo indicates an expected call of GetTeamInfo.
+func (mr *mockClienterMockRecorder) GetTeamInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamInfo", reflect.TypeOf((*mockClienter)(nil).GetTeamInfo))
+}
+
 // GetUsersContext mocks base method.
 func (m *mockClienter) GetUsersContext(ctx context.Context) ([]slack.User, error) {
 	m.ctrl.T.Helper()

--- a/options.go
+++ b/options.go
@@ -40,7 +40,7 @@ var DefOptions = Options{
 	Tier3Retries:        3,             // on tier 3 this was never a problem, even with limiter-boost=120
 	ConversationsPerReq: 200,           // this is the recommended value by Slack. But who listens to them anyway.
 	ChannelsPerReq:      100,           // channels are tier2 rate limited. Slack is greedy and never returns more than 100 per call.
-	UserCacheFilename:   "users.json",  // seems logical
+	UserCacheFilename:   "users.cache", // seems logical
 	MaxUserCacheAge:     4 * time.Hour, // quick math:  that's 1/6th of a day, how's that, huh?
 }
 

--- a/users.go
+++ b/users.go
@@ -76,6 +76,8 @@ func (sd *SlackDumper) fetchUsers(ctx context.Context) (Users, error) {
 
 // loadUsers tries to load the users from the file
 func (sd *SlackDumper) loadUserCache(filename string, suffix string, maxAge time.Duration) (Users, error) {
+	filename = makeCacheFilename(filename, suffix)
+
 	if err := checkCacheFile(filename, maxAge); err != nil {
 		return nil, err
 	}
@@ -95,6 +97,8 @@ func (sd *SlackDumper) loadUserCache(filename string, suffix string, maxAge time
 }
 
 func (sd *SlackDumper) saveUserCache(filename string, suffix string, uu Users) error {
+	filename = makeCacheFilename(filename, suffix)
+
 	f, err := os.Create(filename)
 	if err != nil {
 		return errors.WithStack(err)

--- a/users_go118_test.go
+++ b/users_go118_test.go
@@ -1,0 +1,25 @@
+//go:build go1.18
+// +build go1.18
+
+package slackdump
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func FuzzFilenameSplit(f *testing.F) {
+	testInput := []string{
+		"users.json",
+		"channels.json",
+	}
+	for _, ti := range testInput {
+		f.Add(ti)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		split := filenameSplit(input)
+		joined := filenameJoin(split)
+		assert.Equal(t, input, joined)
+	})
+}

--- a/users_test.go
+++ b/users_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -143,18 +144,14 @@ func TestUsers_ToText(t *testing.T) {
 func TestSlackDumper_saveUserCache(t *testing.T) {
 
 	// test saving file works
-	sd := SlackDumper{}
+	sd := SlackDumper{teamID: testSuffix}
 
-	testFile, err := os.CreateTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(testFile.Name())
-	testFile.Close()
+	dir := t.TempDir()
+	testfile := filepath.Join(dir, "test.json")
 
-	assert.NoError(t, sd.saveUserCache(testFile.Name(), testSuffix, testUsers))
+	assert.NoError(t, sd.saveUserCache(testfile, testSuffix, testUsers))
 
-	reopenedF, err := os.Open(testFile.Name())
+	reopenedF, err := os.Open(makeCacheFilename(testfile, testSuffix))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/users_test.go
+++ b/users_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testSuffix = "UNIT"
+
 var testUsers = Users{
 	{ID: "LOL1", Name: "yippi", Deleted: false},
 	{ID: "DELD", Name: "ka", Deleted: true},
@@ -150,7 +152,7 @@ func TestSlackDumper_saveUserCache(t *testing.T) {
 	defer os.Remove(testFile.Name())
 	testFile.Close()
 
-	assert.NoError(t, sd.saveUserCache(testFile.Name(), testUsers))
+	assert.NoError(t, sd.saveUserCache(testFile.Name(), testSuffix, testUsers))
 
 	reopenedF, err := os.Open(testFile.Name())
 	if err != nil {
@@ -204,7 +206,7 @@ func TestSlackDumper_loadUserCache(t *testing.T) {
 				UserIndex: tt.fields.UserIndex,
 				options:   tt.fields.options,
 			}
-			got, err := sd.loadUserCache(tt.args.filename, tt.args.maxAge)
+			got, err := sd.loadUserCache(tt.args.filename, testSuffix, tt.args.maxAge)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SlackDumper.loadUserCache() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -346,6 +348,7 @@ func TestSlackDumper_GetUsers(t *testing.T) {
 
 			sd := &SlackDumper{
 				client:    mc,
+				teamID:    testSuffix,
 				Users:     tt.fields.Users,
 				UserIndex: tt.fields.UserIndex,
 				options:   tt.fields.options,
@@ -374,7 +377,7 @@ func gimmeTempFile(t *testing.T) string {
 func gimmeTempFileWithUsers(t *testing.T) string {
 	f := gimmeTempFile(t)
 	sd := SlackDumper{}
-	if err := sd.saveUserCache(f, testUsers); err != nil {
+	if err := sd.saveUserCache(f, testSuffix, testUsers); err != nil {
 		t.Fatal(err)
 	}
 	return f


### PR DESCRIPTION
* Slackdump could mistakenly load the users cache from a different  team ID in case it's called consequently for different slack workspaces. 
* Added fuzz tests to filename split/join functions.