### PR TITLE
Fix URL parsing regexp to allow for spaces

### DIFF
--- a/internal/structures/url_parse.go
+++ b/internal/structures/url_parse.go
@@ -115,7 +115,7 @@ func ParseURL(slackURL string) (*SlackLink, error) {
 }
 
 // Sample: https://ora600.slack.com/archives/CHM82GF99/p1577694990000400
-var slackURLRe = regexp.MustCompile(`^https:\/\/[\w]+\.slack\.com\/archives\/[A-Z]{1}[A-Z0-9]+(\/p(\d+))?$`)
+var slackURLRe = regexp.MustCompile(`^https:\/\/[a-zA-Z0-9]{1}[-\w]+\.slack\.com\/archives\/[A-Z]{1}[A-Z0-9]+(\/p(\d+))?$`)
 
 // IsValidSlackURL returns true if the value looks like valid Slack URL, false
 // if not.

--- a/internal/structures/url_parse_test.go
+++ b/internal/structures/url_parse_test.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	sampleChannelURL = "https://ora600.slack.com/archives/CHM82GF99"
-	sampleThreadURL  = "https://ora600.slack.com/archives/CHM82GF99/p1577694990000400"
-	sampleDMURL      = "https://ora600.slack.com/archives/DL98HT3QA"
+	sampleChannelURL     = "https://ora600.slack.com/archives/CHM82GF99"
+	sampleThreadURL      = "https://ora600.slack.com/archives/CHM82GF99/p1577694990000400"
+	sampleThreadWDashURL = "https://ora-600.slack.com/archives/CHM82GF99/p1577694990000400"
+	sampleDMURL          = "https://ora600.slack.com/archives/DL98HT3QA"
 
 	sampleChannelID = "CHM82GF99"
 	sampleThreadTS  = "p1577694990000400"
@@ -33,6 +34,12 @@ func TestParseURL(t *testing.T) {
 		{
 			name:    "thread",
 			args:    args{sampleThreadURL},
+			want:    &SlackLink{Channel: "CHM82GF99", ThreadTS: "1577694990.000400"},
+			wantErr: false,
+		},
+		{
+			name:    "thread",
+			args:    args{sampleThreadWDashURL},
 			want:    &SlackLink{Channel: "CHM82GF99", ThreadTS: "1577694990.000400"},
 			wantErr: false,
 		},


### PR DESCRIPTION
Thanks to @pican79 for flagging this.

Fixes #99:
- updated slack link parsing regexp to allow for dashes in the workspace name.