### PR TITLE
Set the magic cookie to disable cookie banner for EZ-Login 3000

### DIFF
--- a/auth/browser/browser.go
+++ b/auth/browser/browser.go
@@ -32,6 +32,7 @@ func New(workspace string) (*Client, error) {
 }
 
 func (cl *Client) Authenticate(ctx context.Context) (string, []http.Cookie, error) {
+
 	ctx, task := trace.NewTask(ctx, "Authenticate")
 	defer task.End()
 
@@ -55,6 +56,17 @@ func (cl *Client) Authenticate(ctx context.Context) (string, []http.Cookie, erro
 		return "", nil, err
 	}
 	defer context.Close()
+
+	var _s = playwright.String
+	if err := context.AddCookies(playwright.BrowserContextAddCookiesOptionsCookies{
+		Domain:  _s(".slack.com"),
+		Path:    _s("/"),
+		Name:    _s("OptanonAlertBoxClosed"),
+		Value:   _s(time.Now().Add(-10 * time.Minute).Format(time.RFC3339)),
+		Expires: playwright.Float(float64(time.Now().AddDate(10, 0, 0).Unix())),
+	}); err != nil {
+		return "", nil, err
+	}
 
 	page, err := context.NewPage()
 	if err != nil {


### PR DESCRIPTION
Implements #126

Sets an `OptanonAlertBoxClosed` to a recent time to prevent the cookie banner from appearing.

IT IS ALWAYS A COOKIE TIME
![image](https://user-images.githubusercontent.com/16064414/188153843-ae7529aa-2e3c-41ea-94f8-1ef7627bd8b3.png)
