### PR TITLE
rollback #158

### DIFF
--- a/auth/browser/browser.go
+++ b/auth/browser/browser.go
@@ -152,10 +152,6 @@ func extractToken(uri string) (string, error) {
 func convertCookies(pwc []playwright.Cookie) []http.Cookie {
 	var ret = make([]http.Cookie, 0, len(pwc))
 	for _, p := range pwc {
-		if !strings.HasSuffix(p.Domain, slackDomain) {
-			// ignoring filth (thirdparty tracking cookies)
-			continue
-		}
 		ret = append(ret, http.Cookie{
 			Name:     p.Name,
 			Value:    p.Value,


### PR DESCRIPTION
Fixes #168 

Problem: Google auth did not work.

Cause: this is most likely caused by removal of the third-party cookies not matching ".slack.com" domain.