### PR TITLE
V3 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,12 @@ CMD=./cmd/slackdump
 OUTPUT=slackdump
 EXECUTABLE=slackdump
 BUILD=$(shell git describe --tags)
-BUILD_YEAR=$(shell date +%Y)
+BUILD_DATE=$(shell TZ=UTC date +%Y-%m-%d\ %H:%M:%SZ)
+COMMIT=$(shell git rev-parse --short HEAD)
 
 PKG=github.com/rusq/slackdump/v3
 
-LDFLAGS="-s -w -X 'main.build=$(BUILD)' -X 'main.buildYear=$(BUILD_YEAR)'"
+LDFLAGS="-s -w -X 'main.commit=$(COMMIT)' -X 'main.version=$(BUILD)' -X 'main.date=$(BUILD_DATE)'"
 OSES=linux darwin windows
 DISTFILES=README.rst LICENSE
 ZIPFILES=$(foreach s,$(OSES),$(OUTPUT)-$s.zip)

--- a/cmd/slackdump/internal/archive/archive.go
+++ b/cmd/slackdump/internal/archive/archive.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rusq/fsadapter"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/internal/chunk"
@@ -63,7 +64,7 @@ func RunArchive(ctx context.Context, cmd *base.Command, args []string) error {
 		return err
 	}
 
-	sess, err := cfg.SlackdumpSession(ctx)
+	sess, err := bootstrap.SlackdumpSession(ctx)
 	if err != nil {
 		base.SetExitStatus(base.SInitializationError)
 		return err

--- a/cmd/slackdump/internal/archive/search.go
+++ b/cmd/slackdump/internal/archive/search.go
@@ -61,7 +61,7 @@ var fastSearch bool
 
 func init() {
 	for _, cmd := range []*base.Command{cmdSearchMessages, cmdSearchFiles, cmdSearchAll} {
-		cmd.Flag.BoolVar(&fastSearch, "fast", false, "skip channel users ~2.5x faster")
+		cmd.Flag.BoolVar(&fastSearch, "-no-channel-users", false, "skip channel users (approx ~2.5x faster)")
 	}
 }
 

--- a/cmd/slackdump/internal/archive/search.go
+++ b/cmd/slackdump/internal/archive/search.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/rusq/fsadapter"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/internal/chunk"
@@ -109,7 +110,7 @@ func initController(ctx context.Context, args []string) (*control.Controller, fu
 		return nil, nil, errNoOutput
 	}
 
-	sess, err := cfg.SlackdumpSession(ctx)
+	sess, err := bootstrap.SlackdumpSession(ctx)
 	if err != nil {
 		base.SetExitStatus(base.SInitializationError)
 		return nil, nil, err

--- a/cmd/slackdump/internal/archive/search.go
+++ b/cmd/slackdump/internal/archive/search.go
@@ -61,7 +61,7 @@ var fastSearch bool
 
 func init() {
 	for _, cmd := range []*base.Command{cmdSearchMessages, cmdSearchFiles, cmdSearchAll} {
-		cmd.Flag.BoolVar(&fastSearch, "-no-channel-users", false, "skip channel users (approx ~2.5x faster)")
+		cmd.Flag.BoolVar(&fastSearch, "no-channel-users", false, "skip channel users (approx ~2.5x faster)")
 	}
 }
 

--- a/cmd/slackdump/internal/bootstrap/bootstrap.go
+++ b/cmd/slackdump/internal/bootstrap/bootstrap.go
@@ -1,20 +1,3 @@
 // Package bootstrap contains some initialisation functions that are shared
 // between main some other top level commands, i.e. wizard.
 package bootstrap
-
-import (
-	"context"
-
-	"github.com/rusq/slackdump/v3/auth"
-	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
-	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/workspace"
-)
-
-// CurrentProviderCtx returns the context with the current provider.
-func CurrentProviderCtx(ctx context.Context) (context.Context, error) {
-	prov, err := workspace.AuthCurrent(ctx, cfg.CacheDir(), cfg.Workspace, cfg.LegacyBrowser)
-	if err != nil {
-		return ctx, err
-	}
-	return auth.WithContext(ctx, prov), nil
-}

--- a/cmd/slackdump/internal/bootstrap/provider.go
+++ b/cmd/slackdump/internal/bootstrap/provider.go
@@ -1,0 +1,18 @@
+package bootstrap
+
+import (
+	"context"
+
+	"github.com/rusq/slackdump/v3/auth"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/workspace"
+)
+
+// CurrentProviderCtx returns the context with the current provider.
+func CurrentProviderCtx(ctx context.Context) (context.Context, error) {
+	prov, err := workspace.AuthCurrent(ctx, cfg.CacheDir(), cfg.Workspace, cfg.LegacyBrowser)
+	if err != nil {
+		return ctx, err
+	}
+	return auth.WithContext(ctx, prov), nil
+}

--- a/cmd/slackdump/internal/bootstrap/slackdump.go
+++ b/cmd/slackdump/internal/bootstrap/slackdump.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rusq/slackdump/v3"
 	"github.com/rusq/slackdump/v3/auth"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
-	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/workspace"
 )
 
 // SlackdumpSession returns the Slackdump Session initialised with the provider
@@ -31,13 +30,4 @@ func SlackdumpSession(ctx context.Context, opts ...slackdump.Option) (*slackdump
 		prov,
 		stdOpts...,
 	)
-}
-
-// CurrentProviderCtx returns the context with the current provider.
-func CurrentProviderCtx(ctx context.Context) (context.Context, error) {
-	prov, err := workspace.AuthCurrent(ctx, cfg.CacheDir(), cfg.Workspace, cfg.LegacyBrowser)
-	if err != nil {
-		return ctx, err
-	}
-	return auth.WithContext(ctx, prov), nil
 }

--- a/cmd/slackdump/internal/bootstrap/slackdump.go
+++ b/cmd/slackdump/internal/bootstrap/slackdump.go
@@ -1,10 +1,12 @@
-package cfg
+package bootstrap
 
 import (
 	"context"
 
 	"github.com/rusq/slackdump/v3"
 	"github.com/rusq/slackdump/v3/auth"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/workspace"
 )
 
 // SlackdumpSession returns the Slackdump Session initialised with the provider
@@ -18,9 +20,9 @@ func SlackdumpSession(ctx context.Context, opts ...slackdump.Option) (*slackdump
 	}
 
 	var stdOpts = []slackdump.Option{
-		slackdump.WithLogger(Log),
-		slackdump.WithForceEnterprise(ForceEnterprise),
-		slackdump.WithLimits(Limits),
+		slackdump.WithLogger(cfg.Log),
+		slackdump.WithForceEnterprise(cfg.ForceEnterprise),
+		slackdump.WithLimits(cfg.Limits),
 	}
 
 	stdOpts = append(stdOpts, opts...)
@@ -29,4 +31,13 @@ func SlackdumpSession(ctx context.Context, opts ...slackdump.Option) (*slackdump
 		prov,
 		stdOpts...,
 	)
+}
+
+// CurrentProviderCtx returns the context with the current provider.
+func CurrentProviderCtx(ctx context.Context) (context.Context, error) {
+	prov, err := workspace.AuthCurrent(ctx, cfg.CacheDir(), cfg.Workspace, cfg.LegacyBrowser)
+	if err != nil {
+		return ctx, err
+	}
+	return auth.WithContext(ctx, prov), nil
 }

