### PR TITLE
Backporting per-channel time-from/time-to (#283)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ CMD=./cmd/slackdump
 OUTPUT=slackdump
 EXECUTABLE=slackdump
 BUILD=$(shell git describe --tags)
-BUILD_DATE=$(shell TZ=UTC date +%Y-%m-%d\ %H:%M:%SZ)
 COMMIT=$(shell git rev-parse --short HEAD)
+ifeq ($(BUILD_DATE),)
+	BUILD_DATE=$(shell TZ=UTC date -u '+%Y-%m-%d %H:%M:%SZ')
+endif
 
 PKG=github.com/rusq/slackdump/v3
 

--- a/auth/browser.go
+++ b/auth/browser.go
@@ -12,15 +12,18 @@ import (
 	"github.com/rusq/slackdump/v3/internal/structures"
 )
 
-var _ Provider = BrowserAuth{}
+var _ Provider = PlaywrightAuth{}
 var defaultFlow = &auth_ui.Huh{}
 
-type BrowserAuth struct {
+// PlaywrightAuth is the playwright browser authentication provider.
+//
+// Deprecated: Use the [RodAuth] provider instead.
+type PlaywrightAuth struct {
 	simpleProvider
 	opts options
 }
 
-type browserOpts struct {
+type playwrightOptions struct {
 	browser      browser.Browser
 	flow         BrowserAuthUI
 	loginTimeout time.Duration
@@ -35,10 +38,10 @@ type BrowserAuthUI interface {
 	Stop()
 }
 
-func NewBrowserAuth(ctx context.Context, opts ...Option) (BrowserAuth, error) {
-	var br = BrowserAuth{
+func NewPlaywrightAuth(ctx context.Context, opts ...Option) (PlaywrightAuth, error) {
+	var br = PlaywrightAuth{
 		opts: options{
-			browserOpts: browserOpts{
+			playwrightOptions: playwrightOptions{
 				flow:         defaultFlow,
 				browser:      browser.Bfirefox,
 				loginTimeout: browser.DefLoginTimeout,
@@ -49,7 +52,7 @@ func NewBrowserAuth(ctx context.Context, opts ...Option) (BrowserAuth, error) {
 		opt(&br.opts)
 	}
 	if IsDocker() {
-		return BrowserAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in docker, use token/cookie auth instead"}
+		return PlaywrightAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in docker, use token/cookie auth instead"}
 	}
 
 	if br.opts.workspace == "" {

--- a/auth/browser/browser.go
+++ b/auth/browser/browser.go
@@ -1,3 +1,6 @@
+// Package browser provides the playwright browser authentication provider.
+//
+// Deprecated: Use the [auth.RodAuth] provider instead.
 package browser
 
 import (

--- a/auth/option.go
+++ b/auth/option.go
@@ -8,7 +8,7 @@ import (
 )
 
 type options struct {
-	browserOpts
+	playwrightOptions
 	rodOpts
 	workspace string
 }
@@ -20,7 +20,7 @@ func BrowserWithAuthFlow(flow BrowserAuthUI) Option {
 		if flow == nil {
 			return
 		}
-		o.browserOpts.flow = flow
+		o.playwrightOptions.flow = flow
 	}
 }
 
@@ -32,7 +32,7 @@ func BrowserWithWorkspace(name string) Option {
 
 func BrowserWithBrowser(b browser.Browser) Option {
 	return func(o *options) {
-		o.browserOpts.browser = b
+		o.playwrightOptions.browser = b
 	}
 }
 
@@ -41,13 +41,13 @@ func BrowserWithTimeout(d time.Duration) Option {
 		if d < 0 {
 			return
 		}
-		o.browserOpts.loginTimeout = d
+		o.playwrightOptions.loginTimeout = d
 	}
 }
 
 func BrowserWithVerbose(b bool) Option {
 	return func(o *options) {
-		o.browserOpts.verbose = b
+		o.playwrightOptions.verbose = b
 	}
 }
 

--- a/cmd/slackdump/internal/diag/eztest.go
+++ b/cmd/slackdump/internal/diag/eztest.go
@@ -114,7 +114,7 @@ func tryPlaywrightAuth(ctx context.Context, wsp string, populateCreds bool) ezRe
 		return ret
 	}
 
-	prov, err := auth.NewBrowserAuth(ctx, auth.BrowserWithWorkspace(wsp))
+	prov, err := auth.NewPlaywrightAuth(ctx, auth.BrowserWithWorkspace(wsp))
 	if err != nil {
 		ret.Err = ptr(err.Error())
 		return ret

--- a/cmd/slackdump/internal/diag/record.go
+++ b/cmd/slackdump/internal/diag/record.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/internal/chunk"
+	"github.com/rusq/slackdump/v3/internal/structures"
 )
 
 var cmdRecord = &base.Command{
@@ -80,7 +81,7 @@ func runRecord(ctx context.Context, _ *base.Command, args []string) error {
 	for _, ch := range args {
 		lg := cfg.Log.With("channel_id", ch)
 		lg.InfoContext(ctx, "streaming")
-		if err := sess.Stream().SyncConversations(ctx, rec, ch); err != nil {
+		if err := sess.Stream().SyncConversations(ctx, rec, structures.EntityItem{Id: ch}); err != nil {
 			if err2 := rec.Close(); err2 != nil {
 				base.SetExitStatus(base.SApplicationError)
 				return fmt.Errorf("error streaming channel %q: %w; error closing recorder: %v", ch, err, err2)

--- a/cmd/slackdump/internal/export/export.go
+++ b/cmd/slackdump/internal/export/export.go
@@ -32,16 +32,12 @@ type exportFlags struct {
 	ExportStorageType fileproc.StorageType
 	MemberOnly        bool
 	ExportToken       string
-	Oldest            time.Time
-	Latest            time.Time
 }
 
 var (
 	compat  bool
 	options = exportFlags{
 		ExportStorageType: fileproc.STmattermost,
-		Oldest:            time.Time(cfg.Oldest),
-		Latest:            time.Time(cfg.Latest),
 	}
 )
 

--- a/cmd/slackdump/internal/export/v2.go
+++ b/cmd/slackdump/internal/export/v2.go
@@ -13,8 +13,8 @@ import (
 
 func exportV2(ctx context.Context, sess *slackdump.Session, fs fsadapter.FS, list *structures.EntityList, flags exportFlags) error {
 	config := export.Config{
-		Oldest:      time.Time(flags.Oldest),
-		Latest:      time.Time(flags.Latest),
+		Oldest:      time.Time(cfg.Oldest),
+		Latest:      time.Time(cfg.Latest),
 		Logger:      cfg.Log,
 		List:        list,
 		Type:        export.ExportType(flags.ExportStorageType),

--- a/cmd/slackdump/internal/export/v3.go
+++ b/cmd/slackdump/internal/export/v3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/rusq/fsadapter"
 	"github.com/rusq/slack"
@@ -66,8 +67,8 @@ func exportV3(ctx context.Context, sess *slackdump.Session, fsa fsadapter.FS, li
 	_ = pb.RenderBlank()
 
 	stream := sess.Stream(
-		stream.OptOldest(params.Oldest),
-		stream.OptLatest(params.Latest),
+		stream.OptOldest(time.Time(cfg.Oldest)),
+		stream.OptLatest(time.Time(cfg.Latest)),
 		stream.OptResultFn(func(sr stream.Result) error {
 			lg.DebugContext(ctx, "conversations", "sr", sr.String())
 			pb.Describe(sr.String())

--- a/cmd/slackdump/internal/workspace/workspaceui/ezlogin3000.go
+++ b/cmd/slackdump/internal/workspace/workspaceui/ezlogin3000.go
@@ -48,7 +48,7 @@ func playwrightLogin(ctx context.Context, mgr manager) error {
 		}
 		return err
 	}
-	prov, err := auth.NewBrowserAuth(ctx, auth.BrowserWithBrowser(brws))
+	prov, err := auth.NewPlaywrightAuth(ctx, auth.BrowserWithBrowser(brws))
 	if err != nil {
 		return err
 	}

--- a/cmd/slackdump/version.go
+++ b/cmd/slackdump/version.go
@@ -14,10 +14,17 @@ var (
 	date    = "unknown"
 )
 
+func truncate(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
 func init() {
 	cfg.Version = cfg.BuildInfo{
 		Version: version,
-		Commit:  commit,
+		Commit:  truncate(commit, 8), // to fit "Homebrew"
 		Date:    date,
 	}
 }

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -409,7 +409,8 @@ func TestExport_exportConversation(t *testing.T) {
 						Return(tt.mocks.rets.closeErr)
 				}
 			}
-			if err := exp.exportConversation(context.Background(), testUserIdx, tt.args.ch); (err != nil) != tt.wantErr {
+			exportItem := &structures.EntityItem{Id: tt.args.ch.ID}
+			if err := exp.exportConversation(context.Background(), testUserIdx, tt.args.ch, exportItem); (err != nil) != tt.wantErr {
 				t.Errorf("Export.exportConversation() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cache/auth.go
+++ b/internal/cache/auth.go
@@ -97,7 +97,7 @@ func (c AuthData) AuthProvider(ctx context.Context, workspace string, opts ...au
 	case ATRod:
 		return auth.NewRODAuth(ctx, opts...)
 	case ATPlaywright:
-		return auth.NewBrowserAuth(ctx, opts...)
+		return auth.NewPlaywrightAuth(ctx, opts...)
 	}
 	return nil, errors.New("internal error: unsupported auth type")
 }

--- a/internal/chunk/control/interfaces.go
+++ b/internal/chunk/control/interfaces.go
@@ -3,6 +3,8 @@ package control
 import (
 	"context"
 
+	"github.com/rusq/slackdump/v3/internal/structures"
+
 	"github.com/rusq/slack"
 	"github.com/rusq/slackdump/v3/internal/chunk/dirproc"
 	"github.com/rusq/slackdump/v3/processor"
@@ -10,7 +12,7 @@ import (
 
 // Streamer is the interface for the API scraper.
 type Streamer interface {
-	Conversations(ctx context.Context, proc processor.Conversations, links <-chan string) error
+	Conversations(ctx context.Context, proc processor.Conversations, links <-chan structures.EntityItem) error
 	ListChannels(ctx context.Context, proc processor.Channels, p *slack.GetConversationsParameters) error
 	Users(ctx context.Context, proc processor.Users, opt ...slack.GetUsersOption) error
 	WorkspaceInfo(ctx context.Context, proc processor.WorkspaceInfo) error

--- a/internal/chunk/control/workers.go
+++ b/internal/chunk/control/workers.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"runtime/trace"
 
+	"github.com/rusq/slackdump/v3/internal/structures"
+
 	"github.com/rusq/slack"
 	"github.com/rusq/slackdump/v3/internal/chunk"
 	"github.com/rusq/slackdump/v3/internal/chunk/dirproc"
@@ -42,7 +44,7 @@ func userWorker(ctx context.Context, s Streamer, chunkdir *chunk.Directory, tf T
 	return nil
 }
 
-func conversationWorker(ctx context.Context, s Streamer, proc processor.Conversations, links <-chan string) error {
+func conversationWorker(ctx context.Context, s Streamer, proc processor.Conversations, links <-chan structures.EntityItem) error {
 	lg := slog.Default()
 	if err := s.Conversations(ctx, proc, links); err != nil {
 		if errors.Is(err, transform.ErrClosed) {

--- a/internal/structures/entity_list.go
+++ b/internal/structures/entity_list.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -17,6 +17,8 @@ const (
 	// for export or when downloading conversations.
 	excludePrefix = "^"
 	filePrefix    = "@"
+	timeSeparator = "|"
+	timeFmt       = "2006-01-02T15:04:05"
 
 	// maxFileEntries is the maximum non-empty entries that will be read from
 	// the file.
@@ -28,11 +30,19 @@ var (
 	ErrEmptyList   = errors.New("empty list")
 )
 
+type EntityItem struct {
+	Id      string
+	Oldest  time.Time
+	Latest  time.Time
+	Include bool
+}
+
 // EntityList is an Inclusion/Exclusion list
 type EntityList struct {
-	Include []string
-	Exclude []string
-	mu      sync.RWMutex
+	index       map[string]*EntityItem
+	mu          sync.RWMutex
+	hasIncludes bool
+	hasExcludes bool
 }
 
 func HasExcludePrefix(s string) bool {
@@ -81,20 +91,20 @@ func SplitEntryList(s string) []string {
 }
 
 // LoadEntityList creates an EntityList from a slice of IDs or URLs (entites).
-func LoadEntityList(filename string) (*EntityList, error) {
+func loadEntityIndex(filename string) (map[string]bool, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	return readEntityList(f, maxFileEntries)
+	return readEntityIndex(f, maxFileEntries)
 }
 
 // readEntityList is a rather naïve implementation that reads the entire file up
 // to maxEntries entities (empty lines are skipped), and populates the slice of
 // strings, which is then passed to NewEntityList.  On large lists it will
 // probably use a silly amount of memory.
-func readEntityList(r io.Reader, maxEntries int) (*EntityList, error) {
+func readEntityIndex(r io.Reader, maxEntries int) (map[string]bool, error) {
 	br := bufio.NewReader(r)
 	var elements []string
 	total := 0
@@ -124,42 +134,49 @@ func readEntityList(r io.Reader, maxEntries int) (*EntityList, error) {
 
 		total++
 	}
-	return NewEntityList(elements)
+	return buildEntryIndex(elements)
+}
+
+func getTimeTuple(item string) []string {
+	if strings.HasPrefix(item, filePrefix) {
+		return []string{item}
+	}
+	return strings.SplitN(item, timeSeparator, 3)
 }
 
 func (el *EntityList) fromIndex(index map[string]bool) {
+	el.index = make(map[string]*EntityItem, len(index))
+
 	el.mu.Lock()
 	defer el.mu.Unlock()
 
 	for ent, include := range index {
+		parts := getTimeTuple(ent)
+
+		item := &EntityItem{
+			Id:      parts[0],
+			Include: include,
+		}
+		if len(parts) > 1 {
+			item.Oldest, _ = time.Parse(timeFmt, parts[1])
+		}
+		if len(parts) == 3 {
+			item.Latest, _ = time.Parse(timeFmt, parts[2])
+		}
+
+		el.index[item.Id] = item
 		if include {
-			el.Include = append(el.Include, ent)
+			el.hasIncludes = true
 		} else {
-			el.Exclude = append(el.Exclude, ent)
+			el.hasExcludes = true
 		}
 	}
-	sort.Strings(el.Include)
-	sort.Strings(el.Exclude)
 }
 
 // Index returns a map where key is entity, and value show if the entity
 // should be processed (true) or not (false).
-func (el *EntityList) Index() EntityIndex {
-	if el == nil {
-		return map[string]bool{}
-	}
-
-	el.mu.RLock()
-	defer el.mu.RUnlock()
-
-	idx := make(map[string]bool, len(el.Include)+len(el.Exclude))
-	for _, v := range el.Include {
-		idx[v] = true
-	}
-	for _, v := range el.Exclude {
-		idx[v] = false
-	}
-	return idx
+func (el *EntityList) Index() map[string]*EntityItem {
+	return el.index
 }
 
 type EntityIndex map[string]bool
@@ -180,17 +197,17 @@ func (ei EntityIndex) IsIncluded(ent string) bool {
 
 // HasIncludes returns true if there's any included entities.
 func (el *EntityList) HasIncludes() bool {
-	return len(el.Include) > 0
+	return el.hasIncludes
 }
 
 // HasExcludes returns true if there's any excluded entities.
 func (el *EntityList) HasExcludes() bool {
-	return len(el.Exclude) > 0
+	return el.hasExcludes
 }
 
 // IsEmpty returns true if there's no entries in the list.
 func (el *EntityList) IsEmpty() bool {
-	return len(el.Include)+len(el.Exclude) == 0
+	return len(el.index) == 0
 }
 
 func buildEntryIndex(links []string) (map[string]bool, error) {
@@ -202,9 +219,10 @@ func buildEntryIndex(links []string) (map[string]bool, error) {
 		if ent == "" {
 			continue
 		}
+		parts := getTimeTuple(ent)
 		switch {
-		case HasExcludePrefix(ent):
-			trimmed := strings.TrimPrefix(ent, excludePrefix)
+		case HasExcludePrefix(parts[0]):
+			trimmed := strings.TrimPrefix(parts[0], excludePrefix)
 			if trimmed == "" {
 				continue
 			}
@@ -212,29 +230,31 @@ func buildEntryIndex(links []string) (map[string]bool, error) {
 			if err != nil {
 				return nil, err
 			}
-			excluded = append(excluded, sl.String())
-		case hasFilePrefix(ent):
-			trimmed := strings.TrimPrefix(ent, filePrefix)
+			parts[0] = sl.String()
+			excluded = append(excluded, strings.Join(parts, timeSeparator))
+		case hasFilePrefix(parts[0]):
+			trimmed := strings.TrimPrefix(parts[0], filePrefix)
 			if trimmed == "" {
 				continue
 			}
 			files = append(files, trimmed)
 		default:
 			// no prefix
-			sl, err := ParseLink(ent)
+			sl, err := ParseLink(parts[0])
 			if err != nil {
 				return nil, err
 			}
-			index[sl.String()] = true
+			parts[0] = sl.String()
+			index[strings.Join(parts, timeSeparator)] = true
 		}
 	}
 	// process files
 	for _, file := range files {
-		el, err := LoadEntityList(file)
+		index2, err := loadEntityIndex(file)
 		if err != nil {
 			return nil, err
 		}
-		for ent, include := range el.Index() {
+		for ent, include := range index2 {
 			if include {
 				index[ent] = true
 			} else {
@@ -253,9 +273,16 @@ func buildEntryIndex(links []string) (map[string]bool, error) {
 // is cancelled.
 func (el *EntityList) C(ctx context.Context) <-chan string {
 	ch := make(chan string)
+	var include []string
+	for ent, item := range el.index {
+		if item.Include {
+			include = append(include, ent)
+		}
+	}
+
 	go func() {
 		defer close(ch)
-		for _, ent := range el.Include {
+		for _, ent := range include {
 			select {
 			case <-ctx.Done():
 				return

--- a/internal/structures/entity_list_test.go
+++ b/internal/structures/entity_list_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rusq/slackdump/v3/internal/fixtures"
 )
@@ -57,7 +58,22 @@ func TestMakeEntityList(t *testing.T) {
 			"only includes",
 			args{[]string{"one", "two", "three"}},
 			&EntityList{
-				Include: []string{"one", "three", "two"},
+				index: map[string]*EntityItem{
+					"one": {
+						Id:      "one",
+						Include: true,
+					},
+					"three": {
+						Id:      "three",
+						Include: true,
+					},
+					"two": {
+						Id:      "two",
+						Include: true,
+					},
+				},
+				hasIncludes: true,
+				hasExcludes: false,
 			},
 			false,
 		},
@@ -65,7 +81,22 @@ func TestMakeEntityList(t *testing.T) {
 			"only excludes",
 			args{[]string{"^one", "^two", "^three"}},
 			&EntityList{
-				Exclude: []string{"one", "three", "two"},
+				index: map[string]*EntityItem{
+					"one": {
+						Id:      "one",
+						Include: false,
+					},
+					"three": {
+						Id:      "three",
+						Include: false,
+					},
+					"two": {
+						Id:      "two",
+						Include: false,
+					},
+				},
+				hasIncludes: false,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -73,8 +104,23 @@ func TestMakeEntityList(t *testing.T) {
 			"mixed",
 			args{[]string{"one", "^two", "three"}},
 			&EntityList{
-				Include: []string{"one", "three"},
-				Exclude: []string{"two"},
+				index: map[string]*EntityItem{
+
+					"one": {
+						Id:      "one",
+						Include: true,
+					},
+					"three": {
+						Id:      "three",
+						Include: true,
+					},
+					"two": {
+						Id:      "two",
+						Include: false,
+					},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -82,8 +128,22 @@ func TestMakeEntityList(t *testing.T) {
 			"same element included and excluded",
 			args{[]string{"one", "^two", "three", "two"}},
 			&EntityList{
-				Include: []string{"one", "three"},
-				Exclude: []string{"two"},
+				index: map[string]*EntityItem{
+					"one": {
+						Id:      "one",
+						Include: true,
+					},
+					"three": {
+						Id:      "three",
+						Include: true,
+					},
+					"two": {
+						Id:      "two",
+						Include: false,
+					},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -91,8 +151,22 @@ func TestMakeEntityList(t *testing.T) {
 			"duplicate element",
 			args{[]string{"one", "^two", "three", "one"}},
 			&EntityList{
-				Include: []string{"one", "three"},
-				Exclude: []string{"two"},
+				index: map[string]*EntityItem{
+					"one": {
+						Id:      "one",
+						Include: true,
+					},
+					"three": {
+						Id:      "three",
+						Include: true,
+					},
+					"two": {
+						Id:      "two",
+						Include: false,
+					},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -100,21 +174,97 @@ func TestMakeEntityList(t *testing.T) {
 			"empty element",
 			args{[]string{"one", "^two", "three", "", "four", "^"}},
 			&EntityList{
-				Include: []string{"four", "one", "three"},
-				Exclude: []string{"two"},
+				index: map[string]*EntityItem{
+
+					"four": {
+						Id:      "four",
+						Include: true,
+					},
+					"one": {
+						Id:      "one",
+						Include: true,
+					},
+					"three": {
+						Id:      "three",
+						Include: true,
+					},
+					"two": {
+						Id:      "two",
+						Include: false,
+					},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},
 		{
 			"everything is empty",
 			args{[]string{}},
-			&EntityList{},
+			&EntityList{
+				index: map[string]*EntityItem{},
+			},
 			false,
 		},
 		{
 			"nil",
 			args{nil},
-			&EntityList{},
+			&EntityList{
+				index: map[string]*EntityItem{},
+			},
+			false,
+		},
+		{
+			"with date limits",
+			args{[]string{"one||", "^two||", "three|bad|2024-01-10T23:02:12", "four|2023-12-10T23:02:12|2024-01-10T23:02:12", "^five|2023-12-10T23:02:12|2024-01-10T23:02:12", "six|2023-12-10T23:02:12|2024-01-10T23:02:12||", "seven|2024-04-07T23:02:12"}},
+			&EntityList{
+				index: map[string]*EntityItem{
+					"one": {
+						Id:      "one",
+						Include: true,
+						Oldest:  time.Time{},
+						Latest:  time.Time{},
+					},
+					"two": {
+						Id:      "two",
+						Include: false,
+						Oldest:  time.Time{},
+						Latest:  time.Time{},
+					},
+					"three": {
+						Id:      "three",
+						Include: true,
+						Oldest:  time.Time{},
+						Latest:  time.Date(2024, time.January, 10, 23, 2, 12, 0, time.UTC),
+					},
+					"four": {
+						Id:      "four",
+						Include: true,
+						Oldest:  time.Date(2023, time.December, 10, 23, 2, 12, 0, time.UTC),
+						Latest:  time.Date(2024, time.January, 10, 23, 2, 12, 0, time.UTC),
+					},
+					"five": {
+						Id:      "five",
+						Include: false,
+						Oldest:  time.Date(2023, time.December, 10, 23, 2, 12, 0, time.UTC),
+						Latest:  time.Date(2024, time.January, 10, 23, 2, 12, 0, time.UTC),
+					},
+					"six": {
+						Id:      "six",
+						Include: true,
+						Oldest:  time.Date(2023, time.December, 10, 23, 2, 12, 0, time.UTC),
+						Latest:  time.Time{},
+					},
+					"seven": {
+						Id:      "seven",
+						Include: true,
+						Oldest:  time.Date(2024, time.April, 7, 23, 2, 12, 0, time.UTC),
+						Latest:  time.Time{},
+					},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
+			},
 			false,
 		},
 	}
@@ -132,7 +282,7 @@ func TestMakeEntityList(t *testing.T) {
 	}
 }
 
-func Test_readEntityList(t *testing.T) {
+func Test_readEntityIndex(t *testing.T) {
 	type args struct {
 		r          io.Reader
 		maxEntries int
@@ -140,55 +290,65 @@ func Test_readEntityList(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *EntityList
+		want    map[string]bool
 		wantErr bool
 	}{
 		{
 			"two lines one comment, no CR",
 			args{strings.NewReader("C555\n C123\n#C555\n^C321\n\t^C333"), maxFileEntries},
-			&EntityList{
-				Include: []string{"C123", "C555"},
-				Exclude: []string{"C321", "C333"},
+			map[string]bool{
+				"C123": true,
+				"C555": true,
+				"C321": false,
+				"C333": false,
 			},
 			false,
 		},
 		{
 			"two lines one comment",
 			args{strings.NewReader("C123\n#C555\n^C321\n"), maxFileEntries},
-			&EntityList{
-				Include: []string{"C123"},
-				Exclude: []string{"C321"},
+			map[string]bool{
+				"C123": true,
+				"C321": false,
 			},
 			false,
 		},
 		{
 			"last line comment",
 			args{strings.NewReader("C123\n #C555\n#C321\n"), maxFileEntries},
-			&EntityList{Include: []string{"C123"}},
+			map[string]bool{
+				"C123": true,
+			},
 			false,
 		},
 		{
 			"oneliner",
 			args{strings.NewReader("C321"), maxFileEntries},
-			&EntityList{Include: []string{"C321"}},
+			map[string]bool{
+				"C321": true,
+			},
 			false,
 		},
 		{
 			"oneliner url",
 			args{strings.NewReader("https://fake.slack.com/archives/CHM82GF99/p1577694990000400"), maxFileEntries},
-			&EntityList{Include: []string{"CHM82GF99" + LinkSep + "1577694990.000400"}},
+			map[string]bool{
+				"CHM82GF99" + LinkSep + "1577694990.000400": true,
+			},
 			false,
 		},
 		{
 			"excluded oneliner url",
 			args{strings.NewReader("^https://fake.slack.com/archives/CHM82GF99/p1577694990000400"), maxFileEntries},
-			&EntityList{Exclude: []string{"CHM82GF99" + LinkSep + "1577694990.000400"}},
+			map[string]bool{
+				"CHM82GF99" + LinkSep + "1577694990.000400": false,
+			},
 			false,
 		},
 		{
 			"empty file",
 			args{strings.NewReader(""), maxFileEntries},
-			&EntityList{},
+			map[string]bool{},
 			false,
 		},
 		{
@@ -206,34 +366,27 @@ func Test_readEntityList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := readEntityList(tt.args.r, tt.args.maxEntries)
+			got, err := readEntityIndex(tt.args.r, tt.args.maxEntries)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("readEntityList() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("readEntityIndex() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("readEntityList() = %v, want %v", got, tt.want)
+				t.Errorf("readEntityIndex() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
 func TestEntityList_Index(t *testing.T) {
-	type fields struct {
-		Include []string
-		Exclude []string
-	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   EntityIndex
+		name string
+		args []string
+		want EntityIndex
 	}{
 		{
 			"simple",
-			fields{
-				Include: []string{"C123", "C234"},
-				Exclude: []string{"C456", "C567"},
-			},
+			[]string{"C123", "C234", "^C456", "^C567"},
 			EntityIndex{
 				"C123": true,
 				"C234": true,
@@ -243,10 +396,7 @@ func TestEntityList_Index(t *testing.T) {
 		},
 		{
 			"intersecting",
-			fields{
-				Include: []string{"C123", "C234"},
-				Exclude: []string{"C234", "C567"},
-			},
+			[]string{"C123", "C234", "^C234", "^C567"},
 			EntityIndex{
 				"C123": true,
 				"C234": false,
@@ -255,143 +405,132 @@ func TestEntityList_Index(t *testing.T) {
 		},
 		{
 			"nil",
-			fields{},
+			nil,
 			EntityIndex{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el := &EntityList{
-				Include: tt.fields.Include,
-				Exclude: tt.fields.Exclude,
-			}
-			if got := el.Index(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("EntityList.Index() = %v, want %v", got, tt.want)
+			if el, err := NewEntityList(tt.args); err == nil {
+				index := el.Index()
+				for k, include := range tt.want {
+					if item, ok := index[k]; !ok || item.Include != include {
+						t.Errorf("EntityList.Index()[%v] = %v", k, include)
+					}
+				}
+			} else {
+				t.Errorf("EntityList.Index() = %v; error: %v", tt.want, err)
 			}
 		})
 	}
 }
 
 func TestEntityList_HasIncludes(t *testing.T) {
-	type fields struct {
-		Include []string
-		Exclude []string
-	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   bool
+		name string
+		args []string
+		want bool
 	}{
 		{
 			"yes",
-			fields{Include: []string{"1"}},
+			[]string{"A1"},
 			true,
 		},
 		{
 			"no",
-			fields{Include: []string{}},
+			[]string{},
 			false,
 		},
 		{
 			"no",
-			fields{Exclude: []string{"2"}},
+			[]string{"^A2"},
 			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el := &EntityList{
-				Include: tt.fields.Include,
-				Exclude: tt.fields.Exclude,
-			}
-			if got := el.HasIncludes(); got != tt.want {
-				t.Errorf("EntityList.HasIncludes() = %v, want %v", got, tt.want)
+			if el, err := NewEntityList(tt.args); err == nil {
+				if got := el.HasIncludes(); got != tt.want {
+					t.Errorf("EntityList.HasIncludes() = %v, want %v", got, tt.want)
+				}
+			} else {
+				t.Errorf("EntityList.HasIncludes() = %v; error: %v", tt.want, err)
 			}
 		})
 	}
 }
 
 func TestEntityList_HasExcludes(t *testing.T) {
-	type fields struct {
-		Include []string
-		Exclude []string
-	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   bool
+		name string
+		args []string
+		want bool
 	}{
 		{
 			"yes",
-			fields{Exclude: []string{"1"}},
+			[]string{"^A1"},
 			true,
 		},
 		{
 			"no",
-			fields{Exclude: []string{}},
+			[]string{},
 			false,
 		},
 		{
 			"no",
-			fields{Include: []string{"2"}},
+			[]string{"A2"},
 			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el := &EntityList{
-				Include: tt.fields.Include,
-				Exclude: tt.fields.Exclude,
-			}
-			if got := el.HasExcludes(); got != tt.want {
-				t.Errorf("EntityList.HasExcludes() = %v, want %v", got, tt.want)
+			if el, err := NewEntityList(tt.args); err == nil {
+				if got := el.HasExcludes(); got != tt.want {
+					t.Errorf("EntityList.HasExcludes() = %v, want %v", got, tt.want)
+				}
+			} else {
+				t.Errorf("EntityList.HasExcludes() = %v; error: %v", tt.want, err)
 			}
 		})
 	}
 }
 
 func TestEntityList_IsEmpty(t *testing.T) {
-	type fields struct {
-		Include []string
-		Exclude []string
-	}
+
 	tests := []struct {
-		name   string
-		fields fields
-		want   bool
+		name string
+		args []string
+		want bool
 	}{
 		{
 			"empty",
-			fields{},
+			[]string{},
 			true,
 		},
 		{
 			"not empty",
-			fields{Include: []string{"1"}},
+			[]string{"A1"},
 			false,
 		},
 		{
 			"not empty",
-			fields{Exclude: []string{"1"}},
+			[]string{"^A1"},
 			false,
 		},
 		{
 			"not empty",
-			fields{
-				Include: []string{"1"},
-				Exclude: []string{"2"},
-			},
+			[]string{"A1", "^A2"},
 			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el := &EntityList{
-				Include: tt.fields.Include,
-				Exclude: tt.fields.Exclude,
-			}
-			if got := el.IsEmpty(); got != tt.want {
-				t.Errorf("EntityList.IsEmpty() = %v, want %v", got, tt.want)
+			if el, err := NewEntityList(tt.args); err == nil {
+				if got := el.IsEmpty(); got != tt.want {
+					t.Errorf("EntityList.IsEmpty() = %v, want %v", got, tt.want)
+				}
+			} else {
+				t.Errorf("EntityList.IsEmpty() = %v; error: %v", tt.want, err)
 			}
 		})
 	}
@@ -449,6 +588,26 @@ func Test_buildEntityIndex(t *testing.T) {
 				"ANOTHER0INLINE0INCLUDE": true,
 				"SECOND0FILE0INCLUDE":    true,
 				"SECOND0FILE0EXCLUDE":    false,
+			},
+			false,
+		},
+		{
+			"with dates",
+			args{[]string{
+				"one||",
+				"^two||",
+				"three|bad|2024-01-10T23:02:12",
+				"four|2023-12-10T23:02:12|2024-01-10T23:02:12",
+				"^five|2023-12-10T23:02:12|2024-01-10T23:02:12",
+				"six|2023-12-10T23:02:12|2024-01-10T23:02:12||",
+			}},
+			map[string]bool{
+				"one||":                         true,
+				"two||":                         false,
+				"three|bad|2024-01-10T23:02:12": true,
+				"four|2023-12-10T23:02:12|2024-01-10T23:02:12":  true,
+				"five|2023-12-10T23:02:12|2024-01-10T23:02:12":  false,
+				"six|2023-12-10T23:02:12|2024-01-10T23:02:12||": true,
 			},
 			false,
 		},
@@ -510,8 +669,14 @@ func TestNewEntityListFromString(t *testing.T) {
 			"ok",
 			args{"C123 C234 ^C345 C456"},
 			&EntityList{
-				Include: []string{"C123", "C234", "C456"},
-				Exclude: []string{"C345"},
+				index: map[string]*EntityItem{
+					"C123": {Id: "C123", Include: true},
+					"C234": {Id: "C234", Include: true},
+					"C345": {Id: "C345", Include: false},
+					"C456": {Id: "C456", Include: true},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -525,7 +690,13 @@ func TestNewEntityListFromString(t *testing.T) {
 			"only includes",
 			args{"one two three"},
 			&EntityList{
-				Include: []string{"one", "three", "two"},
+				index: map[string]*EntityItem{
+					"one":   {Id: "one", Include: true},
+					"three": {Id: "three", Include: true},
+					"two":   {Id: "two", Include: true},
+				},
+				hasIncludes: true,
+				hasExcludes: false,
 			},
 			false,
 		},
@@ -533,7 +704,13 @@ func TestNewEntityListFromString(t *testing.T) {
 			"only excludes",
 			args{"^one ^two ^three"},
 			&EntityList{
-				Exclude: []string{"one", "three", "two"},
+				index: map[string]*EntityItem{
+					"one":   {Id: "one", Include: false},
+					"two":   {Id: "two", Include: false},
+					"three": {Id: "three", Include: false},
+				},
+				hasIncludes: false,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -541,8 +718,13 @@ func TestNewEntityListFromString(t *testing.T) {
 			"mixed",
 			args{"one ^two three"},
 			&EntityList{
-				Include: []string{"one", "three"},
-				Exclude: []string{"two"},
+				index: map[string]*EntityItem{
+					"one":   {Id: "one", Include: true},
+					"two":   {Id: "two", Include: false},
+					"three": {Id: "three", Include: true},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -550,8 +732,13 @@ func TestNewEntityListFromString(t *testing.T) {
 			"same element included and excluded",
 			args{"one ^two three two"},
 			&EntityList{
-				Include: []string{"one", "three"},
-				Exclude: []string{"two"},
+				index: map[string]*EntityItem{
+					"one":   {Id: "one", Include: true},
+					"two":   {Id: "two", Include: false},
+					"three": {Id: "three", Include: true},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -559,8 +746,13 @@ func TestNewEntityListFromString(t *testing.T) {
 			"duplicate element",
 			args{"one ^two three one"},
 			&EntityList{
-				Include: []string{"one", "three"},
-				Exclude: []string{"two"},
+				index: map[string]*EntityItem{
+					"one":   {Id: "one", Include: true},
+					"two":   {Id: "two", Include: false},
+					"three": {Id: "three", Include: true},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},
@@ -568,8 +760,14 @@ func TestNewEntityListFromString(t *testing.T) {
 			"empty element",
 			args{"one ^two three  four ^"},
 			&EntityList{
-				Include: []string{"four", "one", "three"},
-				Exclude: []string{"two"},
+				index: map[string]*EntityItem{
+					"one":   {Id: "one", Include: true},
+					"two":   {Id: "two", Include: false},
+					"three": {Id: "three", Include: true},
+					"four":  {Id: "four", Include: true},
+				},
+				hasIncludes: true,
+				hasExcludes: true,
 			},
 			false,
 		},

--- a/internal/structures/structures.go
+++ b/internal/structures/structures.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 )
 
 const (
@@ -55,4 +56,12 @@ func ExtractWorkspace(workspace string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid workspace: %s", workspace)
 	}
+}
+
+// NVLTime returns the default time if the given time is zero.
+func NVLTime(t time.Time, def time.Time) time.Time {
+	if t.IsZero() {
+		return def
+	}
+	return t
 }

--- a/internal/structures/structures_test.go
+++ b/internal/structures/structures_test.go
@@ -2,7 +2,9 @@
 package structures
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/rusq/slackdump/v3/internal/fixtures"
 )
@@ -103,6 +105,42 @@ func TestExtractWorkspace(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("ExtractWorkspace() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNVLTime(t *testing.T) {
+	type args struct {
+		t   time.Time
+		def time.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Time
+	}{
+		{
+			"t is zero",
+			args{
+				time.Time{},
+				time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			"t is not zero",
+			args{
+				time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NVLTime(tt.args.t, tt.args.def); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("nvlTime() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/slackdump_test.go
+++ b/slackdump_test.go
@@ -115,7 +115,7 @@ func ExampleNew_cookieFile() {
 }
 
 func ExampleNew_browserAuth() {
-	provider, err := auth.NewBrowserAuth(context.Background())
+	provider, err := auth.NewPlaywrightAuth(context.Background())
 	if err != nil {
 		log.Print(err)
 		return

--- a/stream/stream_workers.go
+++ b/stream/stream_workers.go
@@ -27,7 +27,7 @@ func (cs *Stream) channelWorker(ctx context.Context, proc processor.Conversation
 				results <- Result{Type: RTChannel, ChannelID: req.sl.Channel, Err: err}
 				continue
 			}
-			if err := cs.channel(ctx, req.sl.Channel, func(mm []slack.Message, isLast bool) error {
+			if err := cs.channel(ctx, req, func(mm []slack.Message, isLast bool) error {
 				n, err := procChanMsg(ctx, proc, threadC, channel, isLast, mm)
 				if err != nil {
 					return err
@@ -71,7 +71,7 @@ func (cs *Stream) threadWorker(ctx context.Context, proc processor.Conversations
 				// hackety hack
 				channel.ID = req.sl.Channel
 			}
-			if err := cs.thread(ctx, req.sl, func(msgs []slack.Message, isLast bool) error {
+			if err := cs.thread(ctx, req, func(msgs []slack.Message, isLast bool) error {
 				if err := procThreadMsg(ctx, proc, channel, req.sl.ThreadTS, req.threadOnly, isLast, msgs); err != nil {
 					return err
 				}


### PR DESCRIPTION
- **allow to specify BUILD_DATE**
- **rename BrowserAuth to PlaywrightAuth**
- **entity list ported + tests**
- **implement #283 in stream**

Fixes #372, also fixes #368.