### PR TITLE
graceful handling of empty message slices

### DIFF
--- a/internal/chunk/dirproc/conversations.go
+++ b/internal/chunk/dirproc/conversations.go
@@ -124,7 +124,7 @@ func (cv *Conversations) ChannelInfo(ctx context.Context, ci *slack.Channel, thr
 	return r.ChannelInfo(ctx, ci, threadTS)
 }
 
-// Messages is called for each message that is retrieved.
+// Messages is called for each message slice that is retrieved.
 func (cv *Conversations) Messages(ctx context.Context, channelID string, numThreads int, isLast bool, mm []slack.Message) error {
 	ctx, task := trace.NewTask(ctx, "Messages")
 	defer task.End()

--- a/internal/chunk/dirproc/conversations_test.go
+++ b/internal/chunk/dirproc/conversations_test.go
@@ -143,6 +143,51 @@ func TestConversations_Messages(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "empty message slice, not last",
+			fields: fields{
+				subproc:     nil,
+				recordFiles: false,
+				tf:          nil,
+			},
+			args: args{
+				ctx:        textCtx,
+				channelID:  "channelID",
+				numThreads: 0,
+				isLast:     false,
+				mm:         []slack.Message{},
+			},
+			expectFn: func(mt *Mocktracker, mh *Mockdatahandler) {
+				mt.EXPECT().Recorder(gomock.Any()).Return(mh, nil)
+				mh.EXPECT().Messages(gomock.Any(), "channelID", 0, false, []slack.Message{}).Return(nil)
+				mh.EXPECT().Add(0).Return(0)
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty message slice, last",
+			fields: fields{
+				subproc:     nil,
+				recordFiles: false,
+				tf:          nil,
+			},
+			args: args{
+				ctx:        textCtx,
+				channelID:  "channelID",
+				numThreads: 0,
+				isLast:     true,
+				mm:         []slack.Message{},
+			},
+			expectFn: func(mt *Mocktracker, mh *Mockdatahandler) {
+				mt.EXPECT().Recorder(gomock.Any()).Return(mh, nil)
+				mh.EXPECT().Messages(gomock.Any(), "channelID", 0, true, []slack.Message{}).Return(nil)
+				mh.EXPECT().Add(0).Return(1)
+				mh.EXPECT().Dec().Return(0)
+				mt.EXPECT().RefCount(chunk.ToFileID("channelID", "", false)).Return(0)
+				mt.EXPECT().Unregister(chunk.ToFileID("channelID", "", false)).Return(nil)
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/stream/conversation_test.go
+++ b/stream/conversation_test.go
@@ -1,0 +1,133 @@
+package stream
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rusq/slack"
+	"github.com/rusq/slackdump/v3/internal/fixtures"
+	"github.com/rusq/slackdump/v3/mocks/mock_processor"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+var TestChannel = &slack.Channel{
+	GroupConversation: slack.GroupConversation{
+		Conversation: slack.Conversation{
+			ID: "C12345678",
+		},
+	},
+}
+
+func Test_procChanMsg(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		// proc    processor.Conversations // supplied by test
+		threadC chan<- request
+		channel *slack.Channel
+		isLast  bool
+		mm      []slack.Message
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expectFn func(mp *mock_processor.MockConversations)
+		want     int
+		wantErr  bool
+	}{
+		{
+			"empty messages slice",
+			args{
+				context.Background(),
+				make(chan request),
+				TestChannel,
+				true,
+				[]slack.Message{},
+			},
+			func(mp *mock_processor.MockConversations) {
+				mp.EXPECT().Messages(gomock.Any(), TestChannel.ID, 0, true, []slack.Message{}).Times(1)
+			},
+			0,
+			false,
+		},
+		{
+			"empty message slice, processor error",
+			args{
+				context.Background(),
+				make(chan request),
+				TestChannel,
+				true,
+				[]slack.Message{},
+			},
+			func(mp *mock_processor.MockConversations) {
+				mp.EXPECT().Messages(gomock.Any(), TestChannel.ID, 0, true, []slack.Message{}).Return(assert.AnError).Times(1)
+			},
+			0,
+			true,
+		},
+		{
+			"non-empty messages slice",
+			args{
+				context.Background(),
+				make(chan request),
+				TestChannel,
+				true,
+				fixtures.Load[[]slack.Message](fixtures.TestChannelEveryoneMessagesNativeExport),
+			},
+			func(mp *mock_processor.MockConversations) {
+				mp.EXPECT().Messages(gomock.Any(), TestChannel.ID, 0, true, fixtures.Load[[]slack.Message](fixtures.TestChannelEveryoneMessagesNativeExport)).Times(1)
+				mp.EXPECT().Files(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
+			0,
+			false,
+		},
+		{
+			"non-empty messages slice,files processor error",
+			args{
+				context.Background(),
+				make(chan request),
+				TestChannel,
+				true,
+				fixtures.Load[[]slack.Message](fixtures.TestChannelEveryoneMessagesNativeExport),
+			},
+			func(mp *mock_processor.MockConversations) {
+				mp.EXPECT().Files(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(assert.AnError)
+			},
+			0,
+			true,
+		},
+		{
+			"non-empty messages slice, messages processor error",
+			args{
+				context.Background(),
+				make(chan request),
+				TestChannel,
+				true,
+				fixtures.Load[[]slack.Message](fixtures.TestChannelEveryoneMessagesNativeExport),
+			},
+			func(mp *mock_processor.MockConversations) {
+				mp.EXPECT().Messages(gomock.Any(), TestChannel.ID, 0, true, fixtures.Load[[]slack.Message](fixtures.TestChannelEveryoneMessagesNativeExport)).Return(assert.AnError).Times(1)
+				mp.EXPECT().Files(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
+			0,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mp := mock_processor.NewMockConversations(ctrl)
+			if tt.expectFn != nil {
+				tt.expectFn(mp)
+			}
+			got, err := procChanMsg(tt.args.ctx, mp, tt.args.threadC, tt.args.channel, tt.args.isLast, tt.args.mm)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("procChanMsg() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("procChanMsg() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #373: empty message slice passed to message processor may have caused a panic if processor returned an error.

