### PR TITLE
Fix new workspace creation wizard for enterprise instances + list chan/users fixes

### DIFF
--- a/cmd/slackdump/internal/diag/eztest.go
+++ b/cmd/slackdump/internal/diag/eztest.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/playwright-community/playwright-go"
 
+	"github.com/rusq/slack"
 	"github.com/rusq/slackdump/v3/auth"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
@@ -34,11 +35,12 @@ be printed and the test will be terminated.
 }
 
 type ezResult struct {
-	Engine      string       `json:"engine,omitempty"`
-	HasToken    bool         `json:"has_token,omitempty"`
-	HasCookies  bool         `json:"has_cookies,omitempty"`
-	Err         *string      `json:"error,omitempty"`
-	Credentials *Credentials `json:"credentials,omitempty"`
+	Engine      string                  `json:"engine,omitempty"`
+	HasToken    bool                    `json:"has_token,omitempty"`
+	HasCookies  bool                    `json:"has_cookies,omitempty"`
+	Err         *string                 `json:"error,omitempty"`
+	Credentials *Credentials            `json:"credentials,omitempty"`
+	Response    *slack.AuthTestResponse `json:"response,omitempty"`
 }
 
 type Credentials struct {
@@ -125,6 +127,12 @@ func tryPlaywrightAuth(ctx context.Context, wsp string, populateCreds bool) ezRe
 			Token:   prov.SlackToken(),
 			Cookies: prov.Cookies(),
 		}
+		resp, err := prov.Test(ctx)
+		if err != nil {
+			ret.Err = ptr(err.Error())
+			return ret
+		}
+		ret.Response = resp
 	}
 	return ret
 }
@@ -138,6 +146,7 @@ func tryRodAuth(ctx context.Context, wsp string, populateCreds bool) ezResult {
 		ret.Err = ptr(err.Error())
 		return ret
 	}
+
 	ret.HasCookies = len(prov.Cookies()) > 0
 	ret.HasToken = len(prov.SlackToken()) > 0
 	if populateCreds {
@@ -145,6 +154,12 @@ func tryRodAuth(ctx context.Context, wsp string, populateCreds bool) ezResult {
 			Token:   prov.SlackToken(),
 			Cookies: prov.Cookies(),
 		}
+		resp, err := prov.Test(ctx)
+		if err != nil {
+			ret.Err = ptr(err.Error())
+			return ret
+		}
+		ret.Response = resp
 	}
 	return ret
 }

--- a/cmd/slackdump/internal/list/wizard.go
+++ b/cmd/slackdump/internal/list/wizard.go
@@ -21,17 +21,24 @@ func wizUsers(ctx context.Context, _ *base.Command, _ []string) error {
 		return err
 	}
 
-	filename = makeFilename("users", sess.Info().TeamID, ".json")
+	filename = ""
 	w := dumpui.Wizard{
 		Title:       "List Users",
 		Name:        "List",
 		LocalConfig: userConfiguration,
 		Cmd:         CmdListUsers,
-		ArgsFn: func() []string {
-			return []string{filename}
-		},
+		ArgsFn:      listArgsFn(sess.Info().TeamID, "users"),
 	}
 	return w.Run(ctx)
+}
+
+func listArgsFn(teamID string, prefix string) func() []string {
+	return func() []string {
+		if filename == "" {
+			filename = makeFilename(prefix, teamID, extForType(commonFlags.listType))
+		}
+		return []string{filename}
+	}
 }
 
 func wizChannels(ctx context.Context, _ *base.Command, _ []string) error {
@@ -41,15 +48,13 @@ func wizChannels(ctx context.Context, _ *base.Command, _ []string) error {
 		return err
 	}
 
-	filename = makeFilename("channels", sess.Info().TeamID, ".json")
+	filename = makeFilename("channels", sess.Info().TeamID, extForType(commonFlags.listType))
 	w := dumpui.Wizard{
 		Title:       "List Channels",
 		Name:        "List",
 		LocalConfig: chanFlags.configuration,
 		Cmd:         CmdListChannels,
-		ArgsFn: func() []string {
-			return []string{filename}
-		},
+		ArgsFn:      listArgsFn(sess.Info().TeamID, "channels"),
 	}
 	return w.Run(ctx)
 }
@@ -59,7 +64,7 @@ func userConfiguration() cfgui.Configuration {
 		cfgui.ParamGroup{
 			Name: "User List Options",
 			Params: []cfgui.Parameter{
-				filenameParam("users.json"),
+				filenameParam("users" + extForType(commonFlags.listType)),
 			},
 		},
 	}
@@ -81,7 +86,7 @@ func (o *channelOptions) configuration() cfgui.Configuration {
 		cfgui.ParamGroup{
 			Name: "Channel Options",
 			Params: []cfgui.Parameter{
-				filenameParam("channels.json"),
+				filenameParam("channels" + extForType(commonFlags.listType)),
 				{
 					Name:        "Resolve Users",
 					Value:       cfgui.Checkbox(o.resolveUsers),

--- a/internal/structures/structures.go
+++ b/internal/structures/structures.go
@@ -34,7 +34,7 @@ var ErrInvalidDomain = errors.New("invalid domain")
 
 // ExtractWorkspace takes a workspace name or URL and returns the workspace name.
 func ExtractWorkspace(workspace string) (string, error) {
-	if !strings.Contains(workspace, ".slack.com") && !strings.Contains(workspace, ".") {
+	if !strings.Contains(workspace, ".") {
 		return workspace, nil
 	}
 	if strings.HasPrefix(workspace, "https://") {
@@ -44,13 +44,15 @@ func ExtractWorkspace(workspace string) (string, error) {
 		}
 		workspace = uri.Host
 	}
-	// parse
-	name, domain, found := strings.Cut(workspace, ".")
-	if !found {
-		return "", errors.New("workspace name is empty")
+	if !strings.Contains(workspace, ".slack.com") {
+		return "", ErrInvalidDomain
 	}
-	if strings.TrimRight(domain, "/") != "slack.com" {
-		return "", fmt.Errorf("%s: %w", domain, ErrInvalidDomain)
+
+	parts := strings.Split(workspace, ".")
+	switch len(parts) {
+	case 3, 4:
+		return parts[0], nil
+	default:
+		return "", fmt.Errorf("invalid workspace: %s", workspace)
 	}
-	return name, nil
 }

--- a/internal/structures/structures_test.go
+++ b/internal/structures/structures_test.go
@@ -92,6 +92,7 @@ func TestExtractWorkspace(t *testing.T) {
 		{"url no schema slash", args{"blahblah.slack.com/"}, "blahblah", false},
 		{"url no schema no slash", args{"blahblah.slack.com"}, "blahblah", false},
 		{"not a slack domain", args{"blahblah.example.com"}, "", true},
+		{"enterprise domain", args{"https://acme-co.enterprise.slack.com/"}, "acme-co", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Fix new workspace creation wizard for enterprise instances: failed to correctly parse the workspace name from the API URL.
- list chan/users now generates the correct extension depending on the file type, if the filename is not user-set.
