### PR TITLE
Another jq example

### DIFF
--- a/examples/jq/find_matches_print_dates_and_text.sh
+++ b/examples/jq/find_matches_print_dates_and_text.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+SAMPLE=../sample.json
+
+cat "${SAMPLE}" | jq '.messages[] | select(( .text != null) and (.text | test("JoInEd";"i"))) | (.ts |= (tonumber|todate)) | .ts, .text' | tr -d '"'

--- a/examples/jq/print_messages.sh
+++ b/examples/jq/print_messages.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+SAMPLE=../sample.json
+
+cat "${SAMPLE}" | jq '.messages[]|.user +": "+.text' | tr -d '"'


### PR DESCRIPTION
This example finds messages that have the word "joined" (case insensitive) in the text attribute.  It converts the epoch timestamps to human readable.  And it outputs the timestamp and the text for each matching message.