### PR TITLE
Allow for literal "all" for all channels in export scope selection

### DIFF
--- a/cmd/slackdump/interactive.go
+++ b/cmd/slackdump/interactive.go
@@ -134,7 +134,7 @@ func surveyExport(p *params) error {
 	if err != nil {
 		return err
 	}
-	p.appCfg.Input.List, err = questConversationList("Conversations to export (leave empty for ALL): ")
+	p.appCfg.Input.List, err = questConversationList("Conversations to export (leave empty or type ALL for full export): ")
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func questConversationList(msg string) (*structures.EntityList, error) {
 		if err != nil {
 			return nil, err
 		}
-		if chanStr == "" {
+		if chanStr == "" || strings.ToLower(chanStr) == "all" {
 			return new(structures.EntityList), nil
 		}
 		if el, err := structures.MakeEntityList(strings.Split(chanStr, " ")); err != nil {


### PR DESCRIPTION
Usability fix for #175.
