### PR TITLE
update links to SlackLogViewer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ Messages that were conveyed with the donations:
 .. _slack export viewer: https://github.com/hfaran/slack-export-viewer
 .. _releases: https://github.com/rusq/slackdump/releases/
 .. _Slackord2: https://github.com/thomasloupe/Slackord2
-.. _SlackLogViewer: https://github.com/thayakawa-gh/SlackLogViewer/actions/runs/3029568329
+.. _SlackLogViewer: https://github.com/thayakawa-gh/SlackLogViewer/releases
 
 ..
   bulletin board links

--- a/doc/usage-export.rst
+++ b/doc/usage-export.rst
@@ -306,4 +306,4 @@ slack-like GUI.
 .. _Slackord2: https://github.com/thomasloupe/Slackord2
 .. _issue: https://github.com/rusq/slackdump/issues
 .. _SlackLogViewer: https://github.com/thayakawa-gh/SlackLogViewer
-.. _Download SlackLogViewer: https://github.com/thayakawa-gh/SlackLogViewer/actions/runs/3029568329
+.. _Download SlackLogViewer: https://github.com/thayakawa-gh/SlackLogViewer/releases


### PR DESCRIPTION
As per https://github.com/rusq/slackdump/discussions/127#discussioncomment-3925085