### PR TITLE
new Silent logger PR.

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io"
 	"log"
 	"os"
 
@@ -16,3 +17,7 @@ type Interface interface {
 }
 
 var Default = dlog.New(log.Default().Writer(), "", log.LstdFlags, os.Getenv("DEBUG") == "1")
+
+// note: previously ioutil.Discard which is not deprecated in favord of io.Discard
+// so this is valid only from go1.16
+var Silent = dlog.New(io.Discard, "", log.LstdFlags, os.Getenv("DEBUG") == "1")


### PR DESCRIPTION
following the quick conversation
introduce logger.Silent in case we want to avoid logging on the terminal while dumping, useful for code using the slackdump API.
HTH.