### PR TITLE
Ensure all downloads are finished before terminating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,13 @@ $(OUTPUT).exe: $(OUTPUT)
 $(OUTPUT):
 	GOOS=$(GOOS) go build -ldflags=$(LDFLAGS) -o $(EXECUTABLE) $(CMD)
 
+x86_%:
+	GOARCH=amd64 go build -ldflags=$(LDFLAGS) -o $@ $(CMD)
+
+arm_%:
+	GOARCH=arm64 go build -ldflags=$(LDFLAGS) -o $@ $(CMD)
+
+
 clean:
 	-rm slackdump slackdump.exe $(wildcard *.zip)
 

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -247,7 +247,7 @@ func Filename(f *slack.File) string {
 	return fmt.Sprintf("%s-%s", f.ID, f.Name)
 }
 
-// Stop stops the downloader.
+// Stop waits for all transfers to finish, and stops the downloader.
 func (c *Client) Stop() {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -72,6 +72,7 @@ func (se *Export) messages(ctx context.Context, users types.Users) error {
 	if se.opts.IncludeFiles {
 		// start the downloader
 		dl.Start(ctx)
+		defer dl.Stop()
 	}
 
 	var chans []slack.Channel
@@ -86,7 +87,11 @@ func (se *Export) messages(ctx context.Context, users types.Users) error {
 		return fmt.Errorf("failed to create an index: %w", err)
 	}
 
-	return idx.Marshal(se.fs)
+	if err := idx.Marshal(se.fs); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (se *Export) exportChannels(ctx context.Context, dl *downloader.Client, users types.Users, el *structures.EntityList) ([]slack.Channel, error) {


### PR DESCRIPTION
- file downloader wasn't closed in Export, that may lead to zip file corruption.
