### PR TITLE
#44: fix the different folder name for channels and attachments

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -220,7 +220,7 @@ func validName(ch slack.Channel) string {
 	if ch.IsIM {
 		return ch.ID
 	}
-	return ch.NameNormalized
+	return ch.Name
 }
 
 // saveChannel creates a directory `name` and writes the contents of msgs. for

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -141,8 +141,8 @@ func Test_validName(t *testing.T) {
 			"ID42",
 		},
 		{
-			"channel",
-			args{slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{IsIM: false, ID: "ID42", NameNormalized: "name"}}}},
+			"channel (#144)",
+			args{slack.Channel{GroupConversation: slack.GroupConversation{Name: "name", Conversation: slack.Conversation{IsIM: false, ID: "ID42", NameNormalized: "name_normalized"}}}},
 			"name",
 		},
 	}

--- a/internal/app/emoji/emoji.go
+++ b/internal/app/emoji/emoji.go
@@ -38,6 +38,8 @@ const (
 	emojiDir   = "emojis" // directory where all emojis are downloaded.
 )
 
+var fetchFn = fetchEmoji
+
 // Download saves all emojis to "emoji" subdirectory of the Output.Base directory
 // or archive.
 func Download(ctx context.Context, cfg config.Params, prov auth.Provider) error {
@@ -144,8 +146,6 @@ type result struct {
 	name string
 	err  error
 }
-
-var fetchFn = fetchEmoji
 
 // worker is the function that runs in a separate goroutine and downloads emoji
 // received from emojiC. The result of the operation is sent to resultC channel.

--- a/messages.go
+++ b/messages.go
@@ -175,5 +175,5 @@ func (sd *Session) getChannelName(ctx context.Context, l *rate.Limiter, channelI
 	}); err != nil {
 		return "", err
 	}
-	return ci.NameNormalized, nil
+	return ci.Name, nil
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -322,7 +322,7 @@ func TestSession_DumpAll(t *testing.T) {
 }
 
 func mockConvInfo(mc *mockClienter, channelID, wantName string) {
-	mc.EXPECT().GetConversationInfoContext(gomock.Any(), channelID, false).Return(&slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{NameNormalized: wantName}}}, nil)
+	mc.EXPECT().GetConversationInfoContext(gomock.Any(), channelID, false).Return(&slack.Channel{GroupConversation: slack.GroupConversation{Name: wantName, Conversation: slack.Conversation{NameNormalized: wantName + "_normalized"}}}, nil)
 }
 
 func TestConversation_String(t *testing.T) {
@@ -389,7 +389,7 @@ func TestSession_getChannelName(t *testing.T) {
 				channelID: "TESTCHAN",
 			},
 			expectFn: func(sc *mockClienter) {
-				sc.EXPECT().GetConversationInfoContext(gomock.Any(), "TESTCHAN", false).Return(&slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{NameNormalized: "unittest"}}}, nil)
+				sc.EXPECT().GetConversationInfoContext(gomock.Any(), "TESTCHAN", false).Return(&slack.Channel{GroupConversation: slack.GroupConversation{Name: "unittest", Conversation: slack.Conversation{NameNormalized: "unittest_normalized"}}}, nil)
 			},
 			want:    "unittest",
 			wantErr: false,


### PR DESCRIPTION
- Use name instead of namei\_normalized when naming folders for channels
