### PR TITLE
Goreleaser improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,17 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.19.5'
           cache: true
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
-      - uses: goreleaser/goreleaser-action@v4
+      - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,10 @@ archives:
     format_overrides:
     - goos: windows
       format: zip
+    files:
+      - LICENSE.txt
+      - README.rst
+      - slackdump.1
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -40,6 +44,26 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+nfpms:
+  -
+    vendor: Rustam
+    homepage: https://github.com/rusq
+    maintainer: Rustam <rusq@github.com>
+    description: Save or export your private and public Slack messages, threads, files, and users locally without admin privileges. 
+    license: GPL-3.0
+    formats:
+      - apk
+      - deb
+      - rpm
+      - termux.deb
+      - archlinux
+    release: 1
+    section: default
+    priority: extra
+    contents:
+      - src: ./slackdump.1
+        dst: /usr/share/man/man1/slackdump.1
 
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,14 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
+project_name: slackdump
 before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod tidy
 builds:
-  - env:
+  - id: slackdump
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -17,7 +20,8 @@ builds:
     main: ./cmd/slackdump
 
 archives:
-  - format: tar.gz
+  - id: default
+    format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_
@@ -31,7 +35,7 @@ archives:
     - goos: windows
       format: zip
     files:
-      - LICENSE.txt
+      - LICENSE
       - README.rst
       - slackdump.1
 checksum:


### PR DESCRIPTION
I did this mostly to include the man page. But this also updates the versions of the actions used in github actions, and uses npmf to create packages.

You can see a sample of the files generated here:

https://github.com/arran4/slackdump/releases/tag/v2.5.8-test4

Also Goreleaser 2 is released https://goreleaser.com/blog/goreleaser-v2/

Thus I got: 
```
/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser release --clean
  • starting release...
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
```

And had to address it.

I am not sure of the purpose of having `ACTIONS_TOKEN` since there is an automatically generated one `GITHUB_TOKEN` (which I needed to use in order to test this.)
```
Subject: [PATCH] 
---
Index: .github/workflows/release.yml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
--- a/.github/workflows/release.yml	(revision c9f8103d3d4e72b7fb1e61649f196f57c1c5bb17)
+++ b/.github/workflows/release.yml	(revision 38400ad41ef563cce3191ca18cecc3d68b22618c)
@@ -28,4 +28,4 @@
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

```
I would recommend changing it if there isn't another reason for it.