--- a/cmd/slackdump/internal/bootstrap/slackdump_test.go
+++ b/cmd/slackdump/internal/bootstrap/slackdump_test.go
@@ -1,4 +1,4 @@
-package cfg
+package bootstrap
 
 import (
 	"context"

--- a/cmd/slackdump/internal/cfg/cache_test.go
+++ b/cmd/slackdump/internal/cfg/cache_test.go
@@ -13,16 +13,27 @@ func TestCacheDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	tests := []struct {
-		name string
-		want string
+		name          string
+		localDirCache string // set the LocalDirCache to this value
+		want          string
 	}{
 		{
-			"returns the UserCacheDir value",
+			"returns the UserCacheDir value if global LocalDirCache is empty",
+			"",
 			filepath.Join(ucd, cacheDirName),
+		},
+		{
+			"returns the LocalDirCache value if it's set",
+			"local",
+			"local",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			old := LocalCacheDir
+			LocalCacheDir = tt.localDirCache
+			t.Cleanup(func() { LocalCacheDir = old })
+
 			if got := CacheDir(); got != tt.want {
 				t.Errorf("CacheDir() = %v, want %v", got, tt.want)
 			}

--- a/cmd/slackdump/internal/cfg/cfg.go
+++ b/cmd/slackdump/internal/cfg/cfg.go
@@ -55,7 +55,19 @@ var (
 	NoUserCache        bool
 
 	Log logger.Interface
+
+	Version BuildInfo // version propagated by main package.
 )
+
+type BuildInfo struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+}
+
+func (b BuildInfo) String() string {
+	return fmt.Sprintf("Slackdump %s (commit: %s) built on: %s", b.Version, b.Commit, b.Date)
+}
 
 type FlagMask uint16
 

--- a/cmd/slackdump/internal/cfg/cfg_test.go
+++ b/cmd/slackdump/internal/cfg/cfg_test.go
@@ -1,0 +1,119 @@
+// Package cfg contains common configuration variables.
+package cfg
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/rusq/slackdump/v3/auth/browser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetBaseFlags(t *testing.T) {
+	t.Run("all flags are set", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ExitOnError)
+		mask := DefaultFlags
+
+		SetBaseFlags(fs, mask)
+
+		// Test flag parsing and assignment
+		fs.Parse([]string{
+			"-trace", "trace.log",
+			"-log", "log.txt",
+			"-v",
+			"-token", "slack_token",
+			"-cookie", "slack_cookie",
+			"-browser", "firefox",
+			"-browser-timeout", "5s",
+			"-autologin-timeout", "10s",
+			"-legacy-browser",
+			"-enterprise",
+			"-user-agent", "Mozilla/5.0",
+			"-files=false",
+			"-api-config", "config.json",
+			"-o", "output.zip",
+			"-cache-dir", "/tmp/cache",
+			"-workspace", "my_workspace",
+			"-no-user-cache",
+			"-user-cache-retention", "30m",
+			"-no-chunk-cache",
+			"-time-from", "2022-01-01T00:00:00",
+			"-time-to", "2022-01-31T23:59:59",
+		})
+
+		// Test flag values
+		if TraceFile != "trace.log" {
+			t.Errorf("Expected TraceFile to be 'trace.log', got '%s'", TraceFile)
+		}
+		if LogFile != "log.txt" {
+			t.Errorf("Expected LogFile to be 'log.txt', got '%s'", LogFile)
+		}
+		if !Verbose {
+			t.Error("Expected Verbose to be true, got false")
+		}
+		if SlackToken != "slack_token" {
+			t.Errorf("Expected SlackToken to be 'slack_token', got '%s'", SlackToken)
+		}
+		if SlackCookie != "slack_cookie" {
+			t.Errorf("Expected SlackCookie to be 'slack_cookie', got '%s'", SlackCookie)
+		}
+		if Browser != browser.Bfirefox {
+			t.Errorf("Expected Browser to be 'chrome', got '%s'", Browser)
+		}
+		if LoginTimeout != 5*time.Second {
+			t.Errorf("Expected LoginTimeout to be 5 seconds, got %s", LoginTimeout)
+		}
+		if HeadlessTimeout != 10*time.Second {
+			t.Errorf("Expected HeadlessTimeout to be 10 seconds, got %s", HeadlessTimeout)
+		}
+		if !LegacyBrowser {
+			t.Error("Expected LegacyBrowser to be true, got false")
+		}
+		if !ForceEnterprise {
+			t.Error("Expected ForceEnterprise to be true, got false")
+		}
+		if RODUserAgent != "Mozilla/5.0" {
+			t.Errorf("Expected RODUserAgent to be 'Mozilla/5.0', got '%s'", RODUserAgent)
+		}
+		if DownloadFiles {
+			t.Error("Expected DownloadFiles to be false, got true")
+		}
+		if ConfigFile != "config.json" {
+			t.Errorf("Expected ConfigFile to be 'config.json', got '%s'", ConfigFile)
+		}
+		if Output != "output.zip" {
+			t.Errorf("Expected Output to be 'output.zip', got '%s'", Output)
+		}
+		if LocalCacheDir != "/tmp/cache" {
+			t.Errorf("Expected LocalCacheDir to be '/tmp/cache', got '%s'", LocalCacheDir)
+		}
+		if Workspace != "my_workspace" {
+			t.Errorf("Expected Workspace to be 'my_workspace', got '%s'", Workspace)
+		}
+		if !NoUserCache {
+			t.Error("Expected NoUserCache to be true, got false")
+		}
+		if UserCacheRetention != 30*time.Minute {
+			t.Errorf("Expected UserCacheRetention to be 30 minutes, got %s", UserCacheRetention)
+		}
+		if !NoChunkCache {
+			t.Error("Expected NoChunkCache to be true, got false")
+		}
+		if Oldest.String() != "2022-01-01T00:00:00" {
+			t.Errorf("Expected Oldest to be '2022-01-01T00:00:00Z', got '%s'", Oldest.String())
+		}
+		if Latest.String() != "2022-01-31T23:59:59" {
+			t.Errorf("Expected Latest to be '2022-01-31T23:59:59Z', got '%s'", Latest.String())
+		}
+	})
+	t.Run("omit cache dir set", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ExitOnError)
+		mask := OmitCacheDir
+
+		SetBaseFlags(fs, mask)
+		fs.Parse([]string{})
+
+		assert.Equal(t, LocalCacheDir, CacheDir())
+	})
+}

--- a/cmd/slackdump/internal/cfg/slackdump.go
+++ b/cmd/slackdump/internal/cfg/slackdump.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rusq/slackdump/v3"
 	"github.com/rusq/slackdump/v3/auth"
-	"github.com/rusq/slackdump/v3/logger"
 )
 
 // SlackdumpSession returns the Slackdump Session initialised with the provider
