### PR TITLE
Fix empty MPIMs shown in slack-export-viewer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(OUTPUT).exe: GOOS=windows
 $(OUTPUT).exe: $(OUTPUT)
 
 $(OUTPUT):
-	GOOS=$(GOOS) go build -ldflags=$(LDFLAGS) -o $(EXECUTABLE) $(CMD)
+	GOARCH=$(GOARCH) GOOS=$(GOOS) go build -ldflags=$(LDFLAGS) -o $(EXECUTABLE) $(CMD)
 
 x86_%:
 	GOARCH=amd64 go build -ldflags=$(LDFLAGS) -o $@ $(CMD)

--- a/internal/fixtures/conversation.go
+++ b/internal/fixtures/conversation.go
@@ -1,6 +1,6 @@
 package fixtures
 
-//TestConversationJSON channel: CHM82GF99
+// TestConversationJSON channel: CHM82GF99
 const TestConversationJSON = `
 {
 	"name": "everything",
@@ -324,5 +324,45 @@ const TestConversationJSON = `
 	  }
 	],
 	"channel_id": "CHM82GF99"
+  }
+`
+
+const TestChannel = `
+  {
+    "id": "CLPGTGPAA",
+    "created": 1563771279,
+    "is_open": false,
+    "last_read": "1656044916.988719",
+    "is_group": false,
+    "is_shared": false,
+    "is_im": false,
+    "is_ext_shared": false,
+    "is_org_shared": false,
+    "is_pending_ext_shared": false,
+    "is_private": false,
+    "is_mpim": false,
+    "unlinked": 0,
+    "name_normalized": "random",
+    "num_members": 0,
+    "priority": 0,
+    "user": "",
+    "name": "random",
+    "creator": "LOL1",
+    "is_archived": false,
+    "members": null,
+    "topic": {
+      "value": "Non-work banter and water cooler conversation",
+      "creator": "LOL1",
+      "last_set": 1563771279
+    },
+    "purpose": {
+      "value": "A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you'd prefer to keep out of more focused work-related channels.",
+      "creator": "LOL1",
+      "last_set": 1563771279
+    },
+    "is_channel": true,
+    "is_general": false,
+    "is_member": true,
+    "locale": "en-US"
   }
 `

--- a/internal/fixtures/mpim.go
+++ b/internal/fixtures/mpim.go
@@ -1,0 +1,129 @@
+package fixtures
+
+const (
+	MpIM = `
+  {
+    "id": "C01AB34E90U",
+    "created": 1615855270,
+    "is_open": false,
+    "is_group": false,
+    "is_shared": false,
+    "is_im": false,
+    "is_ext_shared": false,
+    "is_org_shared": false,
+    "is_pending_ext_shared": false,
+    "is_private": true,
+    "is_mpim": true,
+    "unlinked": 0,
+    "name_normalized": "mpdm-yippi--ka--yay--motherfucker-1",
+    "num_members": 4,
+    "priority": 0,
+    "user": "",
+    "name": "mpdm-yippi--ka--yay--motherfucker-1",
+    "creator": "LOL1",
+    "is_archived": false,
+    "members": [
+      "LOL1",
+      "DELD",
+      "LOL3",
+      "LOL4"
+    ],
+    "topic": {
+      "value": "",
+      "creator": "",
+      "last_set": 0
+    },
+    "purpose": {
+      "value": "Group messaging with: @yippi @ka @yay @motherfucker",
+      "creator": "LOL1",
+      "last_set": 1615855270
+    },
+    "is_channel": true,
+    "is_general": false,
+    "is_member": true,
+    "locale": ""
+  }
+`
+
+	MpIMNoMembers = `
+  {
+    "id": "G01M34GA2BX",
+    "created": 1612757627,
+    "is_open": false,
+    "last_read": "1614837294.003700",
+    "is_group": true,
+    "is_shared": false,
+    "is_im": false,
+    "is_ext_shared": false,
+    "is_org_shared": false,
+    "is_pending_ext_shared": false,
+    "is_private": true,
+    "is_mpim": true,
+    "unlinked": 0,
+    "name_normalized": "mpdm-yippi--yay--motherfucker-1",
+    "num_members": 0,
+    "priority": 0,
+    "user": "",
+    "name": "mpdm-yippi--yay--motherfucker-1",
+    "creator": "LOL1",
+    "is_archived": false,
+    "members": [],
+    "topic": {
+      "value": "",
+      "creator": "",
+      "last_set": 0
+    },
+    "purpose": {
+      "value": "Group messaging with: @yippi @yay @motherfucker",
+      "creator": "LOL1",
+      "last_set": 1612757627
+    },
+    "is_channel": false,
+    "is_general": false,
+    "is_member": true,
+    "locale": ""
+  }
+`
+
+	MpIMnoMembersFixed = `  {
+    "id": "G01M34GA2BX",
+    "created": 1612757627,
+    "is_open": false,
+    "last_read": "1614837294.003700",
+    "is_group": true,
+    "is_shared": false,
+    "is_im": false,
+    "is_ext_shared": false,
+    "is_org_shared": false,
+    "is_pending_ext_shared": false,
+    "is_private": true,
+    "is_mpim": true,
+    "unlinked": 0,
+    "name_normalized": "mpdm-yippi--yay--motherfucker-1",
+    "num_members": 0,
+    "priority": 0,
+    "user": "",
+    "name": "mpdm-yippi--yay--motherfucker-1",
+    "creator": "LOL1",
+    "is_archived": false,
+    "members": [
+		"LOL1",
+		"LOL3",
+		"LOL4"
+	],
+    "topic": {
+      "value": "",
+      "creator": "",
+      "last_set": 0
+    },
+    "purpose": {
+      "value": "Group messaging with: @yippi @yay @motherfucker",
+      "creator": "LOL1",
+      "last_set": 1612757627
+    },
+    "is_channel": false,
+    "is_general": false,
+    "is_member": true,
+    "locale": ""
+  }`
+)

--- a/internal/structures/mpim.go
+++ b/internal/structures/mpim.go
@@ -1,0 +1,71 @@
+package structures
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+const (
+	mpimNameSep = "--"
+	mpimPrefix  = "mpdm-"
+)
+
+// FixMpIMmembers verifies Channel.Members to contain all channel members, if
+// not, it attempts to populate it by parsing out the usernames from
+// name_normalized, and populating Channel.Members with IDs of the users
+// discovered.  usernameIDs is a mapping of username -> user_id.
+func FixMpIMmembers(ch *slack.Channel, users []slack.User) (*slack.Channel, error) {
+	if !isMpIM(ch) {
+		return nil, fmt.Errorf("not a MpIM channel: %s (IsMpIM=%v)", ch.ID, ch.IsMpIM)
+	}
+	if len(ch.Members) == mpimMemberCount(ch.NameNormalized) {
+		return ch, nil
+	}
+	members, err := parseMpIMmembers(ch.NameNormalized, usernameIDs(users))
+	if err != nil {
+		return nil, err
+	}
+	ch.Members = members
+	return ch, nil
+}
+
+func mpimMemberCount(nameNormalized string) int {
+	return strings.Count(nameNormalized, mpimNameSep) + 1
+}
+
+func isMpIM(ch *slack.Channel) bool {
+	return ch.IsMpIM && strings.HasPrefix(ch.NameNormalized, mpimPrefix)
+}
+
+func parseMpIMmembers(nn string, usernameIDs map[string]string) ([]string, error) {
+	if mpimMemberCount(nn) == 0 {
+		return nil, errors.New("no members in mpim")
+	}
+	if len(usernameIDs) == 0 {
+		return nil, errors.New("no user mapping")
+	}
+	nn = strings.TrimRight(strings.TrimLeft(nn, mpimPrefix), "-1")
+	names := strings.Split(nn, mpimNameSep)
+	var members = make([]string, len(names))
+	for i := range names {
+		var ok bool
+		members[i], ok = usernameIDs[names[i]]
+		if !ok {
+			// TODO: log?
+			continue
+		}
+	}
+	return members, nil
+}
+
+// UsernameIDs returns a mapping of user.name->user.id.
+func usernameIDs(us []slack.User) map[string]string {
+	var ui = make(map[string]string)
+	for _, u := range us {
+		ui[u.Name] = u.ID
+	}
+	return ui
+}

--- a/internal/structures/mpim_test.go
+++ b/internal/structures/mpim_test.go
@@ -1,0 +1,188 @@
+package structures
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/slack-go/slack"
+
+	"github.com/rusq/slackdump/v2/internal/fixtures"
+)
+
+var (
+	testMpIM          = fixtures.Load[*slack.Channel](fixtures.MpIM)
+	testMpIMnoMembers = fixtures.Load[*slack.Channel](fixtures.MpIMNoMembers)
+	testMpIMFixed     = fixtures.Load[*slack.Channel](fixtures.MpIMnoMembersFixed)
+	testChannel       = fixtures.Load[*slack.Channel](fixtures.TestChannel)
+	testMpIMUsers     = fixtures.TestUsers
+)
+
+func TestFixMpIMmembers(t *testing.T) {
+	type args struct {
+		ch    *slack.Channel
+		users []slack.User
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *slack.Channel
+		wantErr bool
+	}{
+		{
+			"fixed",
+			args{ch: testMpIMnoMembers, users: testMpIMUsers},
+			testMpIMFixed,
+			false,
+		},
+		{
+			"mpim with populated members is untouched",
+			args{ch: testMpIM, users: testMpIMUsers},
+			testMpIM,
+			false,
+		},
+		{
+			"empty users is an error",
+			args{ch: testMpIMnoMembers, users: nil},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var testCopy slack.Channel = *tt.args.ch
+			got, err := FixMpIMmembers(&testCopy, tt.args.users)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FixMpIMmembers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FixMpIMmembers() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isMpIM(t *testing.T) {
+	type args struct {
+		ch *slack.Channel
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"mpim",
+			args{testMpIM},
+			true,
+		},
+		{"mpim (group)",
+			args{testMpIMnoMembers},
+			true,
+		},
+		{
+			"not a mpim (public channel)",
+			args{testChannel},
+			false,
+		},
+		{
+			"invalid (ismpim, but normalised name is not mpdm",
+			args{&slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{NameNormalized: "blah", IsMpIM: true},
+					Name:         "blah",
+				},
+			}},
+			false,
+		},
+		{
+			"invalid (mpim=false, but normalised name is mpdb",
+			args{&slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{NameNormalized: "blah", IsMpIM: false},
+					Name:         mpimPrefix + "-yay-1",
+				},
+			}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMpIM(tt.args.ch); got != tt.want {
+				t.Errorf("isMpIM() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mpimMemberCount(t *testing.T) {
+	type args struct {
+		nameNormalized string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			"count is correct",
+			args{testMpIM.NameNormalized},
+			4,
+		},
+		{
+			"count is correct (empty members)",
+			args{testMpIMnoMembers.NameNormalized},
+			3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mpimMemberCount(tt.args.nameNormalized); got != tt.want {
+				t.Errorf("mpimMemberCount(%q) = %v, want %v", tt.args.nameNormalized, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseMpIMmembers(t *testing.T) {
+	type args struct {
+		nn          string
+		usernameIDs map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			"mpim with members",
+			args{testMpIM.NameNormalized, usernameIDs(testMpIMUsers)},
+			[]string{"LOL1", "DELD", "LOL3", "LOL4"},
+			false,
+		},
+		{
+			"mpim with no members",
+			args{testMpIMnoMembers.NameNormalized, usernameIDs(testMpIMUsers)},
+			[]string{"LOL1", "LOL3", "LOL4"},
+			false,
+		},
+		{
+			"empty users is an error",
+			args{testMpIMnoMembers.NameNormalized, nil},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMpIMmembers(tt.args.nn, tt.args.usernameIDs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseMpIMmembers(%q) error = %v, wantErr %v", tt.args.nn, err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseMpIMmembers(%q) got = %v, want %v", tt.args.nn, got, tt.want)
+			}
+		})
+	}
+}

--- a/types/users.go
+++ b/types/users.go
@@ -6,8 +6,9 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"github.com/rusq/slackdump/v2/internal/structures"
 	"github.com/slack-go/slack"
+
+	"github.com/rusq/slackdump/v2/internal/structures"
 )
 
 // Users is a slice of users.


### PR DESCRIPTION
It was reported that some of the mpims do not have names on them.

The problem lied within the way that API return the mpims - sometimes the "members" slice, that normally contains users participating in MPIM, is not populated.

This PR fixes that.

Also, kind of related, a PR is submitted to slack-export-viewer that fixes Internal Server Error in case the export.zip does not contain a directory for mpim listed in mpim.json: https://github.com/hfaran/slack-export-viewer/pull/161