### PR TITLE
(viewer styling): Restrict video width + extend maximum image width

### DIFF
--- a/internal/viewer/templates/styles.html
+++ b/internal/viewer/templates/styles.html
@@ -92,8 +92,8 @@
         border-radius: 5px;
     }
 
-    .slack-files img {
-        max-width: 320px;
+    .slack-files img, .slack-files video {
+        max-width: 50%;
         max-height: 320px;
     }
 


### PR DESCRIPTION
This PR is a small addition I've made locally while testing out Slack dump that restricts the width of videos.

Mainly just getting my fork ready to do some other changes if/when I get around to them 🙂

**Before**:
![CleanShot 2024-09-09 at 18 04 42@2x](https://github.com/user-attachments/assets/48eb087f-f4a6-4efb-8de8-8564cce4ae1f)

**After**:
![CleanShot 2024-09-09 at 18 00 45@2x](https://github.com/user-attachments/assets/af256502-c532-4a9a-8674-b673bd861235)
