### PR TITLE
Add suppor per channel dump-from dump-to limitation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ ZIPFILES=$(foreach s,$(OSES),$(OUTPUT)-$s.zip)
 $(OUTPUT)-windows.zip: EXECUTABLE=$(OUTPUT).exe
 
 $(foreach s,$(OSES),$(eval $(OUTPUT)-$s.zip: GOOS=$s))
-$(foreach s,$(OSES),$(eval $(OUTPUT)-$s.zip: $(EXECUTABLE)))
+$(foreach s,$(OSES),$(eval $(OUTPUT)-$s.zip: $(OUTPUT)))
+
+$(foreach s,$(OSES),$(eval $(OUTPUT)-$s: GOOS=$s))
+$(foreach s,$(OSES),$(eval $(OUTPUT)-$s: $(OUTPUT)))
 
 
 all: $(EXECUTABLE)

--- a/cmd/slackdump/main_test.go
+++ b/cmd/slackdump/main_test.go
@@ -47,6 +47,7 @@ func Test_checkParameters(t *testing.T) {
 	slackdump.DefOptions.CacheDir = app.CacheDir()
 
 	// test
+	emptyEntityList, _ := structures.NewEntityList([]string{})
 	type args struct {
 		args []string
 	}
@@ -72,7 +73,7 @@ func Test_checkParameters(t *testing.T) {
 					},
 					FilenameTemplate: defFilenameTemplate,
 
-					Input:   config.Input{List: &structures.EntityList{}},
+					Input:   config.Input{List: emptyEntityList},
 					Output:  config.Output{Filename: "-", Format: "text"},
 					Options: slackdump.DefOptions,
 				}},
@@ -93,7 +94,7 @@ func Test_checkParameters(t *testing.T) {
 						Users:    true,
 					},
 					FilenameTemplate: defFilenameTemplate,
-					Input:            config.Input{List: &structures.EntityList{}},
+					Input:            config.Input{List: emptyEntityList},
 					Output:           config.Output{Filename: "-", Format: "text"},
 					Options:          slackdump.DefOptions,
 				}},

