### PR TITLE
allow auth with legacy/app/bot tokens (without cookies)

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // Type is the auth type.
@@ -45,7 +46,7 @@ func (c simpleProvider) Validate() error {
 	if c.Token == "" {
 		return ErrNoToken
 	}
-	if len(c.Cookie) == 0 {
+	if IsClientToken(c.Token) && len(c.Cookie) == 0 {
 		return ErrNoCookies
 	}
 	return nil
@@ -98,4 +99,8 @@ func Save(w io.Writer, p Provider) error {
 	}
 
 	return nil
+}
+
+func IsClientToken(tok string) bool {
+	return strings.HasPrefix(tok, "xoxc-")
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -81,10 +81,17 @@ func TestSave(t *testing.T) {
 			true,
 		},
 		{
-			"cookies missing",
-			args{ValueAuth{simpleProvider{Token: "token_value", Cookie: []http.Cookie{}}}},
+			"cookies missing on client token",
+			args{ValueAuth{simpleProvider{Token: "xoxc-blah", Cookie: []http.Cookie{}}}},
 			"",
 			true,
+		},
+		{
+			"cookies missing on non-client token",
+			args{ValueAuth{simpleProvider{Token: "xoxp-blah", Cookie: []http.Cookie{}}}},
+			`{"Token":"xoxp-blah","Cookie":[]}
+`,
+			false,
 		},
 		{
 			"token and cookie are missing",

--- a/auth/value.go
+++ b/auth/value.go
@@ -24,16 +24,19 @@ func NewValueAuth(token string, cookie string) (ValueAuth, error) {
 	if token == "" {
 		return ValueAuth{}, ErrNoToken
 	}
-	if cookie == "" {
-		return ValueAuth{}, ErrNoCookies
-	}
-	return ValueAuth{simpleProvider{
+	c := ValueAuth{simpleProvider{
 		Token: token,
-		Cookie: []http.Cookie{
+	}}
+	if IsClientToken(token) {
+		if len(cookie) == 0 {
+			return ValueAuth{}, ErrNoCookies
+		}
+		c.Cookie = []http.Cookie{
 			makeCookie("d", cookie),
 			makeCookie("d-s", fmt.Sprintf("%d", time.Now().Unix()-10)),
-		},
-	}}, nil
+		}
+	}
+	return c, nil
 }
 
 func (ValueAuth) Type() Type {

--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -61,7 +61,7 @@ func (c SlackCreds) Type(ctx context.Context) (auth.Type, error) {
 }
 
 func (c SlackCreds) IsEmpty() bool {
-	return c.Token == "" || c.Cookie == ""
+	return c.Token == "" || (auth.IsClientToken(c.Token) && c.Cookie == "")
 }
 
 // AuthProvider returns the appropriate auth Provider depending on the values

--- a/internal/app/auth_test.go
+++ b/internal/app/auth_test.go
@@ -98,9 +98,10 @@ func TestSlackCreds_IsEmpty(t *testing.T) {
 		want   bool
 	}{
 		{"empty", fields{Token: "", Cookie: ""}, true},
-		{"empty", fields{Token: "x", Cookie: ""}, true},
-		{"empty", fields{Token: "", Cookie: "x"}, true},
-		{"empty", fields{Token: "x", Cookie: "x"}, false},
+		{"no token", fields{Token: "", Cookie: "x"}, true},
+		{"xoxc: token and cookie present", fields{Token: "xoxc-", Cookie: "x"}, false},
+		{"xoxc: no cookie is not ok", fields{Token: "xoxc-", Cookie: ""}, true},
+		{"other: no cookie is ok", fields{Token: "xoxp-", Cookie: ""}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -127,7 +128,6 @@ func TestInitProvider(t *testing.T) {
 
 	storedProv, _ := auth.NewValueAuth("xoxc", "xoxd")
 	returnedProv, _ := auth.NewValueAuth("a", "b")
-	// using default filer
 
 	type args struct {
 		ctx       context.Context


### PR DESCRIPTION
- Allow auth without cookies (for legacy, bot and app tokens)