@@ -13,14 +12,13 @@ import (
 // configuration.  One can provide additional options to override the
 // defaults.
 func SlackdumpSession(ctx context.Context, opts ...slackdump.Option) (*slackdump.Session, error) {
-	lg := logger.FromContext(ctx)
 	prov, err := auth.FromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var stdOpts = []slackdump.Option{
-		slackdump.WithLogger(lg),
+		slackdump.WithLogger(Log),
 		slackdump.WithForceEnterprise(ForceEnterprise),
 		slackdump.WithLimits(Limits),
 	}

--- a/cmd/slackdump/internal/cfg/slackdump_test.go
+++ b/cmd/slackdump/internal/cfg/slackdump_test.go
@@ -1,0 +1,38 @@
+package cfg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rusq/slack"
+	"github.com/rusq/slackdump/v3"
+	"github.com/rusq/slackdump/v3/auth"
+	"github.com/rusq/slackdump/v3/internal/fixtures"
+)
+
+func TestSlackdumpSession(t *testing.T) {
+	t.Run("no auth in context", func(t *testing.T) {
+		_, err := SlackdumpSession(context.Background())
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+	t.Run("auth in context", func(t *testing.T) {
+		var authJSON = `{"token":"` + strings.Replace(fixtures.TestClientToken, `xoxc`, `xoxb`, -1) + `"}`
+		prov, err := auth.Load(strings.NewReader(authJSON))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// start fake Slack server
+		srv := fixtures.TestAuthServer(t)
+		defer srv.Close()
+		s := slack.New("", slack.OptionAPIURL(srv.URL+"/"))
+
+		ctx := auth.WithContext(context.Background(), prov)
+		if _, err := SlackdumpSession(ctx, slackdump.WithSlackClient(s)); err != nil {
+			t.Error(err)
+		}
+	})
+}

--- a/cmd/slackdump/internal/cfg/timevalue_test.go
+++ b/cmd/slackdump/internal/cfg/timevalue_test.go
@@ -30,6 +30,20 @@ func TestTimeValue_Set(t *testing.T) {
 			tv(time.Date(2009, 9, 16, 20, 30, 40, 0, time.UTC)),
 			false,
 		},
+		{
+			"empty value",
+			&TimeValue{},
+			args{""},
+			tv(time.Time{}),
+			false,
+		},
+		{
+			"invalid value",
+			&TimeValue{},
+			args{"invalid"},
+			tv(time.Time{}),
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -38,6 +52,33 @@ func TestTimeValue_Set(t *testing.T) {
 				t.Errorf("TimeValue.Set() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(t, tt.wantTime, tv)
+		})
+	}
+}
+
+func TestTimeValue_String(t *testing.T) {
+	tests := []struct {
+		name string
+		tv   *TimeValue
+		want string
+	}{
+		{
+			"zero value",
+			tv(time.Time{}),
+			"",
+		},
+		{
+			"valid value",
+			tv(time.Date(2009, 9, 16, 20, 30, 40, 0, time.UTC)),
+			"2009-09-16T20:30:40",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tv := tt.tv
+			if got := tv.String(); got != tt.want {
+				t.Errorf("TimeValue.String() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/cmd/slackdump/internal/diag/info/info.go
+++ b/cmd/slackdump/internal/diag/info/info.go
@@ -44,11 +44,12 @@ import (
 )
 
 type SysInfo struct {
-	OS         OSInfo    `json:"os"`
-	Workspace  Workspace `json:"workspace"`
-	Playwright PwInfo    `json:"playwright"`
-	Rod        RodInfo   `json:"rod"`
-	EzLogin    EZLogin   `json:"ez_login"`
+	Slackdump  SlackdumpInfo `json:"slackdump"`
+	OS         OSInfo        `json:"os"`
+	Workspace  Workspace     `json:"workspace"`
+	Playwright PwInfo        `json:"playwright"`
+	Rod        RodInfo       `json:"rod"`
+	EzLogin    EZLogin       `json:"ez_login"`
 }
 
 // Collect collects system information, replacing user's name in paths with
@@ -71,6 +72,7 @@ func collect(fn func(string) string) *SysInfo {
 		si.Rod.collect,
 		si.EzLogin.collect,
 		si.OS.collect,
+		si.Slackdump.collect,
 	}
 	for _, c := range collectors {
 		c(fn)

--- a/cmd/slackdump/internal/diag/info/info.go
+++ b/cmd/slackdump/internal/diag/info/info.go
@@ -58,7 +58,7 @@ func Collect() *SysInfo {
 	return collect(homeReplacer)
 }
 
-// CollectWithPathReplacer collects the informaiton with the custom path
+// CollectRaw collects the information with the custom path
 // replacing function.
 func CollectRaw() *SysInfo {
 	return collect(noopReplacer)

--- a/cmd/slackdump/internal/diag/info/slackdump.go
+++ b/cmd/slackdump/internal/diag/info/slackdump.go
@@ -1,0 +1,17 @@
+package info
+
+import (
+	"runtime"
+
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
+)
+
+type SlackdumpInfo struct {
+	Build     cfg.BuildInfo `json:"build"`
+	GoVersion string        `json:"go_version"`
+}
+
+func (inf *SlackdumpInfo) collect(PathReplFunc) {
+	inf.Build = cfg.Version
+	inf.GoVersion = runtime.Version()
+}

--- a/cmd/slackdump/internal/diag/record.go
+++ b/cmd/slackdump/internal/diag/record.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/internal/chunk"
@@ -55,7 +56,7 @@ func runRecord(ctx context.Context, _ *base.Command, args []string) error {
 		return errors.New("missing channel argument")
 	}
 
-	sess, err := cfg.SlackdumpSession(ctx)
+	sess, err := bootstrap.SlackdumpSession(ctx)
 	if err != nil {
 		base.SetExitStatus(base.SInitializationError)
 		return err

--- a/cmd/slackdump/internal/dump/dump.go
+++ b/cmd/slackdump/internal/dump/dump.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/rusq/fsadapter"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 
 	"github.com/rusq/slackdump/v3"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
@@ -110,7 +111,7 @@ func RunDump(ctx context.Context, _ *base.Command, args []string) error {
 		}
 	}()
 
-	sess, err := cfg.SlackdumpSession(ctx, slackdump.WithFilesystem(fsa))
+	sess, err := bootstrap.SlackdumpSession(ctx, slackdump.WithFilesystem(fsa))
 	if err != nil {
 		base.SetExitStatus(base.SInitializationError)
 		return err

--- a/cmd/slackdump/internal/emoji/emoji.go
+++ b/cmd/slackdump/internal/emoji/emoji.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rusq/fsadapter"
 	"github.com/rusq/slackdump/v3"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/emoji/emojidl"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
@@ -38,7 +39,7 @@ func run(ctx context.Context, cmd *base.Command, args []string) error {
 	}
 	defer fsa.Close()
 
-	sess, err := cfg.SlackdumpSession(ctx, slackdump.WithFilesystem(fsa))
+	sess, err := bootstrap.SlackdumpSession(ctx, slackdump.WithFilesystem(fsa))
 	if err != nil {
 		base.SetExitStatus(base.SApplicationError)
 		return fmt.Errorf("application error: %s", err)

--- a/cmd/slackdump/internal/export/export.go
+++ b/cmd/slackdump/internal/export/export.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rusq/dlog"
 	"github.com/rusq/fsadapter"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
@@ -72,7 +73,7 @@ func runExport(ctx context.Context, cmd *base.Command, args []string) error {
 		return fmt.Errorf("error parsing the entity list: %w", err)
 	}
 
-	sess, err := cfg.SlackdumpSession(ctx)
+	sess, err := bootstrap.SlackdumpSession(ctx)
 	if err != nil {
 		base.SetExitStatus(base.SApplicationError)
 		return err

--- a/cmd/slackdump/internal/format/format.go
+++ b/cmd/slackdump/internal/format/format.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/rusq/dlog"
 	"github.com/rusq/slack"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
@@ -238,7 +239,7 @@ func getUsers(ctx context.Context, dmp *dump, isOnline bool) ([]slack.User, erro
 }
 
 func getUsersOnline(ctx context.Context, cacheDir, wsp string, usePlaywright bool) ([]slack.User, error) {
-	sess, err := cfg.SlackdumpSession(ctx)
+	sess, err := bootstrap.SlackdumpSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/slackdump/internal/list/list.go
+++ b/cmd/slackdump/internal/list/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rusq/fsadapter"
 	"github.com/rusq/slack"
 	"github.com/rusq/slackdump/v3"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/internal/cache"
@@ -89,7 +90,7 @@ func list(ctx context.Context, listFn listFunc) error {
 	}
 
 	// initialize the session.
-	sess, err := cfg.SlackdumpSession(ctx)
+	sess, err := bootstrap.SlackdumpSession(ctx)
 	if err != nil {
 		base.SetExitStatus(base.SInitializationError)
 		return err

--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -126,7 +126,6 @@ BigCmdLoop:
 			if err := invoke(cmd, args); err != nil {
 				msg := fmt.Sprintf("Error %03[1]d (%[1]s): %[2]s", base.ExitStatus(), err)
 				logger.Default.Print(msg)
-				fmt.Fprintln(os.Stderr, msg)
 			}
 			base.Exit()
 			return

--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -288,7 +288,7 @@ func initLog(filename string, verbose bool) (*dlog.Logger, error) {
 }
 
 // secrets defines the names of the supported secret files that we load our
-// secrets from.  Inexperienced windows users might have bad experience trying
+// secrets from.  Inexperienced Windows users might have bad experience trying
 // to create .env file with the notepad as it will battle for having the
 // "txt" extension.  Let it have it.
 var secretFiles = []string{".env", ".env.txt", "secrets.txt"}
@@ -310,9 +310,7 @@ const (
 )
 
 func whatDo() (choice, error) {
-	fmt.Println()
-	printVersion()
-	fmt.Println()
+	fmt.Print("\n" + cfg.Version.String() + "\n")
 
 	var ans choice
 	err := huh.NewSelect[choice]().

--- a/cmd/slackdump/version.go
+++ b/cmd/slackdump/version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 )
 
@@ -12,6 +13,14 @@ var (
 	commit  = "unknown"
 	date    = "unknown"
 )
+
+func init() {
+	cfg.Version = cfg.BuildInfo{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+	}
+}
 
 var CmdVersion = &base.Command{
 	UsageLine: "version",
@@ -27,10 +36,6 @@ And by the way, version is: ` + version + `, commit: ` + commit + `, built on ` 
 }
 
 func versionRun(context.Context, *base.Command, []string) error {
-	printVersion()
+	fmt.Println(cfg.Version)
 	return nil
-}
-
-func printVersion() {
-	fmt.Printf("Slackdump %s (commit: %s) built on: %s\n", version, commit, date)
 }

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -30,7 +30,7 @@ const (
 var ErrUnsupChunkType = fmt.Errorf("unsupported chunk type")
 
 // Chunk is a representation of a single chunk of data retrieved from the API.
-// A single API call always produce a single Chunk.
+// A single API call always produces a single Chunk.
 type Chunk struct {
 	// header
 	// Type is the type of the Chunk

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -190,7 +190,7 @@ func (c *Chunk) messageTimestamps() ([]int64, error) {
 	for i := range c.Messages {
 		iTS, err := fasttime.TS2int(c.Messages[i].Timestamp)
 		if err != nil {
-			return nil, fmt.Errorf("invalid timestamp: %q: %w", c.Messages[i].Timestamp, err)
+			return nil, err
 		}
 		ts[i] = iTS
 	}

--- a/internal/chunk/directory.go
+++ b/internal/chunk/directory.go
@@ -323,6 +323,8 @@ func (d *Directory) WorkspaceInfo() (*slack.AuthTestResponse, error) {
 	return nil, errors.New("no workspace info found")
 }
 
+const extIdx = ".idx"
+
 func cachedFromReader(wf osext.ReadSeekCloseNamer, wantCache bool) (*File, error) {
 	if !wantCache {
 		return FromReader(wf)

--- a/internal/chunk/dirproc/dirproc.go
+++ b/internal/chunk/dirproc/dirproc.go
@@ -19,8 +19,9 @@ type dirproc struct {
 	*chunk.Recorder
 }
 
-// newDirProc initialises the new base processor which wraps the file
-// recorder.  It creates a new chunk file in a directory dir which must exist.
+// newDirProc initialises the new directory processor which wraps the file
+// recorder.  It creates a new chunk file in a directory cd. Directory cd
+// must exist.
 func newDirProc(cd *chunk.Directory, name chunk.FileID) (*dirproc, error) {
 	wc, err := cd.Create(name)
 	if err != nil {

--- a/internal/chunk/dirproc/users.go
+++ b/internal/chunk/dirproc/users.go
@@ -39,13 +39,15 @@ func NewUsers(cd *chunk.Directory, opt ...UserOption) (*Users, error) {
 	return u, nil
 }
 
+// Users processes chunk of users.  If the callback is set, it will be called
+// with the users slice.
 func (u *Users) Users(ctx context.Context, users []slack.User) error {
 	if err := u.dirproc.Users(ctx, users); err != nil {
 		return err
 	}
 	if u.cb != nil {
 		if err := u.cb(users); err != nil {
-			return fmt.Errorf("users callback: %w", err)
+			return fmt.Errorf("users callback returned an error: %w", err)
 		}
 	}
 	return nil

--- a/internal/chunk/file.go
+++ b/internal/chunk/file.go
@@ -131,11 +131,13 @@ func indexChunks(dec decoder) (index, error) {
 }
 
 // ensure ensures that the file index was generated.
-//
-// TODO: maybe it shouldn't panic.
 func (f *File) ensure() {
 	if f.idx == nil {
-		log.Panicf("internal error:  %s called before File.Open", osext.Caller(1))
+		var err error
+		f.idx, err = indexChunks(json.NewDecoder(f.rs))
+		if err != nil {
+			log.Panicf("%s: index error: %s", osext.Caller(1), err)
+		}
 	}
 }
 

--- a/internal/chunk/file.go
+++ b/internal/chunk/file.go
@@ -87,6 +87,7 @@ func fromReaderWithIndex(rs io.ReadSeeker, idx index) (*File, error) {
 	if _, err := rs.Seek(0, io.SeekStart); err != nil { // reset offset
 		return nil, err
 	}
+	// TODO: validate index.
 	return &File{
 		rs:  rs,
 		idx: idx,

--- a/internal/chunk/file.go
+++ b/internal/chunk/file.go
@@ -148,10 +148,13 @@ func (f *File) Offsets(id GroupID) ([]int64, bool) {
 	return ret, ok && len(ret) > 0
 }
 
+// HasUsers returns true if there is at least one user chunk in the file.
 func (f *File) HasUsers() bool {
 	return f.HasChunks(userChunkID)
 }
 
+// HasChannels returns true if there is at least one channel chunk in the
+// file.
 func (f *File) HasChannels() bool {
 	return f.HasChunks(channelChunkID)
 }
@@ -395,7 +398,7 @@ func (p *File) AllChannelIDs() []string {
 	var ids = make([]string, 0, 1)
 	for gid := range p.idx {
 		id := string(gid)
-		if !strings.Contains(id, ":") && !gid.isInfo() && !gid.isList() {
+		if !strings.Contains(id, ":") && !gid.isInfo() && !gid.isList() && !gid.isSearch() {
 			ids = append(ids, id)
 		}
 	}

--- a/internal/chunk/file_test.go
+++ b/internal/chunk/file_test.go
@@ -228,6 +228,14 @@ var testChunks = []Chunk{
 			},
 		},
 	},
+	{
+		Type:        CSearchMessages,
+		Timestamp:   1234567890,
+		SearchQuery: "hello",
+		SearchMessages: []slack.SearchMessage{
+			{},
+		},
+	},
 }
 
 func Test_indexRecords(t *testing.T) {

--- a/internal/chunk/filemgr_test.go
+++ b/internal/chunk/filemgr_test.go
@@ -1,0 +1,38 @@
+package chunk
+
+import "testing"
+
+func Test_hash(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"empty",
+			args{""},
+			"da39a3ee5e6b4b0d3255bfef95601890afd80709",
+		},
+		{
+			"hello",
+			args{"hello"},
+			"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hash(tt.args.s); got != tt.want {
+				t.Errorf("hash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Benchmark_hash(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		hash("hello")
+	}
+}

--- a/internal/chunk/player.go
+++ b/internal/chunk/player.go
@@ -1,15 +1,12 @@
 package chunk
 
 import (
-	"errors"
 	"io"
 	"sync"
 	"sync/atomic"
 
 	"github.com/rusq/slack"
 )
-
-var ErrExhausted = errors.New("exhausted")
 
 // offsets holds the index of the current offset in the index for each chunk
 // ID.

--- a/internal/chunk/player.go
+++ b/internal/chunk/player.go
@@ -8,8 +8,8 @@ import (
 	"github.com/rusq/slack"
 )
 
-// offsets holds the index of the current offset in the index for each chunk
-// ID.
+// offsets holds the pointer to the current offset in the File offset index
+// for each group ID.
 type offsets map[GroupID]int
 
 // Player replays the chunks from a file, it is able to emulate the API

--- a/internal/chunk/recorder.go
+++ b/internal/chunk/recorder.go
@@ -208,6 +208,7 @@ func (rec *Recorder) ChannelUsers(ctx context.Context, channelID string, threadT
 	chunk := Chunk{
 		Type:         CChannelUsers,
 		ChannelID:    channelID,
+		Count:        len(users),
 		Timestamp:    time.Now().UnixNano(),
 		ChannelUsers: users,
 	}
@@ -225,6 +226,7 @@ func (rec *Recorder) SearchMessages(ctx context.Context, query string, sm []slac
 	chunk := Chunk{
 		Type:           CSearchMessages,
 		Timestamp:      time.Now().UnixNano(),
+		Count:          len(sm),
 		SearchQuery:    query,
 		SearchMessages: sm,
 	}
@@ -241,6 +243,7 @@ func (rec *Recorder) SearchFiles(ctx context.Context, query string, sf []slack.F
 	chunk := Chunk{
 		Type:        CSearchFiles,
 		Timestamp:   time.Now().UnixNano(),
+		Count:       len(sf),
 		SearchQuery: query,
 		SearchFiles: sf,
 	}

--- a/internal/chunk/recorder.go
+++ b/internal/chunk/recorder.go
@@ -121,8 +121,9 @@ func (rec *Recorder) ThreadMessages(ctx context.Context, channelID string, paren
 	return nil
 }
 
-// isThread should be set to true, if channelinfo is called while streaming a
-// thread (user requested a thread).
+// ChannelInfo records a channel information.  threadTS should be set to
+// threadTS, if ChannelInfo is called while streaming a thread (user requested
+// a thread).
 func (rec *Recorder) ChannelInfo(ctx context.Context, channel *slack.Channel, threadTS string) error {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
@@ -141,6 +142,7 @@ func (rec *Recorder) ChannelInfo(ctx context.Context, channel *slack.Channel, th
 	return nil
 }
 
+// Users records a slice of users.
 func (rec *Recorder) Users(ctx context.Context, users []slack.User) error {
 	chunk := Chunk{
 		Type:      CUsers,
@@ -154,6 +156,7 @@ func (rec *Recorder) Users(ctx context.Context, users []slack.User) error {
 	return nil
 }
 
+// Channel records a slice of channels.
 func (rec *Recorder) Channels(ctx context.Context, channels []slack.Channel) error {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
@@ -169,6 +172,7 @@ func (rec *Recorder) Channels(ctx context.Context, channels []slack.Channel) err
 	return nil
 }
 
+// State returns the current recorder state.
 func (rec *Recorder) State() (*state.State, error) {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
@@ -176,6 +180,7 @@ func (rec *Recorder) State() (*state.State, error) {
 	return rec.state, nil
 }
 
+// Close closes the recorder (it's a noop for now).
 func (rec *Recorder) Close() error {
 	return nil
 }
@@ -213,7 +218,7 @@ func (rec *Recorder) ChannelUsers(ctx context.Context, channelID string, threadT
 	return nil
 }
 
-// SearchMessages records the search messages.
+// SearchMessages records the result of a message search.
 func (rec *Recorder) SearchMessages(ctx context.Context, query string, sm []slack.SearchMessage) error {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
@@ -229,6 +234,7 @@ func (rec *Recorder) SearchMessages(ctx context.Context, query string, sm []slac
 	return nil
 }
 
+// SearchMessages records the result of a file search.
 func (rec *Recorder) SearchFiles(ctx context.Context, query string, sf []slack.File) error {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()

--- a/internal/edge/conversations.go
+++ b/internal/edge/conversations.go
@@ -53,3 +53,63 @@ func (cl *Client) ConversationsGenericInfo(ctx context.Context, channelID ...str
 	}
 	return r.Channels, nil
 }
+
+type conversationsViewForm struct {
+	BaseRequest
+	CanonicalAvatars             bool   `json:"canonical_avatars"`
+	NoUserProfile                bool   `json:"no_user_profile"`
+	IgnoreReplies                bool   `json:"ignore_replies"`
+	NoSelf                       bool   `json:"no_self"`
+	IncludeFullUsers             bool   `json:"include_full_users"`
+	IncludeUseCases              bool   `json:"include_use_cases"`
+	IncludeStories               bool   `json:"include_stories"`
+	NoMembers                    bool   `json:"no_members"`
+	IncludeMutationTimestamps    bool   `json:"include_mutation_timestamps"`
+	Count                        int    `json:"count"`
+	Channel                      string `json:"channel"`
+	IncludeFreeTeamExtraMessages bool   `json:"include_free_team_extra_messages"`
+	WebClientFields
+}
+
+type ConversationsViewResponse struct {
+	Users  []User            `json:"users"`
+	IM     IM                `json:"im"`
+	Emojis map[string]string `json:"emojis"`
+	// we don't care about the rest of the response
+}
+
+func (cl *Client) ConversationsView(ctx context.Context, channelID string) (ConversationsViewResponse, error) {
+	ctx, task := trace.NewTask(ctx, "ConversationsView")
+	defer task.End()
+	trace.Logf(ctx, "params", "channelID=%v", channelID)
+
+	form := conversationsViewForm{
+		BaseRequest: BaseRequest{
+			Token: cl.token,
+		},
+		CanonicalAvatars:          true,
+		NoUserProfile:             true,
+		IgnoreReplies:             true,
+		NoSelf:                    true,
+		IncludeFullUsers:          false,
+		IncludeUseCases:           false,
+		IncludeStories:            false,
+		NoMembers:                 true,
+		IncludeMutationTimestamps: false,
+		Count:                     50,
+		Channel:                   channelID,
+		WebClientFields:           webclientReason(""),
+	}
+	resp, err := cl.PostForm(ctx, "conversations.view", values(form, true))
+	if err != nil {
+		return ConversationsViewResponse{}, err
+	}
+	var r = struct {
+		BaseResponse
+		ConversationsViewResponse
+	}{}
+	if err := cl.ParseResponse(&r, resp); err != nil {
+		return ConversationsViewResponse{}, err
+	}
+	return r.ConversationsViewResponse, nil
+}

--- a/internal/fasttime/benchmarks.adoc
+++ b/internal/fasttime/benchmarks.adoc
@@ -70,3 +70,28 @@ BenchmarkTs2Int-16      34785256                34.28 ns/op
 PASS
 ok      github.com/rusq/slackdump/v3/internal/fasttime  13.389s
 ---
+
+= Apple M2 Pro
+== 64bit
+
+[source]
+---
+[0:slackdump/internal/fasttime (v3-tests)> go test . -bench='.*' -count=10
+goos: darwin
+goarch: arm64
+pkg: github.com/rusq/slackdump/v3/internal/fasttime
+cpu: Apple M2 Pro
+BenchmarkTs2Int-12    	42965772	        26.23 ns/op
+BenchmarkTs2Int-12    	46241808	        25.96 ns/op
+BenchmarkTs2Int-12    	46265431	        26.06 ns/op
+BenchmarkTs2Int-12    	46032642	        26.04 ns/op
+BenchmarkTs2Int-12    	45946497	        26.06 ns/op
+BenchmarkTs2Int-12    	46274054	        26.08 ns/op
+BenchmarkTs2Int-12    	45322496	        26.23 ns/op
+BenchmarkTs2Int-12    	45914998	        26.02 ns/op
+BenchmarkTs2Int-12    	45696441	        26.22 ns/op
+BenchmarkTs2Int-12    	46148742	        26.25 ns/op
+PASS
+ok  	github.com/rusq/slackdump/v3/internal/fasttime	12.895s
+---
+

--- a/internal/fasttime/benchmarks.adoc
+++ b/internal/fasttime/benchmarks.adoc
@@ -95,3 +95,24 @@ PASS
 ok  	github.com/rusq/slackdump/v3/internal/fasttime	12.895s
 ---
 
+== Raspberry PI 5
+=== 64-bit arm
+
+[source]
+---
+goos: linux
+goarch: arm64
+pkg: github.com/rusq/slackdump/v3/internal/fasttime
+BenchmarkTs2Int-4   	18843753	        63.67 ns/op
+BenchmarkTs2Int-4   	18833313	        63.59 ns/op
+BenchmarkTs2Int-4   	18854378	        63.66 ns/op
+BenchmarkTs2Int-4   	18791438	        63.65 ns/op
+BenchmarkTs2Int-4   	18855210	        63.66 ns/op
+BenchmarkTs2Int-4   	18888588	        63.08 ns/op
+BenchmarkTs2Int-4   	18831703	        63.65 ns/op
+BenchmarkTs2Int-4   	18925939	        63.64 ns/op
+BenchmarkTs2Int-4   	18885816	        63.39 ns/op
+BenchmarkTs2Int-4   	18879703	        63.73 ns/op
+PASS
+ok  	github.com/rusq/slackdump/v3/internal/fasttime	12.651s
+---

--- a/internal/fasttime/benchmarks.adoc
+++ b/internal/fasttime/benchmarks.adoc
@@ -52,7 +52,7 @@ ok      github.com/rusq/slackdump/v3/internal/fasttime  12.546s
 
 [source]
 ---
-[3:30:15] 0:slackdump/internal/fasttime (v3-tests)> go test . -bench '.*' -count=10
+[0:slackdump/internal/fasttime (v3-tests)> go test . -bench '.*' -count=10
 goos: darwin
 goarch: amd64
 pkg: github.com/rusq/slackdump/v3/internal/fasttime
@@ -71,8 +71,8 @@ PASS
 ok      github.com/rusq/slackdump/v3/internal/fasttime  13.389s
 ---
 
-= Apple M2 Pro
-== 64bit
+== Apple M2 Pro
+=== 64bit
 
 [source]
 ---

--- a/internal/fasttime/benchmarks.adoc
+++ b/internal/fasttime/benchmarks.adoc
@@ -46,3 +46,27 @@ BenchmarkTs2Int-4       16509716                72.28 ns/op
 PASS
 ok      github.com/rusq/slackdump/v3/internal/fasttime  18.064s
 ---
+
+== i9-9880H @ 2.30GHz
+== 64bit
+
+[source]
+---
+[3:30:15] 0:slackdump/internal/fasttime (v3-tests)> go test . -bench '.*' -count=10
+goos: darwin
+goarch: amd64
+pkg: github.com/rusq/slackdump/v3/internal/fasttime
+cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
+BenchmarkTs2Int-16      29724420                34.15 ns/op
+BenchmarkTs2Int-16      30925324                34.26 ns/op
+BenchmarkTs2Int-16      29584566                33.91 ns/op
+BenchmarkTs2Int-16      35253584                34.05 ns/op
+BenchmarkTs2Int-16      29480674                35.25 ns/op
+BenchmarkTs2Int-16      29552312                34.18 ns/op
+BenchmarkTs2Int-16      31243936                34.79 ns/op
+BenchmarkTs2Int-16      29591794                34.35 ns/op
+BenchmarkTs2Int-16      30912422                34.46 ns/op
+BenchmarkTs2Int-16      34785256                34.28 ns/op
+PASS
+ok      github.com/rusq/slackdump/v3/internal/fasttime  13.389s
+---

--- a/internal/fasttime/benchmarks.adoc
+++ b/internal/fasttime/benchmarks.adoc
@@ -10,41 +10,41 @@ goos: windows
 goarch: 386
 pkg: github.com/rusq/slackdump/v3/internal/fasttime
 cpu: Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz
-BenchmarkTs2Int-4        3084236               388.5 ns/op
-BenchmarkTs2Int-4        3130807               379.5 ns/op
-BenchmarkTs2Int-4        3134098               382.9 ns/op
-BenchmarkTs2Int-4        3142426               378.4 ns/op
-BenchmarkTs2Int-4        3133819               382.8 ns/op
-BenchmarkTs2Int-4        3152484               376.7 ns/op
-BenchmarkTs2Int-4        3076028               377.8 ns/op
-BenchmarkTs2Int-4        3143527               379.2 ns/op
-BenchmarkTs2Int-4        3134566               380.1 ns/op
-BenchmarkTs2Int-4        3152730               378.8 ns/op
+BenchmarkTs2Int-4        3395229               342.9 ns/op
+BenchmarkTs2Int-4        3516256               330.3 ns/op
+BenchmarkTs2Int-4        3571240               334.7 ns/op
+BenchmarkTs2Int-4        3588696               332.4 ns/op
+BenchmarkTs2Int-4        3579144               330.6 ns/op
+BenchmarkTs2Int-4        3565935               331.5 ns/op
+BenchmarkTs2Int-4        3505794               333.7 ns/op
+BenchmarkTs2Int-4        3601692               331.8 ns/op
+BenchmarkTs2Int-4        3552079               332.3 ns/op
+BenchmarkTs2Int-4        3594452               334.0 ns/op
 PASS
-ok      github.com/rusq/slackdump/v3/internal/fasttime  16.000s
+ok      github.com/rusq/slackdump/v3/internal/fasttime  15.460s
 ---
 
 === 64bit
 
 [source]
 ---   
-PS C:\slackdump\internal\fasttime> go test . -bench ".*" -count=10
+PS C:\slackdump\internal\fasttime>go test . -bench=".*" -count=10
 goos: windows
 goarch: amd64
 pkg: github.com/rusq/slackdump/v3/internal/fasttime
 cpu: Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz
-BenchmarkTs2Int-4       15718426                73.29 ns/op
-BenchmarkTs2Int-4       16554610                72.74 ns/op
-BenchmarkTs2Int-4       13828022                73.78 ns/op
-BenchmarkTs2Int-4       14210768                72.53 ns/op
-BenchmarkTs2Int-4       14328169                74.43 ns/op
-BenchmarkTs2Int-4       16349811                72.58 ns/op
-BenchmarkTs2Int-4       16485547                72.99 ns/op
-BenchmarkTs2Int-4       16368154                72.58 ns/op
-BenchmarkTs2Int-4       13619184                73.89 ns/op
-BenchmarkTs2Int-4       16509716                72.28 ns/op
+BenchmarkTs2Int-4       24260755                46.94 ns/op
+BenchmarkTs2Int-4       22409967                46.41 ns/op
+BenchmarkTs2Int-4       23303821                47.15 ns/op
+BenchmarkTs2Int-4       22653648                46.85 ns/op
+BenchmarkTs2Int-4       23203335                46.85 ns/op
+BenchmarkTs2Int-4       23275254                46.59 ns/op
+BenchmarkTs2Int-4       23464814                46.64 ns/op
+BenchmarkTs2Int-4       22861932                47.32 ns/op
+BenchmarkTs2Int-4       22373408                46.77 ns/op
+BenchmarkTs2Int-4       23907906                46.81 ns/op
 PASS
-ok      github.com/rusq/slackdump/v3/internal/fasttime  18.064s
+ok      github.com/rusq/slackdump/v3/internal/fasttime  12.546s
 ---
 
 == i9-9880H @ 2.30GHz

--- a/internal/fasttime/benchmarks.adoc
+++ b/internal/fasttime/benchmarks.adoc
@@ -1,0 +1,48 @@
+= BenchmarkTs2Int
+
+== i7-4600U
+=== 32bit
+
+[source]
+---
+PS C:\slackdump\internal\fasttime>go test . -bench ".*" -count=10
+goos: windows
+goarch: 386
+pkg: github.com/rusq/slackdump/v3/internal/fasttime
+cpu: Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz
+BenchmarkTs2Int-4        3084236               388.5 ns/op
+BenchmarkTs2Int-4        3130807               379.5 ns/op
+BenchmarkTs2Int-4        3134098               382.9 ns/op
+BenchmarkTs2Int-4        3142426               378.4 ns/op
+BenchmarkTs2Int-4        3133819               382.8 ns/op
+BenchmarkTs2Int-4        3152484               376.7 ns/op
+BenchmarkTs2Int-4        3076028               377.8 ns/op
+BenchmarkTs2Int-4        3143527               379.2 ns/op
+BenchmarkTs2Int-4        3134566               380.1 ns/op
+BenchmarkTs2Int-4        3152730               378.8 ns/op
+PASS
+ok      github.com/rusq/slackdump/v3/internal/fasttime  16.000s
+---
+
+=== 64bit
+
+[source]
+---   
+PS C:\slackdump\internal\fasttime> go test . -bench ".*" -count=10
+goos: windows
+goarch: amd64
+pkg: github.com/rusq/slackdump/v3/internal/fasttime
+cpu: Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz
+BenchmarkTs2Int-4       15718426                73.29 ns/op
+BenchmarkTs2Int-4       16554610                72.74 ns/op
+BenchmarkTs2Int-4       13828022                73.78 ns/op
+BenchmarkTs2Int-4       14210768                72.53 ns/op
+BenchmarkTs2Int-4       14328169                74.43 ns/op
+BenchmarkTs2Int-4       16349811                72.58 ns/op
+BenchmarkTs2Int-4       16485547                72.99 ns/op
+BenchmarkTs2Int-4       16368154                72.58 ns/op
+BenchmarkTs2Int-4       13619184                73.89 ns/op
+BenchmarkTs2Int-4       16509716                72.28 ns/op
+PASS
+ok      github.com/rusq/slackdump/v3/internal/fasttime  18.064s
+---

--- a/internal/fasttime/fasttime.go
+++ b/internal/fasttime/fasttime.go
@@ -2,7 +2,6 @@ package fasttime
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -35,20 +34,6 @@ func (t Time) SlackString() string {
 }
 
 var ErrNotATimestamp = errors.New("not a slack timestamp")
-
-// TS2int converts a slack timestamp to an int64 by stripping the dot and
-// converting the string to an int64.  It is useful for fast comparison.
-func TS2int(ts string) (int64, error) {
-	if ts == "" {
-		return 0, nil
-	}
-	i := strings.IndexByte(ts, '.')
-	if i == -1 {
-		return 0, fmt.Errorf("%w: %q", ErrNotATimestamp, ts)
-	}
-	val, err := atoi(ts[:i] + ts[i+1:])
-	return int64(val), err
-}
 
 // Int2TS converts an int64 to a slack timestamp by inserting a dot in the
 // right place.

--- a/internal/fasttime/fasttime.go
+++ b/internal/fasttime/fasttime.go
@@ -46,7 +46,7 @@ func TS2int(ts string) (int64, error) {
 	if i == -1 {
 		return 0, fmt.Errorf("%w: %q", ErrNotATimestamp, ts)
 	}
-	val, err := strconv.ParseUint(ts[:i]+ts[i+1:], 10, 64)
+	val, err := atoi(ts[:i] + ts[i+1:])
 	return int64(val), err
 }
 

--- a/internal/fasttime/fasttime.go
+++ b/internal/fasttime/fasttime.go
@@ -42,11 +42,12 @@ func TS2int(ts string) (int64, error) {
 	if ts == "" {
 		return 0, nil
 	}
-	before, after, found := strings.Cut(ts, ".")
-	if !found {
-		return 0, fmt.Errorf("%w: %s", ErrNotATimestamp, ts)
+	i := strings.IndexByte(ts, '.')
+	if i == -1 {
+		return 0, fmt.Errorf("%w: %q", ErrNotATimestamp, ts)
 	}
-	return strconv.ParseInt(before+after, 10, 64)
+	val, err := strconv.ParseUint(ts[:i]+ts[i+1:], 10, 64)
+	return int64(val), err
 }
 
 // Int2TS converts an int64 to a slack timestamp by inserting a dot in the

--- a/internal/fasttime/fasttime_386.go
+++ b/internal/fasttime/fasttime_386.go
@@ -2,8 +2,24 @@
 
 package fasttime
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // int size on the 32-bit systems is 32 bit (surprise), this constraints us to slower 64-bit implementation.
 
-var atoi = func(s string) (int64, error) { return strconv.ParseInt(s, 10, 64) }
+// TS2int converts a slack timestamp to an int64 by stripping the dot and
+// converting the string to an int64.  It is useful for fast comparison.
+func TS2int(ts string) (int64, error) {
+	if ts == "" {
+		return 0, nil
+	}
+	i := strings.IndexByte(ts, '.')
+	if i == -1 {
+		return 0, fmt.Errorf("%w: %q", ErrNotATimestamp, ts)
+	}
+	val, err := strconv.ParseInt(ts[:i]+ts[i+1:], 10, 64)
+	return int64(val), err
+}

--- a/internal/fasttime/fasttime_386.go
+++ b/internal/fasttime/fasttime_386.go
@@ -1,0 +1,9 @@
+//go:build 386
+
+package fasttime
+
+import "strconv"
+
+// int size on the 32-bit systems is 32 bit (surprise), this constraints us to slower 64-bit implementation.
+
+var atoi = func(s string) (int64, error) { return strconv.ParseInt(s, 10, 64) }

--- a/internal/fasttime/fasttime_test.go
+++ b/internal/fasttime/fasttime_test.go
@@ -112,3 +112,13 @@ func TestInt2Time(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkTs2Int(b *testing.B) {
+	var n int64
+	for i := 0; i < b.N; i++ {
+		n, _ = TS2int("1638494510.037400")
+	}
+	if n != 1638494510037400 {
+		b.Errorf("Expected 1638494510037400, got %d", n)
+	}
+}

--- a/internal/fasttime/fasttime_test.go
+++ b/internal/fasttime/fasttime_test.go
@@ -1,7 +1,9 @@
 package fasttime
 
 import (
+	"math"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -32,6 +34,12 @@ func TestTs2int(t *testing.T) {
 			"real ts",
 			args{"1674255434.388009"},
 			1674255434388009,
+			false,
+		},
+		{
+			"maxint64",
+			args{strconv.FormatInt(math.MaxInt64/1000, 10) + ".000"},
+			math.MaxInt64 / 1000 * 1000,
 			false,
 		},
 		{

--- a/internal/fasttime/fasttime_x64.go
+++ b/internal/fasttime/fasttime_x64.go
@@ -1,0 +1,9 @@
+//go:build !386
+
+package fasttime
+
+import "strconv"
+
+// As int on 64-bit systems is 64 bit, it is possible to use faster Atoi.
+
+var atoi = strconv.Atoi

--- a/internal/fasttime/fasttime_x64.go
+++ b/internal/fasttime/fasttime_x64.go
@@ -2,8 +2,22 @@
 
 package fasttime
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
-// As int on 64-bit systems is 64 bit, it is possible to use faster Atoi.
-
-var atoi = strconv.Atoi
+// TS2int converts a slack timestamp to an int64 by stripping the dot and
+// converting the string to an int64.  It is useful for fast comparison.
+func TS2int(ts string) (int64, error) {
+	if ts == "" {
+		return 0, nil
+	}
+	i := strings.IndexByte(ts, '.')
+	if i == -1 {
+		return 0, fmt.Errorf("%w: %q", ErrNotATimestamp, ts)
+	}
+	val, err := strconv.Atoi(ts[:i] + ts[i+1:])
+	return int64(val), err
+}

--- a/internal/fixtures/api.go
+++ b/internal/fixtures/api.go
@@ -1,0 +1,28 @@
+package fixtures
+
+import (
+	_ "embed"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+//go:embed assets/slack_api/authtestinfo.json
+var TestAuthTestInfo []byte
+
+// TestAuthServer returns a test HTTP server that responds with the test auth
+// info [TestAuthTestInfo].  The caller should close the server when done.
+func TestAuthServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return TestServer(t, http.StatusOK, TestAuthTestInfo)
+}
+
+// TestServer returns a test HTTP server that responds with the given code and
+// response. The caller should close the server when done.
+func TestServer(t *testing.T, code int, response []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		w.Write(response)
+	}))
+}

--- a/internal/fixtures/assets/slack_api/authtestinfo.json
+++ b/internal/fixtures/assets/slack_api/authtestinfo.json
@@ -1,0 +1,1 @@
+{"url":"https://test.slack.com/","team":"team_test","user":"user_test","team_id":"TAAAAAAAA","user_id":"UBBBBBBBB","bot_id":""}

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -59,7 +59,6 @@ func (e *ErrRetryFailed) Is(target error) bool {
 // slack.RateLimitedError, it will delay, and then call it again up to
 // maxAttempts times. It will return an error if it runs out of attempts.
 func WithRetry(ctx context.Context, lim *rate.Limiter, maxAttempts int, fn func() error) error {
-	tracelogf(ctx, "info", "maxAttempts=%d", maxAttempts)
 	var ok bool
 	if maxAttempts == 0 {
 		maxAttempts = defNumAttempts
@@ -78,7 +77,6 @@ func WithRetry(ctx context.Context, lim *rate.Limiter, maxAttempts int, fn func(
 
 		cbErr := fn()
 		if cbErr == nil {
-			tracelogf(ctx, "info", "success")
 			ok = true
 			break
 		}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -45,10 +45,13 @@ const (
 	logCtxKey logCtx = iota
 )
 
+// NewContext returns a new context with the logger.
 func NewContext(ctx context.Context, l Interface) context.Context {
 	return context.WithValue(ctx, logCtxKey, l)
 }
 
+// FromContext returns the logger from the context.  If no logger is found,
+// the Default logger is returned.
 func FromContext(ctx context.Context) Interface {
 	if l, ok := ctx.Value(logCtxKey).(Interface); ok {
 		return l

--- a/slackdump.go
+++ b/slackdump.go
@@ -205,6 +205,7 @@ func (s *Session) initClient(ctx context.Context, prov auth.Provider, forceEdge 
 	isEnterpriseWsp := s.wspInfo.EnterpriseID != ""
 	if forceEdge || isEnterpriseWsp {
 		// replace the client with the edge client
+		// TODO: this is hacky af.
 		ecl, err := edge.NewWithInfo(s.wspInfo, prov)
 		if err != nil {
 			return err

--- a/stream/resulttype_string.go
+++ b/stream/resulttype_string.go
@@ -12,11 +12,12 @@ func _() {
 	_ = x[RTChannel-1]
 	_ = x[RTThread-2]
 	_ = x[RTChannelInfo-3]
+	_ = x[RTChannelUsers-4]
 }
 
-const _ResultType_name = "MainChannelThreadChannelInfo"
+const _ResultType_name = "MainChannelThreadChannelInfoChannelUsers"
 
-var _ResultType_index = [...]uint8{0, 4, 11, 17, 28}
+var _ResultType_index = [...]uint8{0, 4, 11, 17, 28, 40}
 
 func (i ResultType) String() string {
 	if i < 0 || i >= ResultType(len(_ResultType_index)-1) {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -89,6 +89,7 @@ const (
 	RTChannel                   // Result containing channel information
 	RTThread                    // Result containing thread information
 	RTChannelInfo
+	RTChannelUsers
 )
 
 // Result is sent to the callback function for each channel or thread.

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -54,6 +54,7 @@ type Stream struct {
 	client         Slacker
 	limits         rateLimits
 	chanCache      *chanCache
+	fastSearch     bool
 	resultFn       []func(sr Result) error
 }
 
@@ -149,6 +150,12 @@ func OptLatest(t time.Time) Option {
 func OptResultFn(fn func(sr Result) error) Option {
 	return func(cs *Stream) {
 		cs.resultFn = append(cs.resultFn, fn)
+	}
+}
+
+func OptFastSearch() Option {
+	return func(cs *Stream) {
+		cs.fastSearch = true
 	}
 }
 

--- a/stream/stream_workers.go
+++ b/stream/stream_workers.go
@@ -22,7 +22,7 @@ func (cs *Stream) channelWorker(ctx context.Context, proc processor.Conversation
 			if !more {
 				return // channel closed
 			}
-			channel, err := cs.channelInfoWithUsers(ctx, proc, req.sl.Channel, req.sl.ThreadTS)
+			channel, err := cs.procChannelInfoWithUsers(ctx, proc, req.sl.Channel, req.sl.ThreadTS)
 			if err != nil {
 				results <- Result{Type: RTChannel, ChannelID: req.sl.Channel, Err: err}
 				continue
@@ -63,7 +63,7 @@ func (cs *Stream) threadWorker(ctx context.Context, proc processor.Conversations
 			var channel = new(slack.Channel)
 			if req.threadOnly {
 				var err error
-				if channel, err = cs.channelInfoWithUsers(ctx, proc, req.sl.Channel, req.sl.ThreadTS); err != nil {
+				if channel, err = cs.procChannelInfoWithUsers(ctx, proc, req.sl.Channel, req.sl.ThreadTS); err != nil {
 					results <- Result{Type: RTThread, ChannelID: req.sl.Channel, ThreadTS: req.sl.ThreadTS, Err: err}
 					continue
 				}
@@ -89,9 +89,9 @@ func (cs *Stream) channelInfoWorker(ctx context.Context, proc processor.ChannelI
 	ctx, task := trace.NewTask(ctx, "channelInfoWorker")
 	defer task.End()
 
-	infoFetcher := cs.channelInfoWithUsers
+	infoFetcher := cs.procChannelInfoWithUsers
 	if cs.fastSearch {
-		infoFetcher = cs.channelInfo
+		infoFetcher = cs.procChannelInfo
 	}
 
 	var seen = make(map[string]struct{}, 512)
@@ -112,7 +112,37 @@ func (cs *Stream) channelInfoWorker(ctx context.Context, proc processor.ChannelI
 			}
 
 			if _, err := infoFetcher(ctx, proc, id, ""); err != nil {
+				// if _, err := cs.procChannelInfo(ctx, proc, id, ""); err != nil {
 				srC <- Result{Type: RTChannelInfo, ChannelID: id, Err: fmt.Errorf("channelInfoWorker: %s: %s", id, err)}
+			}
+			seen[id] = struct{}{}
+		}
+	}
+}
+
+func (cs *Stream) channelUsersWorker(ctx context.Context, proc processor.ChannelInformer, srC chan<- Result, channelIdC <-chan string) {
+	ctx, task := trace.NewTask(ctx, "channelUsersWorker")
+	defer task.End()
+
+	var seen = make(map[string]struct{}, 512)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case id, more := <-channelIdC:
+			if !more {
+				return
+			}
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+
+			if _, err := cs.procChannelUsers(ctx, proc, id, ""); err != nil {
+				srC <- Result{Type: RTChannelUsers, ChannelID: id, Err: fmt.Errorf("channelUsersWorker: %s: %s", id, err)}
 			}
 			seen[id] = struct{}{}
 		}

--- a/stream/stream_workers.go
+++ b/stream/stream_workers.go
@@ -89,6 +89,11 @@ func (cs *Stream) channelInfoWorker(ctx context.Context, proc processor.ChannelI
 	ctx, task := trace.NewTask(ctx, "channelInfoWorker")
 	defer task.End()
 
+	infoFetcher := cs.channelInfoWithUsers
+	if cs.fastSearch {
+		infoFetcher = cs.channelInfo
+	}
+
 	var seen = make(map[string]struct{}, 512)
 
 	for {
@@ -105,7 +110,8 @@ func (cs *Stream) channelInfoWorker(ctx context.Context, proc processor.ChannelI
 			if _, ok := seen[id]; ok {
 				continue
 			}
-			if _, err := cs.channelInfo(ctx, proc, id, ""); err != nil {
+
+			if _, err := infoFetcher(ctx, proc, id, ""); err != nil {
 				srC <- Result{Type: RTChannelInfo, ChannelID: id, Err: fmt.Errorf("channelInfoWorker: %s: %s", id, err)}
 			}
 			seen[id] = struct{}{}


### PR DESCRIPTION
- **Adding tests**
- **move session init into bootstrap**
- **sane version reporting**
- **add build and version to the info tool**
- **add tests, optimise fasttime**
- **add provider.go**
- **for the lulz**
- **for the lulz**
- **update benchmark**
- **add m2 pro benchmark**
- **add rpi benchmark**
- **more tests**
- **fix memory leak in file manager**
- **more file manager tests**
- **final filemgr tests, close decompressor**
- **fix count of results not populated for search**
- **add fast search option**
- **fixing chunk file channel id collection**
- **fix edge userinfo method**
- **rename -fast to -no-channel-users**
