### PR TITLE
Offer to authenticate if there are no workspaces

### DIFF
--- a/cmd/slackdump/internal/bootstrap/bootstrap.go
+++ b/cmd/slackdump/internal/bootstrap/bootstrap.go
@@ -10,17 +10,11 @@ import (
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/workspace"
 )
 
-// CurrentProvider is a shortcut function to initialise the current auth
-// provider.
-func CurrentProvider(ctx context.Context) (auth.Provider, error) {
-	return workspace.AuthCurrent(ctx, cfg.CacheDir(), cfg.Workspace, cfg.LegacyBrowser)
-}
-
 // CurrentProviderCtx returns the context with the current provider.
 func CurrentProviderCtx(ctx context.Context) (context.Context, error) {
 	prov, err := workspace.AuthCurrent(ctx, cfg.CacheDir(), cfg.Workspace, cfg.LegacyBrowser)
 	if err != nil {
-		return nil, err
+		return ctx, err
 	}
 	return auth.WithContext(ctx, prov), nil
 }

--- a/internal/cache/manager.go
+++ b/internal/cache/manager.go
@@ -289,11 +289,20 @@ func (m *Manager) FileInfo(name string) (fs.FileInfo, error) {
 // Exists returns true if the workspace with name "name" exists in the list of
 // authenticated workspaces.
 func (m *Manager) Exists(name string) bool {
-	existing, err := m.List()
+	return m.ExistsErr(name) == nil
+}
+
+// ExistsErr checks if the workspace exists, and returns any errors that may
+// occur.
+func (m *Manager) ExistsErr(name string) error {
+	ws, err := m.List()
 	if err != nil {
-		return false
+		return err
 	}
-	return slices.Contains(existing, name)
+	if !slices.Contains(ws, name) {
+		return newErrNoWorkspace(name)
+	}
+	return nil
 }
 
 // filename returns the filename for the workspace name.


### PR DESCRIPTION
When running slackdump for the first time, i.e.
```
./slackdump archive
```
without prior authentication, it would output the cryptic error message:
```
$ slackdump archive
archive: 2024/07/27 07:24:52 Error 004 (Authentication Error): auth error: workspace does not exist: ""
Error 004 (Authentication Error): auth error: workspace does not exist: ""
exit status 4
```

This PR introduces the change that handles this case correctly, offering to authenticate in a new workspace.