### PR TITLE
Switching to Firefox due to inability to login to slack via Google on Chromium

### DIFF
--- a/auth/browser/browser.go
+++ b/auth/browser/browser.go
@@ -30,6 +30,11 @@ func New(workspace string) (*Client, error) {
 	if workspace == "" {
 		return nil, errors.New("workspace can't be empty")
 	}
+	if err := playwright.Install(&playwright.RunOptions{
+		Browsers: []string{"firefox"},
+	}); err != nil {
+		return nil, err
+	}
 	return &Client{workspace: workspace, pageClosed: make(chan bool, 1)}, nil
 }
 
@@ -47,7 +52,7 @@ func (cl *Client) Authenticate(ctx context.Context) (string, []http.Cookie, erro
 	opts := playwright.BrowserTypeLaunchOptions{
 		Headless: playwright.Bool(false),
 	}
-	browser, err := pw.Chromium.Launch(opts)
+	browser, err := pw.Firefox.Launch(opts)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
Problem: when attempting to login to Slack via Google during EZ-Login 3000 session in the Playwright-taylored Chromium, google denies login attempt with "You're using insecure browser".  Chromium version: 101.0.4929.0.

Switch to Firefox.

Fixes #168 
