### PR TITLE
Lowercase the user provided workspace name

### DIFF
--- a/auth/auth_error.go
+++ b/auth/auth_error.go
@@ -6,10 +6,15 @@ import "fmt"
 // an API error returned by slack.AuthTest call.
 type Error struct {
 	Err error
+	Msg string
 }
 
 func (ae *Error) Error() string {
-	return fmt.Sprintf("failed to authenticate: %s", ae.Err)
+	var msg string = ae.Msg
+	if msg == "" {
+		msg = ae.Err.Error()
+	}
+	return fmt.Sprintf("authentication error: %s", msg)
 }
 
 func (ae *Error) Unwrap() error {

--- a/auth/browser.go
+++ b/auth/browser.go
@@ -43,6 +43,9 @@ func NewBrowserAuth(ctx context.Context, opts ...Option) (BrowserAuth, error) {
 	for _, opt := range opts {
 		opt(&options{browserOpts: &br.opts})
 	}
+	if isDocker() {
+		return BrowserAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in docker, use token/cookie auth instead"}
+	}
 
 	if br.opts.workspace == "" {
 		var err error
@@ -70,7 +73,6 @@ func NewBrowserAuth(ctx context.Context, opts ...Option) (BrowserAuth, error) {
 		Token:  token,
 		Cookie: cookies,
 	}
-
 	return br, nil
 }
 
@@ -92,4 +94,9 @@ func sanitize(workspace string) (string, error) {
 	// parse
 	parts := strings.Split(workspace, ".")
 	return parts[0], nil
+}
+
+func isDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
 }

--- a/auth/option.go
+++ b/auth/option.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"strings"
 	"time"
 
 	"github.com/rusq/slackdump/v2/auth/browser"
@@ -23,7 +24,7 @@ func BrowserWithAuthFlow(flow BrowserAuthUI) Option {
 
 func BrowserWithWorkspace(name string) Option {
 	return func(o *options) {
-		o.browserOpts.workspace = name
+		o.browserOpts.workspace = strings.ToLower(name)
 	}
 }
 


### PR DESCRIPTION
It was reported that browser auth fails if the workspace name is not lowercase.

The root cause was it was never able to match the request name when waiting for
features api request, i.e. the browser reported `https://workspace.slack.com/api/...`
and slackdump was expecting `https://WorkSpace.slack.com/api/...`.