--- a/export/export.go
+++ b/export/export.go
@@ -121,13 +121,21 @@ func (se *Export) exclusiveExport(ctx context.Context, uidx structures.UserIndex
 
 	chans := make([]slack.Channel, 0)
 
-	listIdx := el.Index()
+	items := el.Index()
 	// we need the current user to be able to build an index of DMs.
 	if err := se.sd.StreamChannels(ctx, slackdump.AllChanTypes, func(ch slack.Channel) error {
-		if include, ok := listIdx[ch.ID]; ok && !include {
-			trace.Logf(ctx, "info", "skipping %s", ch.ID)
-			se.lg.Printf("skipping: %s", ch.ID)
-			return nil
+		item, ok := items[ch.ID]
+		if ok {
+			if !item.Include && item.Oldest.IsZero() && item.Latest.IsZero() {
+				trace.Logf(ctx, "info", "skipping %s", ch.ID)
+				se.lg.Printf("skipping: %s", ch.ID)
+				return nil
+			}
+		} else {
+			item = &structures.EntityItem{
+				Id: ch.ID,
+				Include: true,
+			}
 		}
 
 		var eg errgroup.Group
@@ -145,7 +153,7 @@ func (se *Export) exclusiveExport(ctx context.Context, uidx structures.UserIndex
 
 		// 2. export conversation
 		eg.Go(func() error {
-			if err := se.exportConversation(ctx, uidx, ch); err != nil {
+			if err := se.exportConversation(ctx, uidx, ch, item); err != nil {
 				return fmt.Errorf("error exporting conversation %s: %w", ch.ID, err)
 			}
 			return nil
@@ -179,13 +187,11 @@ func (se *Export) inclusiveExport(ctx context.Context, uidx structures.UserIndex
 
 	// preallocate, some channels might be excluded, so this is optimistic
 	// allocation
-	chans := make([]slack.Channel, 0, len(list.Include))
-
-	elIdx := list.Index()
+	chans := make([]slack.Channel, 0, len(list.Index()))
 
 	// we need the current user to be able to build an index of DMs.
-	for _, entry := range list.Include {
-		if include, ok := elIdx[entry]; ok && !include {
+	for entry, item := range list.Index() {
+		if !item.Include && item.Oldest.IsZero() && item.Latest.IsZero() {
 			se.td(ctx, "info", "skipping %s", entry)
 			se.lg.Printf("skipping: %s", entry)
 			continue
@@ -212,7 +218,7 @@ func (se *Export) inclusiveExport(ctx context.Context, uidx structures.UserIndex
 		})
 
 		eg.Go(func() error {
-			if err := se.exportConversation(ctx, uidx, *ch); err != nil {
+			if err := se.exportConversation(ctx, uidx, *ch, item); err != nil {
 				return fmt.Errorf("error exporting conversation %s: %w", ch.ID, err)
 			}
 			return nil
@@ -231,11 +237,21 @@ func (se *Export) inclusiveExport(ctx context.Context, uidx structures.UserIndex
 }
 
 // exportConversation exports one conversation.
-func (se *Export) exportConversation(ctx context.Context, userIdx structures.UserIndex, ch slack.Channel) error {
+func (se *Export) exportConversation(ctx context.Context, userIdx structures.UserIndex, ch slack.Channel, exportItem *structures.EntityItem) error {
 	ctx, task := trace.NewTask(ctx, "export.conversation")
 	defer task.End()
 
-	messages, err := se.sd.DumpRaw(ctx, ch.ID, se.opts.Oldest, se.opts.Latest, se.dl.ProcessFunc(validName(ch)))
+	eOldest := se.opts.Oldest
+	eLatest := se.opts.Latest
+
+	if !exportItem.Oldest.IsZero() {
+		eOldest = exportItem.Oldest
+	}
+	if !exportItem.Latest.IsZero() {
+		eLatest = exportItem.Latest
+	}
+
+	messages, err := se.sd.DumpRaw(ctx, ch.ID, eOldest, eLatest, se.dl.ProcessFunc(validName(ch)))
 	if err != nil {
 		return fmt.Errorf("failed to dump %q (%s): %w", ch.Name, ch.ID, err)
 	}

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -405,7 +405,8 @@ func TestExport_exportConversation(t *testing.T) {
 						Return(tt.mocks.rets.closeErr)
 				}
 			}
-			if err := exp.exportConversation(context.Background(), testUserIdx, tt.args.ch); (err != nil) != tt.wantErr {
+			exportItem := &structures.EntityItem{Id: tt.args.ch.ID}
+			if err := exp.exportConversation(context.Background(), testUserIdx, tt.args.ch, exportItem); (err != nil) != tt.wantErr {
 				t.Errorf("Export.exportConversation() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -73,16 +73,18 @@ func (in *Input) IsValid() bool {
 
 // listProducer iterates over the input.List.Include, and calls fn for each
 // entry.
-func (in *Input) listProducer(fn func(string) error) error {
+func (in *Input) listProducer(fn func(*structures.EntityItem) error) error {
 	if !in.List.HasIncludes() {
 		return ErrInvalidInput
 	}
-	for _, entry := range in.List.Include {
-		if err := fn(entry); err != nil {
-			if errors.Is(err, ErrSkip) {
-				continue
+	for _, entry := range in.List.Index() {
+		if entry.Include {
+			if err := fn(entry); err != nil {
+				if errors.Is(err, ErrSkip) {
+					continue
+				}
+				return err
 			}
-			return err
 		}
 	}
 	return nil
@@ -192,7 +194,7 @@ func (p *Params) compileValidateTemplate() error {
 
 // Producer iterates over the list or reads the list from the file and calls
 // fn for each entry.
-func (in Input) Producer(fn func(string) error) error {
+func (in Input) Producer(fn func(*structures.EntityItem) error) error {
 	if !in.IsValid() {
 		return ErrInvalidInput
 	}


### PR DESCRIPTION
This patch allow to configure `-dump-from` and `-dump-to` limitation per channel.

### How to use
As channel name you must provide channel ID and dates with format `{CHANNEL_ID}|{OLDEST_TIME}|{LATEST_TIME}`

To dump only specified channel where messages not older
```
slackdump 'C123|2024-04-07T23:02:12' 'C321|2024-01-01T23:02:12'
```

To dump only specified channels where message time between specified time
```
slackdump 'C123|2024-01-07T23:02:12|2024-04-07T23:02:12' 'C321|2024-01-01T23:02:12|2024-03-07T23:02:12'
```

To dump only specified channels where message time  older than specified time
```
slackdump 'C123||2024-04-07T23:02:12' 'C321||2024-03-07T23:02:12'
```

To dump all available channels but channel C123 and C321 only from specified time
```
slackdump '^C123|2024-04-07T23:02:12' '^C321|2024-01-01T23:02:12'
```

