### PR TITLE
Fixing #184 out of memory

### DIFF
--- a/export/conversation.go
+++ b/export/conversation.go
@@ -48,13 +48,13 @@ func (mbd messagesByDate) validate() error {
 // flattenMsgs takes the messages input, splits them by the date and
 // populates the msgsByDate map.
 func flattenMsgs(msgsByDate messagesByDate, messages []types.Message, usrIdx structures.UserIndex) error {
-	for _, msg := range messages {
-		expMsg := newExportMessage(&msg, usrIdx)
+	for i := range messages {
+		expMsg := newExportMessage(&messages[i], usrIdx)
 
-		if len(msg.ThreadReplies) > 0 {
+		if len(messages[i].ThreadReplies) > 0 {
 			// Recursive call:  are you ready, mr. stack?
-			if err := flattenMsgs(msgsByDate, msg.ThreadReplies, usrIdx); err != nil {
-				return fmt.Errorf("thread ID %s: %w", msg.Timestamp, err)
+			if err := flattenMsgs(msgsByDate, messages[i].ThreadReplies, usrIdx); err != nil {
+				return fmt.Errorf("thread ID %s: %w", messages[i].Timestamp, err)
 			}
 		}
 

--- a/export/conversation.go
+++ b/export/conversation.go
@@ -17,7 +17,7 @@ const dateFmt = "2006-01-02"
 // users should contain the users in the conversation for population of
 // required fields.  Threads are flattened.
 func (Export) byDate(c *types.Conversation, userIdx structures.UserIndex) (map[string][]ExportMessage, error) {
-	msgsByDate := make(map[string][]ExportMessage, len(c.Messages))
+	msgsByDate := make(map[string][]ExportMessage, 0)
 	if err := populateMsgs(msgsByDate, c.Messages, userIdx); err != nil {
 		return nil, err
 	}
@@ -25,7 +25,7 @@ func (Export) byDate(c *types.Conversation, userIdx structures.UserIndex) (map[s
 	// sort messages by Time within each date.
 	for date, messages := range msgsByDate {
 		sort.Slice(msgsByDate[date], func(i, j int) bool {
-			return messages[i].Time().Before(messages[j].Time())
+			return messages[i].slackdumpTime.Before(messages[j].slackdumpTime)
 		})
 	}
 
@@ -58,12 +58,7 @@ func populateMsgs(msgsByDate messagesByDate, messages []types.Message, usrIdx st
 			}
 		}
 
-		dt, err := msg.Datetime()
-		if err != nil {
-			return fmt.Errorf("updateDateMsgs: unable to parse message timestamp (%s): %w", msg.Timestamp, err)
-		}
-
-		formattedDt := dt.Format(dateFmt)
+		formattedDt := expMsg.slackdumpTime.Format(dateFmt)
 		msgsByDate[formattedDt] = append(msgsByDate[formattedDt], *expMsg)
 	}
 

--- a/export/conversation.go
+++ b/export/conversation.go
@@ -14,11 +14,10 @@ import (
 const dateFmt = "2006-01-02"
 
 // byDate sorts the messages by date and returns a map date->[]slack.Message.
-// users should contain the users in the conversation for population of required
-// fields.
-// Threads are flattened.
+// users should contain the users in the conversation for population of
+// required fields.  Threads are flattened.
 func (Export) byDate(c *types.Conversation, userIdx structures.UserIndex) (map[string][]ExportMessage, error) {
-	msgsByDate := make(map[string][]ExportMessage)
+	msgsByDate := make(map[string][]ExportMessage, len(c.Messages))
 	if err := populateMsgs(msgsByDate, c.Messages, userIdx); err != nil {
 		return nil, err
 	}

--- a/export/conversation.go
+++ b/export/conversation.go
@@ -16,8 +16,8 @@ const dateFmt = "2006-01-02"
 // byDate sorts the messages by date and returns a map date->[]ExportMessage.
 // userIdx should contain the users in the conversation for populating the
 // required fields.  Threads are flattened.
-func (Export) byDate(c *types.Conversation, userIdx structures.UserIndex) (map[string][]ExportMessage, error) {
-	msgsByDate := make(map[string][]ExportMessage, 0)
+func (Export) byDate(c *types.Conversation, userIdx structures.UserIndex) (messagesByDate, error) {
+	msgsByDate := make(map[string][]*ExportMessage, 0)
 	if err := flattenMsgs(msgsByDate, c.Messages, userIdx); err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (Export) byDate(c *types.Conversation, userIdx structures.UserIndex) (map[s
 	return msgsByDate, nil
 }
 
-type messagesByDate map[string][]ExportMessage
+type messagesByDate map[string][]*ExportMessage
 
 // validate checks if mbd keys are valid dates.
 func (mbd messagesByDate) validate() error {
@@ -59,7 +59,7 @@ func flattenMsgs(msgsByDate messagesByDate, messages []types.Message, usrIdx str
 		}
 
 		formattedDt := expMsg.slackdumpTime.Format(dateFmt)
-		msgsByDate[formattedDt] = append(msgsByDate[formattedDt], *expMsg)
+		msgsByDate[formattedDt] = append(msgsByDate[formattedDt], expMsg)
 	}
 
 	return nil

--- a/export/conversation_test.go
+++ b/export/conversation_test.go
@@ -102,7 +102,7 @@ func init() {
 	var (
 		startDate   = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 		endDate     = time.Date(2020, 1, 1, 15, 0, 0, 0, time.UTC)
-		numMessages = 10_000
+		numMessages = 1_000_000
 	)
 	benchConv = fixgen.GenerateTestConversation("test", startDate, endDate, numMessages)
 }

--- a/export/conversation_test.go
+++ b/export/conversation_test.go
@@ -29,7 +29,7 @@ func TestConversation_ByDate(t *testing.T) {
 	// uncomment to write the json for fixtures
 	require.NoError(t, writeOutput("convDt", convDt))
 
-	want := fixtures.Load[map[string][]ExportMessage](fixtures.TestConversationExportJSON)
+	want := fixtures.Load[messagesByDate](fixtures.TestConversationExportJSON)
 
 	// we need to depopulate slackdumpTime for comparison, as it is not saved
 	// in the fixture.
@@ -37,7 +37,7 @@ func TestConversation_ByDate(t *testing.T) {
 	assert.Equal(t, want, convDt)
 }
 
-func zeroSlackdumpTime(m map[string][]ExportMessage) {
+func zeroSlackdumpTime(m messagesByDate) {
 	for _, msgs := range m {
 		for i := range msgs {
 			msgs[i].slackdumpTime = time.Time{}
@@ -64,22 +64,22 @@ func Test_messagesByDate_validate(t *testing.T) {
 	}{
 		{"valid",
 			messagesByDate{
-				"2019-09-16": []ExportMessage{},
-				"2020-12-31": []ExportMessage{},
+				"2019-09-16": []*ExportMessage{},
+				"2020-12-31": []*ExportMessage{},
 			},
 			false,
 		},
 		{"empty key",
 			messagesByDate{
-				"":           []ExportMessage{},
-				"2020-12-31": []ExportMessage{},
+				"":           []*ExportMessage{},
+				"2020-12-31": []*ExportMessage{},
 			},
 			true,
 		},
 		{"invalid key",
 			messagesByDate{
-				"2019-09-16": []ExportMessage{},
-				"2020-31-12": []ExportMessage{}, //swapped month and date
+				"2019-09-16": []*ExportMessage{},
+				"2020-31-12": []*ExportMessage{}, //swapped month and date
 			},
 			true,
 		},
@@ -94,7 +94,7 @@ func Test_messagesByDate_validate(t *testing.T) {
 }
 
 var (
-	benchResult map[string][]ExportMessage
+	benchResult messagesByDate
 	benchConv   types.Conversation
 )
 
@@ -118,7 +118,7 @@ func BenchmarkByDate(b *testing.B) {
 	)
 	region := trace.StartRegion(ctx, "byDateBenchRun")
 	defer region.End()
-	var m map[string][]ExportMessage
+	var m messagesByDate
 	for i := 0; i < b.N; i++ {
 		m, err = ex.byDate(&benchConv, nil)
 		if err != nil {

--- a/export/conversation_test.go
+++ b/export/conversation_test.go
@@ -1,9 +1,13 @@
 package export
 
 import (
+	"context"
+	"runtime/trace"
 	"testing"
+	"time"
 
 	"github.com/rusq/slackdump/v2/internal/fixtures"
+	"github.com/rusq/slackdump/v2/internal/fixtures/fixgen"
 	"github.com/rusq/slackdump/v2/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -61,5 +65,35 @@ func Test_messagesByDate_validate(t *testing.T) {
 				t.Errorf("messagesByDate.validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+var m map[string][]ExportMessage
+
+func BenchmarkByDate(b *testing.B) {
+	var (
+		startDate   = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		endDate     = time.Date(2020, 1, 1, 15, 0, 0, 0, time.UTC)
+		numMessages = 10_000
+	)
+	ctx, task := trace.NewTask(context.Background(), "BenchmarkByDate")
+	defer task.End()
+
+	var conv types.Conversation
+	trace.WithRegion(ctx, "generate", func() {
+		conv = fixgen.GenerateTestConversation("test", startDate, endDate, numMessages)
+	})
+
+	var (
+		ex  Export
+		err error
+	)
+	region := trace.StartRegion(ctx, "byDateBenchRun")
+	defer region.End()
+	for i := 0; i < b.N; i++ {
+		m, err = ex.byDate(&conv, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -42,10 +42,10 @@ func TestExport_saveChannel(t *testing.T) {
 			args{
 				"unittest",
 				messagesByDate{
-					"2020-12-30": []ExportMessage{
+					"2020-12-30": []*ExportMessage{
 						{Msg: fixtures.Load[slack.Msg](fixtures.SimpleMessageJSON)},
 					},
-					"2020-12-31": []ExportMessage{
+					"2020-12-31": []*ExportMessage{
 						{Msg: fixtures.Load[slack.Msg](fixtures.SimpleMessageJSON)},
 						{Msg: fixtures.Load[slack.Msg](fixtures.BotMessageThreadParentJSON)},
 						{Msg: fixtures.Load[slack.Msg](fixtures.BotMessageThreadChildJSON)},
@@ -54,10 +54,10 @@ func TestExport_saveChannel(t *testing.T) {
 			},
 			false,
 			messagesByDate{
-				"2020-12-30": []ExportMessage{
+				"2020-12-30": []*ExportMessage{
 					{Msg: fixtures.Load[slack.Msg](fixtures.SimpleMessageJSON)},
 				},
-				"2020-12-31": []ExportMessage{
+				"2020-12-31": []*ExportMessage{
 					{Msg: fixtures.Load[slack.Msg](fixtures.SimpleMessageJSON)},
 					{Msg: fixtures.Load[slack.Msg](fixtures.BotMessageThreadParentJSON)},
 					{Msg: fixtures.Load[slack.Msg](fixtures.BotMessageThreadChildJSON)},
@@ -105,7 +105,7 @@ func loadTestDir(path string) (messagesByDate, error) {
 		}
 		defer f.Close()
 
-		var mm []ExportMessage
+		var mm []*ExportMessage
 		dec := json.NewDecoder(f)
 		if err := dec.Decode(&mm); err != nil {
 			return err

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -43,24 +43,24 @@ func TestExport_saveChannel(t *testing.T) {
 				"unittest",
 				messagesByDate{
 					"2020-12-30": []*ExportMessage{
-						{Msg: fixtures.Load[slack.Msg](fixtures.SimpleMessageJSON)},
+						{Msg: fixtures.LoadPtr[slack.Msg](fixtures.SimpleMessageJSON)},
 					},
 					"2020-12-31": []*ExportMessage{
-						{Msg: fixtures.Load[slack.Msg](fixtures.SimpleMessageJSON)},
-						{Msg: fixtures.Load[slack.Msg](fixtures.BotMessageThreadParentJSON)},
-						{Msg: fixtures.Load[slack.Msg](fixtures.BotMessageThreadChildJSON)},
+						{Msg: fixtures.LoadPtr[slack.Msg](fixtures.SimpleMessageJSON)},
+						{Msg: fixtures.LoadPtr[slack.Msg](fixtures.BotMessageThreadParentJSON)},
+						{Msg: fixtures.LoadPtr[slack.Msg](fixtures.BotMessageThreadChildJSON)},
 					},
 				},
 			},
 			false,
 			messagesByDate{
 				"2020-12-30": []*ExportMessage{
-					{Msg: fixtures.Load[slack.Msg](fixtures.SimpleMessageJSON)},
+					{Msg: fixtures.LoadPtr[slack.Msg](fixtures.SimpleMessageJSON)},
 				},
 				"2020-12-31": []*ExportMessage{
-					{Msg: fixtures.Load[slack.Msg](fixtures.SimpleMessageJSON)},
-					{Msg: fixtures.Load[slack.Msg](fixtures.BotMessageThreadParentJSON)},
-					{Msg: fixtures.Load[slack.Msg](fixtures.BotMessageThreadChildJSON)},
+					{Msg: fixtures.LoadPtr[slack.Msg](fixtures.SimpleMessageJSON)},
+					{Msg: fixtures.LoadPtr[slack.Msg](fixtures.BotMessageThreadParentJSON)},
+					{Msg: fixtures.LoadPtr[slack.Msg](fixtures.BotMessageThreadChildJSON)},
 				},
 			},
 		},

--- a/export/message.go
+++ b/export/message.go
@@ -70,6 +70,7 @@ func newExportMessage(msg *types.Message, users structures.UserIndex) *ExportMes
 
 	// threaded message branch
 
+	expMsg.Replies = make([]slack.Reply, 0, len(msg.ThreadReplies))
 	for _, replyMsg := range msg.ThreadReplies {
 		expMsg.Msg.Replies = append(expMsg.Msg.Replies, slack.Reply{User: replyMsg.User, Timestamp: replyMsg.Timestamp})
 		expMsg.ReplyUsers = append(expMsg.ReplyUsers, replyMsg.User)

--- a/export/message.go
+++ b/export/message.go
@@ -49,6 +49,9 @@ func (em ExportMessage) Time() time.Time {
 // some additional fields.  Slack messages produced by export are much more
 // saturated with information, i.e. contain user profiles and thread stats.
 func newExportMessage(msg *types.Message, users structures.UserIndex) *ExportMessage {
+	if msg == nil {
+		panic("internal error: msg is nil")
+	}
 	expMsg := ExportMessage{Msg: msg.Msg}
 
 	expMsg.UserTeam = msg.Team

--- a/export/message.go
+++ b/export/message.go
@@ -13,7 +13,7 @@ import (
 // ExportMessage is the slack.Message with additional fields usually found in
 // slack exports.
 type ExportMessage struct {
-	slack.Msg
+	*slack.Msg
 
 	// additional fields not defined by the slack library, but present
 	// in slack exports
@@ -52,7 +52,7 @@ func newExportMessage(msg *types.Message, users structures.UserIndex) *ExportMes
 	if msg == nil {
 		panic("internal error: msg is nil")
 	}
-	expMsg := ExportMessage{Msg: msg.Msg}
+	expMsg := ExportMessage{Msg: &msg.Msg}
 
 	expMsg.UserTeam = msg.Team
 	expMsg.SourceTeam = msg.Team

--- a/export/message_test.go
+++ b/export/message_test.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -40,6 +41,7 @@ func Test_newExportMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newExportMessage(tt.args.msg, tt.args.users)
+			got.slackdumpTime = time.Time{} // clear for comparison. not saved in fixture.
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/fixtures/conversation.go
+++ b/internal/fixtures/conversation.go
@@ -366,3 +366,32 @@ const TestChannel = `
     "locale": "en-US"
   }
 `
+
+const TestMessage = `	  {
+	"client_msg_id": "c6cdfb3a-59d6-4198-9800-cc74bcdc0b7d",
+	"type": "message",
+	"user": "UHSD97ZA5",
+	"text": "Test message with Html chars \u0026lt; \u0026gt;",
+	"ts": "1645095505.023899",
+	"team": "THY5HTZ8U",
+	"replace_original": false,
+	"delete_original": false,
+	"blocks": [
+	  {
+		"type": "rich_text",
+		"block_id": "SkX",
+		"elements": [
+		  {
+			"type": "rich_text_section",
+			"elements": [
+			  {
+				"type": "text",
+				"text": "Test message with Html chars \u003c \u003e"
+			  }
+			]
+		  }
+		]
+	  }
+	]
+  }
+`

--- a/internal/fixtures/fixgen/conversation.go
+++ b/internal/fixtures/fixgen/conversation.go
@@ -1,0 +1,57 @@
+package fixgen
+
+import (
+	"encoding/json"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/rusq/slackdump/v2/internal/fixtures"
+	"github.com/rusq/slackdump/v2/types"
+)
+
+func init() {
+	// Seed the random number generator
+	rand.Seed(time.Now().UnixNano())
+}
+
+// ReSeed reseeds the random number generator
+func ReSeed(n int64) {
+	rand.Seed(n)
+}
+
+// randString generates a random string of length n.
+func randString(n int) string {
+	var letter = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letter[rand.Intn(len(letter))]
+	}
+	return string(b)
+}
+
+// GenerateTestConversation generates a test conversation with a random name.
+func GenerateTestConversation(name string, startDate time.Time, endDate time.Time, numMessages int) types.Conversation {
+	var messages = make([]types.Message, numMessages)
+	for i := 0; i < numMessages; i++ {
+		messages[i] = GenerateTestMessage(startDate, endDate)
+	}
+
+	return types.Conversation{
+		Messages: messages,
+		Name:     name,
+		ID:       randString(9),
+	}
+}
+
+func GenerateTestMessage(startDate, endDate time.Time) types.Message {
+	var message types.Message
+	err := json.Unmarshal([]byte(fixtures.TestMessage), &message.Message)
+	if err != nil {
+		panic(err)
+	}
+	message.Timestamp = strconv.FormatInt(rand.Int63n(endDate.Unix()-startDate.Unix())+startDate.Unix(), 10)
+
+	return message
+}

--- a/internal/fixtures/fixtures.go
+++ b/internal/fixtures/fixtures.go
@@ -7,13 +7,19 @@ import (
 	"os"
 )
 
-// loadFixture loads a json data into T, or panics.
+// Load loads a json data into T, or panics.
 func Load[T any](js string) T {
 	var ret T
 	if err := json.Unmarshal([]byte(js), &ret); err != nil {
 		panic(err)
 	}
 	return ret
+}
+
+// LoadPtr loads a json data into *T, or panics.
+func LoadPtr[T any](js string) *T {
+	v := Load[T](js)
+	return &v
 }
 
 // FilledBuffer returns buffer that filled with sz bytes of 0x00.

--- a/internal/structures/slacktime.go
+++ b/internal/structures/slacktime.go
@@ -25,21 +25,24 @@ func ParseThreadID(threadID string) (time.Time, error) {
 
 // ParseSlackTS parses the slack timestamp.
 func ParseSlackTS(timestamp string) (time.Time, error) {
-	strTime := strings.Split(timestamp, ".")
-	var hi, lo int64
+	const (
+		base = 10
+		bit  = 64
+	)
+	sHi, sLo, found := strings.Cut(timestamp, ".")
 
-	hi, err := strconv.ParseInt(strTime[0], 10, 64)
+	var hi, lo int64
+	hi, err := strconv.ParseInt(sHi, base, bit)
 	if err != nil {
 		return time.Time{}, err
 	}
-	if len(strTime) > 1 {
-		lo, err = strconv.ParseInt(strTime[1], 10, 64)
+	if found {
+		lo, err = strconv.ParseInt(sLo, base, bit)
 		if err != nil {
 			return time.Time{}, err
 		}
 	}
-	t := time.Unix(hi, lo).UTC()
-	return t, nil
+	return time.Unix(hi, lo).UTC(), nil
 }
 
 func FormatSlackTS(ts time.Time) string {


### PR DESCRIPTION
- benchmark and fixture generator
- memoise message time
- isolate init from the benchmark
- optimised slicing
- use slice of pointers, instead of slice of exportMessages
- address by index, save by pointer
