### PR TITLE
Documentation and viewer fix on Windows

### DIFF
--- a/cmd/slackdump/internal/archive/assets/archive.md
+++ b/cmd/slackdump/internal/archive/assets/archive.md
@@ -1,33 +1,43 @@
-# Archive Command
+# Command: archive
 
-The archive command archives the Slack workspace into a directory of files.
-By default, it will perform the archiving of the full workspace that is accessible
-to your user.
+The `archive` command saves your Slack workspace as a directory of files. By
+default, it archives the entire workspace that your user can access. You can
+customize the archive to include specific channels, groups, or direct messages
+by providing their URLs or IDs.
 
-Optionally, one can select channels, groups and DMs to archive.  For this, one
-needs to specify the URLs or IDs of the channels.
+## Features
 
-The workspace is archived in the "Chunk" format, that can be viewed with the
-`view` command, or converted to other supported formats, such as native Slack
-Export format.
+### Default Behavior
+- Archives the full workspace accessible to your user.
 
-## What is contained in the archive?
+### Optional Customization
+- Specify channels, groups, or DMs to archive by providing their URLs or IDs.
 
-"Archive" behaves similarly to the Slackdump export feature, the output of a
-successful run contains the following:
-- channels.json.gz - list of channels in the workspace (full archives only);
-- users.json.gz - list of users in the workspace;
-- CXXXXXXX.json.gz - channel or group conversation messages, where XXXXXXX is
-  the channel ID;
-- DXXXXXXX.json.gz - direct messages, where XXXXXXX is the user ID;
+### Output Format
+- The archive uses the **"Chunk" format**, which can be:
+  - Viewed using the `view` command.
+  - Converted to other formats, including the native Slack Export format.
 
-Output format:
+## Archive Contents
 
-- Each file is a JSONL file compressed with GZIP.
+The archive behaves like the Slackdump export feature. A successful run
+output includes:
 
-Please note that "archive" can not create ZIP files, but you can zip the output
-directory manually.
+- **`channels.json.gz`**: A list of channels in the workspace (only for full
+  archives).
+- **`users.json.gz`**: A list of users in the workspace.
+- **`CXXXXXXX.json.gz`**: Messages from a channel or group, where `XXXXXXX` is
+  the channel ID.
+- **`DXXXXXXX.json.gz`**: Direct messages, where `XXXXXXX` is the user ID.
 
-## What is chunk file format?
+### File Format
+- Files are saved as **JSONL** (newline-delimited JSON) and compressed with
+  **GZIP**.
+- Note: The `archive` command does not create ZIP files, but you can manually
+  compress the output directory into a ZIP file if needed.
 
-Run `slackdump help chunk` for the format specification.
+## What is the Chunk Format?
+
+The Chunk format is a specific structure used for archiving data. For details
+on this format, run:  `slackdump help chunk`
+

--- a/cmd/slackdump/internal/archive/assets/search.md
+++ b/cmd/slackdump/internal/archive/assets/search.md
@@ -1,0 +1,56 @@
+# Command: search
+
+The `search` command allows you to search and export messages or files from a
+Slack workspace based on specified query terms. This command supports searching
+for messages, files, or both, and outputs the results in a directory.
+
+### Subcommands
+- **`slackdump search messages`**: Searches and records messages matching the
+  given query.
+- **`slackdump search files`**: Searches and records files matching the given
+  query.
+- **`slackdump search all`**: Searches and records both messages and files
+  matching the query.
+
+### Flags
+- **`--no-channel-users`**: Skips retrieving user data for channels, making the
+  process approximately 2.5x faster.
+
+### Requirements
+- Authentication is required for all search operations.
+- An output directory must be specified (see configuration details).
+
+## Usage Examples
+
+### Search Messages
+
+```bash
+slackdump search messages "meeting notes"
+```
+
+### Search Files
+
+```bash
+slackdump search files "report"
+```
+
+### Search Messages and Files
+
+```bash
+slackdump search all "project updates"
+```
+
+### Faster Searches
+To speed up searches, add the `--no-channel-users` flag:
+
+```bash
+slackdump search messages -no-channel-users "status update"
+```
+
+
+## Output Directory
+The search command outputs results to the specified directory. The directory
+contains:
+
+- **`search.jsonl.gz`**: A list of messages matching the query.
+- directory with saved files (if files are included in the search).

--- a/cmd/slackdump/internal/archive/search.go
+++ b/cmd/slackdump/internal/archive/search.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"log/slog"
 	"strings"
@@ -22,7 +23,7 @@ import (
 var CmdSearch = &base.Command{
 	UsageLine:   "slackdump search",
 	Short:       "dump search results",
-	Long:        `Searches for messages matching criteria.`,
+	Long:        searchMD,
 	Wizard:      wizSearch,
 	RequireAuth: true,
 	Commands: []*base.Command{
@@ -31,6 +32,9 @@ var CmdSearch = &base.Command{
 		cmdSearchAll,
 	},
 }
+
+//go:embed assets/search.md
+var searchMD string
 
 const flagMask = cfg.OmitUserCacheFlag | cfg.OmitCacheDir | cfg.OmitTimeframeFlag | cfg.OmitMemberOnlyFlag
 

--- a/cmd/slackdump/internal/diag/edge.go
+++ b/cmd/slackdump/internal/diag/edge.go
@@ -22,6 +22,8 @@ var cmdEdge = &base.Command{
 # Slack Edge API test tool
 
 Edge test attempts to call the Edge API with the provided credentials.
+
+Not particularly useful for end users, but can be used to test the Edge API.
 `,
 }
 
@@ -62,7 +64,7 @@ func runEdge(ctx context.Context, cmd *base.Command, args []string) error {
 	lg.Info("*** AdminEmojiList test ***")
 	var allEmoji edge.EmojiResult
 
-	var iter = 0
+	iter := 0
 	for res, err := range cl.AdminEmojiList(ctx) {
 		if err != nil {
 			return err

--- a/cmd/slackdump/internal/diag/uninstall.go
+++ b/cmd/slackdump/internal/diag/uninstall.go
@@ -157,8 +157,8 @@ func uninstallPlaywright(ctx context.Context, si info.PwInfo, dry bool) error {
 	if err := removeFn(si.Path); err != nil {
 		return fmt.Errorf("failed to remove the playwright library: %w", err)
 	}
-	lg.InfoContext(ctx, "Deleting browsers", "browsers_path", si.BrowsersPath)
 
+	lg.InfoContext(ctx, "Deleting browsers", "browsers_path", si.BrowsersPath)
 	if err := removeFn(si.BrowsersPath); err != nil {
 		return fmt.Errorf("failed to remove the playwright browsers: %w", err)
 	}
@@ -219,12 +219,23 @@ func (p *uninstOptions) configuration() cfgui.Configuration {
 					Updater:     updaters.NewBool(&p.playwright),
 				},
 				{
+					Name:        "Rod Browser",
+					Value:       cfgui.Checkbox(p.rod),
+					Description: "Browser to uninstall (if unselected, uninstalls Playwright)",
+					Updater:     updaters.NewBool(&p.rod),
+				},
+				{
+					Name:        "User cache",
+					Value:       cfgui.Checkbox(p.cache),
+					Description: "Remove all saved workspaces and user/channel cache",
+					Updater:     updaters.NewBool(&p.cache),
+				},
+				{
 					Name:        "Dry run",
 					Value:       cfgui.Checkbox(p.dry),
 					Description: "Do not perform the uninstallation, just show what would be done",
 					Updater:     updaters.NewBool(&p.dry),
 				},
-				// TODO: add an option to delete slackdump from user cache options.
 			},
 		},
 	}

--- a/cmd/slackdump/internal/diag/wizdebug.go
+++ b/cmd/slackdump/internal/diag/wizdebug.go
@@ -5,6 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
+
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/bubbles/menu"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/cfgui"
@@ -15,6 +16,7 @@ var cmdWizDebug = &base.Command{
 	Short:      "run the wizard debug command",
 	Run:        runWizDebug,
 	PrintFlags: true,
+	HideWizard: true,
 }
 
 type wdWhat int

--- a/cmd/slackdump/internal/emoji/assets/emoji.md
+++ b/cmd/slackdump/internal/emoji/assets/emoji.md
@@ -1,13 +1,13 @@
-# Emoji Command
-This command allows you to download all the custom emojis from the Slack
-workspace.
+# Command: emoji ฅ(^•ﻌ•^ฅ)
+This command allows you to download all emoticons from the Slack Workspace.
 
 There are two modes of operation:
-- **Standard**: download only the names and URLs of the custom emojis;
-- **Full**: Download all the custom emojis from the workspace.
+- **Standard**: download only the names and URLs of the workspace emojis;
+- **Full**: downloads all the information about the custom emojis from the
+  workspace.
 
-Full mode is approx. 2.3 times slower than the standard mode, but it provides
-more information about the custom emojis.
+Full mode is approximately 2.3 times slower than the standard mode, but it
+provides more information about the custom emojis.
 
 In both modes:
 - aliases are skipped, as they just point to the main emoji;

--- a/cmd/slackdump/internal/emoji/emoji.go
+++ b/cmd/slackdump/internal/emoji/emoji.go
@@ -27,8 +27,8 @@ var emojiMD string
 var CmdEmoji = &base.Command{
 	Run:         run,
 	UsageLine:   "slackdump emoji [flags]",
-	Short:       "download custom workspace emojis",
-	Long:        emojiMD, // TODO: add long description
+	Short:       "download workspace emoticons ಠ_ಠ",
+	Long:        emojiMD,
 	FlagMask:    cfg.OmitDownloadFlag | cfg.OmitConfigFlag | cfg.OmitChunkCacheFlag | cfg.OmitUserCacheFlag,
 	RequireAuth: true,
 	PrintFlags:  true,
@@ -94,7 +94,6 @@ func statusReporter() (emojidl.StatusFunc, io.Closer) {
 		})
 		pb.Add(1)
 	}, pb
-
 }
 
 func runLegacy(ctx context.Context, fsa fsadapter.FS, cb emojidl.StatusFunc) error {

--- a/cmd/slackdump/internal/export/assets/export.md
+++ b/cmd/slackdump/internal/export/assets/export.md
@@ -5,7 +5,8 @@ By default, it exports the entire workspace that your user can access.
 You can customize the archive to include specific channels, groups, or
 direct messages by providing their URLs or IDs.
 
-The ZIP file it generates is compatible with the Slack Export format with Slackdump specific extensions.
+The ZIP file it generates is compatible with the Slack Export format with
+Slackdump specific extensions.
 
 The export file is understood by Slack Import feature with the following
 caveat:
@@ -21,7 +22,7 @@ caveat:
 /
 ├── __uploads              : all uploaded files are placed in this dir.
 │   └── F02PM6A1AUA        : slack file ID is used as a directory name
-|       └── Chevy.jpg      : file attachment
+│       └── Chevy.jpg      : file attachment
 ├── everyone               : channel "#everyone"
 │   ├── 2022-01-01.json    :   all messages for the 1 Jan 2022.
 │   └── 2022-01-04.json    :    "     "      "   "  4 Jan 2022.
@@ -36,11 +37,13 @@ caveat:
 ### Channels
 The channels are be saved in directories, named after the channel title,
 i.e. `#random` would be saved to "random" directory. The directory will
-contain a set of JSON files, one per each day.
+contain a set of JSON files, one per each day.  If there were no
+conversations on some particular day, there will be no JSON file for that
+day.
 
 ### Users
-User directories will have an "D" prefix, to find out the user name,
-check `users.json` file.
+User directories will have a "D" prefix, to find out the user name, check
+`users.json` file.
 
 ### Group Messages
 Group messages will have all involved user handles in their name.

--- a/cmd/slackdump/internal/export/assets/export.md
+++ b/cmd/slackdump/internal/export/assets/export.md
@@ -1,0 +1,58 @@
+# Command: export
+
+The `export` command saves your Slack workspace as a directory of files.
+By default, it exports the entire workspace that your user can access.
+You can customize the archive to include specific channels, groups, or
+direct messages by providing their URLs or IDs.
+
+The ZIP file it generates is compatible with the Slack Export format with Slackdump specific extensions.
+
+The export file is understood by Slack Import feature with the following
+caveat:
+- files will not be imported, unless the `export` token is specified.
+  Github user @codeallthethingz has created a script that allows you to
+  import attachments from the export file.  You can find it
+  [here](https://github.com/rusq/slackdump/issues/371)
+
+
+## Export file structure
+
+```plaintext
+/
+├── __uploads              : all uploaded files are placed in this dir.
+│   └── F02PM6A1AUA        : slack file ID is used as a directory name
+|       └── Chevy.jpg      : file attachment
+├── everyone               : channel "#everyone"
+│   ├── 2022-01-01.json    :   all messages for the 1 Jan 2022.
+│   └── 2022-01-04.json    :    "     "      "   "  4 Jan 2022.
+├── DM12345678             : Your DMs with Scumbag Steve^
+│   └── 2022-01-04.json    :   (you did not have much to discuss —
+│                          :    Steve turned out to be a scumbag)
+├── channels.json          : all workspace channels information
+├── dms.json               : direct message information
+└── users.json             : all workspace users information
+```
+
+### Channels
+The channels are be saved in directories, named after the channel title,
+i.e. `#random` would be saved to "random" directory. The directory will
+contain a set of JSON files, one per each day.
+
+### Users
+User directories will have an "D" prefix, to find out the user name,
+check `users.json` file.
+
+### Group Messages
+Group messages will have all involved user handles in their name.
+
+## Inclusive and Exclusive Modes
+
+It is possible to **include** or **exclude** channels in/from the Export.
+
+For more details, run `slackdump help syntax`.
+
+## Viewing the Export
+
+To view the export, run `slackdump view <export_file>`.
+
+

--- a/cmd/slackdump/internal/export/export.go
+++ b/cmd/slackdump/internal/export/export.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"strings"
@@ -23,23 +24,23 @@ var CmdExport = &base.Command{
 	UsageLine:   "slackdump export",
 	Short:       "exports the Slack Workspace or individual conversations",
 	FlagMask:    cfg.OmitUserCacheFlag,
-	Long:        ``, // TODO: add long description
+	Long:        mdExport, // TODO: add long description
 	CustomFlags: false,
 	PrintFlags:  true,
 	RequireAuth: true,
 }
+
+//go:embed assets/export.md
+var mdExport string
 
 type exportFlags struct {
 	ExportStorageType fileproc.StorageType
 	ExportToken       string
 }
 
-var (
-	compat  bool
-	options = exportFlags{
-		ExportStorageType: fileproc.STmattermost,
-	}
-)
+var options = exportFlags{
+	ExportStorageType: fileproc.STmattermost,
+}
 
 func init() {
 	CmdExport.Flag.Var(&options.ExportStorageType, "type", "export file storage type")

--- a/cmd/slackdump/internal/man/assets/syntax.md
+++ b/cmd/slackdump/internal/man/assets/syntax.md
@@ -1,13 +1,14 @@
 # Slackdump Channel List Syntax
 
-Slackdump major modes like `archive`, `export` and `dump` support
-including or excluding channels from the operation. This document
-describes how to use the inclusive and exclusive modes, along with
-examples.
+Slackdump major commands like `archive`, `export`, and `dump` allow you
+to include or exclude specific channels from an operation. This document
+explains the inclusive and exclusive modes, their syntax, and provides
+examples for practical use.
 
-Slackdump accepts channel IDs or URLs as arguments separated by space.
-The channel ID is the last part of the channel URL. For example, in the
-URL
+## Syntax
+
+Slackdump accepts channel IDs or URLs as arguments, separated by spaces.  
+The **channel ID** is the last part of the channel URL. For example, in the URL:
 
 ```
 https://xxx.slack.com/archives/C12345678
@@ -15,54 +16,85 @@ https://xxx.slack.com/archives/C12345678
 
 the channel ID is `C12345678`.
 
-You can also get all available channel IDs by running the `slackdump list channels` command.
+To get a list of all available channel IDs, run:
+```bash
+slackdump list channels
+```
 
-## Syntax
+The syntax for specifying entities is as follows:
+```
+[[prefix]term[/[time_from]/[time_to]]|@file]
+```
 
-- No prefix: include the channel in the operation.
-- `^`: exclude the channel from the operation.
-- `@`: read the channels from a file.
+Where:
+- `prefix`: Determines how the channel is processed.
+  - No prefix: Include the channel in the operation.
+  - `^`: Exclude the channel from the operation.
+- `term`: The channel ID, URL, or filename.
+- `time_from` and `time_to`: Optional parameters specifying the time
+  range for the operation in `YYYY-MM-DDTHH:MM:SS` format.
+  - If only `time_from` is specified, the operation includes all messages
+    starting from that time.
+  - If only `time_to` is specified, the operation includes all messages
+    up to that time.
+  - If both are specified, the operation includes messages within that
+    time range.
 
-File can contain one or more channel IDs or URLs, one per line.
-
-Below, we'll look at some examples.
+A file can contain one or more channel IDs or URLs, with each entry on a
+new line.
 
 ## Examples
 
-### Exporting Only Channels You Need
+### 1. Exporting Specific Channels
 
-To include only those channels you're interested in, use the following
-syntax:
+To include only specific channels in the operation:
 
 ```bash
 slackdump export C12401724 https://xxx.slack.com/archives/C4812934
 ```
 
-The command above will export ONLY channels `C12401724` and `C4812934`.
+This command exports **only** channels `C12401724` and `C4812934`.
 
-### Exporting Everything Except Some Unwanted Channels
+### 2. Exclude Specific Channels
 
-To exclude one or more channels from the export, prefix the channel with
-the caret "^" character. For example, you want to export everything
-except channel `C123456`:
+To exclude one or more channels, prefix them with ^. For example, to
+export everything except channel C123456:
 
 ```bash
-slackdump -export my-workspace.zip ^C123456
+slackdump export ^C123456
 ```
+This excludes `C123456` while exporting the rest.
 
-### Providing the List in a File
+### 3. Using a File for Channel Lists
 
-You can specify the filename instead of listing all the channels on the
-command line. To include the channels from the file, use the "@"
-character prefix. The following example shows how to load the channels
-from the file named "data.txt":
+You can specify a file containing channel IDs or URLs. To include
+channels from a file:
+
 ```bash
 slackdump archive @data.txt
 ```
-It is also possible to combine files and channels, i.e.:
+You can also combine files and individual channel exclusions. For
+example:
+
 ```bash
 slackdump archive @data.txt ^C123456
 ```
-The command above will read the channels from data.txt and exclude the
-channel `C123456` from the Export.
+This command includes channels listed in data.txt but excludes C123456.
+
+### 4. Using Time Ranges
+
+To include messages from a specific time range:
+
+```bash
+slackdump archive C123456/2022-01-01T00:00:00/2022-01-31T23:59:59
+```
+
+This command archives messages from channel `C123456` between January 1st
+and January 31st, 2022.
+
+## TL;DR
+
+- Use the `@` prefix for files and the `^` prefix for exclusions.
+- Time range parameters are optional but can refine your export or
+  archive operation.
 

--- a/cmd/slackdump/internal/man/assets/syntax.md
+++ b/cmd/slackdump/internal/man/assets/syntax.md
@@ -1,0 +1,68 @@
+# Slackdump Channel List Syntax
+
+Slackdump major modes like `archive`, `export` and `dump` support
+including or excluding channels from the operation. This document
+describes how to use the inclusive and exclusive modes, along with
+examples.
+
+Slackdump accepts channel IDs or URLs as arguments separated by space.
+The channel ID is the last part of the channel URL. For example, in the
+URL
+
+```
+https://xxx.slack.com/archives/C12345678
+```
+
+the channel ID is `C12345678`.
+
+You can also get all available channel IDs by running the `slackdump list channels` command.
+
+## Syntax
+
+- No prefix: include the channel in the operation.
+- `^`: exclude the channel from the operation.
+- `@`: read the channels from a file.
+
+File can contain one or more channel IDs or URLs, one per line.
+
+Below, we'll look at some examples.
+
+## Examples
+
+### Exporting Only Channels You Need
+
+To include only those channels you're interested in, use the following
+syntax:
+
+```bash
+slackdump export C12401724 https://xxx.slack.com/archives/C4812934
+```
+
+The command above will export ONLY channels `C12401724` and `C4812934`.
+
+### Exporting Everything Except Some Unwanted Channels
+
+To exclude one or more channels from the export, prefix the channel with
+the caret "^" character. For example, you want to export everything
+except channel `C123456`:
+
+```bash
+slackdump -export my-workspace.zip ^C123456
+```
+
+### Providing the List in a File
+
+You can specify the filename instead of listing all the channels on the
+command line. To include the channels from the file, use the "@"
+character prefix. The following example shows how to load the channels
+from the file named "data.txt":
+```bash
+slackdump archive @data.txt
+```
+It is also possible to combine files and channels, i.e.:
+```bash
+slackdump archive @data.txt ^C123456
+```
+The command above will read the channels from data.txt and exclude the
+channel `C123456` from the Export.
+

--- a/cmd/slackdump/internal/man/syntax.go
+++ b/cmd/slackdump/internal/man/syntax.go
@@ -1,0 +1,18 @@
+package man
+
+import (
+	_ "embed"
+
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
+)
+
+//go:embed assets/syntax.md
+var syntaxMD string
+
+var Syntax = &base.Command{
+	Run:       nil,
+	Wizard:    nil,
+	UsageLine: "slackdump syntax",
+	Short:     "how to specify channels to dump",
+	Long:      syntaxMD,
+}

--- a/cmd/slackdump/internal/view/assets/view.md
+++ b/cmd/slackdump/internal/view/assets/view.md
@@ -1,0 +1,34 @@
+# Command: view
+
+The `view` command allows you to view the contents of an archive, 
+export, or dump directory or ZIP file.
+
+It is a read-only command that does not modify the contents of the
+specified directory or file.
+
+Viewer supports displaying downloaded images, videos as well as remote
+content.
+
+## Usage
+
+```bash
+slackdump view <directory_or_file>
+```
+
+If you experience problems viewing, run the viewer with DEBUG mode
+enabled, and report the violating message to the Github Issues page.
+
+```bash
+DEBUG=1 slackdump view <directory_or_file>
+```
+
+It is recommended that you remove all sensitive information from the
+JSON before sharing it, and also, to encrypt your message, you can use
+the `slackdump tools encrypt` command, for example:
+
+```bash
+cat your_message.txt | slackdump tools encrypt > encrypted_message.txt
+```
+
+This will encrypt it using the embedded GPG public key, and can only be
+encrypted by the author.

--- a/cmd/slackdump/internal/view/view.go
+++ b/cmd/slackdump/internal/view/view.go
@@ -3,6 +3,7 @@ package view
 import (
 	"archive/zip"
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"strings"
 
 	br "github.com/pkg/browser"
+
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/internal/chunk"
@@ -20,12 +22,13 @@ import (
 	"github.com/rusq/slackdump/v3/internal/viewer/source"
 )
 
+//go:embed assets/view.md
+var mdView string
+
 var CmdView = &base.Command{
-	Short:     "View the slackdump files",
-	UsageLine: "slackdump view [flags]",
-	Long: `
-View the slackdump files.
-`,
+	Short:      "View the slackdump files",
+	UsageLine:  "slackdump view [flags]",
+	Long:       mdView,
 	PrintFlags: true,
 	FlagMask:   cfg.OmitAll,
 	Run:        RunView,

--- a/cmd/slackdump/internal/workspace/assets/del.md
+++ b/cmd/slackdump/internal/workspace/assets/del.md
@@ -1,0 +1,10 @@
+# Command: "workspace del"
+The `workspace del` command removes the Slack workspace login information
+(effectively "forgetting" the workspace).
+
+Once deleted, you will need to re-authenticate by running the `workspace new`
+command to log in to that workspace again.
+
+Slackdump will prompt you for confirmation before deleting the workspace. To
+bypass this confirmation, use the `-y` flag.
+

--- a/cmd/slackdump/internal/workspace/assets/import.md
+++ b/cmd/slackdump/internal/workspace/assets/import.md
@@ -1,24 +1,26 @@
-# Workspace Import Command
+# Command: "workspace import"
 
-**Import** allows you to import credentials from a .env or secrets.txt file.
+The `workspace import` command allows you to import credentials from a `.env`
+or `secrets.txt` file.
 
-It requires the file to have the following format:
-```
+The file should have the following format:
+```shell
 SLACK_TOKEN=xoxc-...
 SLACK_COOKIE=xoxd-...
 ```
 
-`SLACK_TOKEN` can be one of the following:
+**SLACK_TOKEN** can be one of the following types:
 
-- xoxa-...: app token
-- xoxb-...: bot token
-- xoxc-...: client token
-- xoxe-...: export token
-- xoxp-...: legacy user token
+- xoxa-...: App token
+- xoxb-...: Bot token
+- xoxc-...: Client token
+- xoxe-...: Export token
+- xoxp-...: Legacy user token
 
-`SLACK_COOKIE` is only required, if the `SLACK_TOKEN` is a client type token
-(starts with `xoxc-`).
+**SLACK_COOKIE** is required only if the `SLACK_TOKEN` is a client token
+(`xoxc-...`).
 
-It will test the provided credentials, and if successful, encrypt and save
-them to the to the slackdump credential storage.  It is recommended to delete
-the .env file afterwards.
+The command will test the provided credentials, and if successful, it will
+encrypt and save them to Slackdump's credential storage. It is recommended to
+delete the .env or secrets.txt file after the import to ensure security.
+

--- a/cmd/slackdump/internal/workspace/assets/list.md
+++ b/cmd/slackdump/internal/workspace/assets/list.md
@@ -1,14 +1,17 @@
-# Workspace List Command
+# Command: workspace list
 
-**List** allows to list Slack Workspaces, that you have previously
-authenticated in.  It supports several output formats:
-- full (default): outputs workspace names, filenames, and last modification.
-- bare: outputs just workspace names, with the current workspace marked with
+The workspace list command displays the Slack workspaces you have previously
+authenticated. It supports several output formats:
+
+- **full** (default): Displays workspace names, filenames, and last
+  modification dates.
+- **bare**: Displays only workspace names, with the current workspace marked by
   an asterisk.
-- all: outputs all information, including the team name and the user name for
-  each workspace.
+- **all**: Displays all available information, including the team name and user
+  name for each workspace.
 
-If the "all" listing is requested, Slackdump will interrogate the Slack API to
-get the team name and the user name for each workspace.  This may take some
-time, as it involves multiple network requests, depending on your network
-speed and the number of workspaces.
+When the "all" format is selected, Slackdump will query the Slack API to
+retrieve the team name and user name for each workspace. This may take some
+time, depending on your network speed and the number of workspaces, as it
+involves multiple network requests.
+

--- a/cmd/slackdump/internal/workspace/assets/new.md
+++ b/cmd/slackdump/internal/workspace/assets/new.md
@@ -1,0 +1,25 @@
+# Command "workspace new"
+
+This command authenticates to a new Slack workspace and saves the
+authentication credentials.
+
+- If a workspace with the same name already exists, Slackdump will prompt you
+  to either overwrite the existing workspace or cancel the operation.
+- If no workspace name is provided, the command will create or replace the
+  "default" workspace.
+
+**Note**:  If you're migrating from Slackdump v2, you will only have a "default"
+workspace by default. You can either continue using it as your default
+workspace or create a new one. Later, you can switch between workspaces using
+the `workspace select` command.
+
+## Usage
+
+```shell
+slackdump workspace new <workspace name or url>
+```
+
+For example:
+```shell
+slackdump workspace new https://ora600.slack.com
+```

--- a/cmd/slackdump/internal/workspace/del.go
+++ b/cmd/slackdump/internal/workspace/del.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 
@@ -15,21 +16,13 @@ var (
 	ErrNotExists   = errors.New("workspace does not exist")
 )
 
+//go:embed assets/del.md
+var delMD string
+
 var CmdWspDel = &base.Command{
-	UsageLine: baseCommand + " del [flags]",
-	Short:     "deletes the saved workspace credentials",
-	Long: `
-# Workspace Delete Command
-
-Use ` + "`del`" + ` to delete the Slack Workspace login information ("forget"
-the workspace).
-
-If the workspace login information is deleted, you will need to login into that
-workspace again by running ` + " `slackdump workspace new <name>`" + `.
-
-Slackdump will ask for the confirmation before deleting.  To omit the
-question, use ` + "`-y`" + ` flag.
-`,
+	UsageLine:   baseCommand + " del [flags]",
+	Short:       "deletes the saved workspace credentials",
+	Long:        delMD,
 	CustomFlags: false,
 	FlagMask:    cfg.OmitAll,
 	PrintFlags:  true,

--- a/cmd/slackdump/internal/workspace/new.go
+++ b/cmd/slackdump/internal/workspace/new.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"os"
@@ -14,14 +15,13 @@ import (
 	"github.com/rusq/slackdump/v3/internal/cache"
 )
 
-var CmdWspNew = &base.Command{
-	UsageLine: baseCommand + " new [flags] <name>",
-	Short:     "authenticate in a Slack Workspace",
-	Long: `
-# Workspace New Command
+//go:embed assets/new.md
+var newMD string
 
-**New** allows you to authenticate in an existing Slack Workspace.
-`,
+var CmdWspNew = &base.Command{
+	UsageLine:  baseCommand + " new [flags] <name>",
+	Short:      "authenticate in a Slack Workspace",
+	Long:       newMD,
 	FlagMask:   flagmask &^ cfg.OmitAuthFlags, // only auth flags.
 	PrintFlags: true,
 	Wizard:     workspaceui.WorkspaceNew,

--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -55,6 +55,7 @@ func init() {
 		CmdVersion,
 
 		man.WhatsNew,
+		man.Syntax,
 		man.Login,
 		man.Chunk,
 	}

--- a/internal/chunk/file.go
+++ b/internal/chunk/file.go
@@ -102,7 +102,7 @@ func (f *File) Close() error {
 }
 
 type decoder interface {
-	Decode(interface{}) error
+	Decode(any) error
 	InputOffset() int64
 }
 
@@ -400,7 +400,7 @@ func allForID[T any](p *File, id GroupID, fn func(*Chunk) []T) ([]T, error) {
 
 // AllChannelIDs returns all the channels in the chunkfile.
 func (p *File) AllChannelIDs() []string {
-	var ids = make([]string, 0, 1)
+	ids := make([]string, 0, 1)
 	for gid := range p.idx {
 		id := string(gid)
 		if !strings.Contains(id, ":") && !gid.isInfo() && !gid.isList() && !gid.isSearch() {
@@ -438,7 +438,7 @@ func (f *File) offsetTimestamps(ctx context.Context) (offts, error) {
 	ctx, task := trace.NewTask(ctx, "offsetTimestamps")
 	defer task.End()
 
-	var ret = make(offts, f.idx.OffsetCount())
+	ret := make(offts, f.idx.OffsetCount())
 	for id, offsets := range f.idx {
 		switch id[0] {
 		case catInfo, catFile, catList, catSearch: // ignoring files, information and list chunks
@@ -478,7 +478,7 @@ type Addr struct {
 // string timestamp to an int64 timestamp using structures.TS2int, but the
 // original string timestamp returned in the TimeOffset struct.
 func timeOffsets(ots offts) map[int64]Addr {
-	var ret = make(map[int64]Addr, len(ots))
+	ret := make(map[int64]Addr, len(ots))
 	for offset, info := range ots {
 		for i, ts := range info.Timestamps {
 			ret[ts] = Addr{
@@ -506,7 +506,7 @@ func (f *File) Sorted(ctx context.Context, desc bool, fn func(ts time.Time, m *s
 	rgnTos := trace.StartRegion(ctx, "timeOffsets")
 	tos := timeOffsets(ots)
 	rgnTos.End()
-	var tsList = make([]int64, 0, len(tos))
+	tsList := make([]int64, 0, len(tos))
 	for ts := range tos {
 		tsList = append(tsList, ts)
 	}

--- a/internal/osext/move.go
+++ b/internal/osext/move.go
@@ -12,8 +12,6 @@ import (
 // overwritten.
 //
 // Adopted solution from https://stackoverflow.com/questions/50740902/move-a-file-to-a-different-drive-with-go
-// TODO: This is a temporary solution.  We should use os.Rename() instead, but
-// that doesn't work across filesystems, see the above link.
 func MoveFile(src string, fs fsadapter.FS, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {

--- a/internal/structures/entity_list.go
+++ b/internal/structures/entity_list.go
@@ -17,7 +17,7 @@ const (
 	// exclusions, i.e. for export or when downloading conversations.
 	excludePrefix = "^"
 	filePrefix    = "@"
-	timeSeparator = "/"
+	timeSeparator = ","
 	timeFmt       = "2006-01-02T15:04:05"
 
 	// maxFileEntries is the maximum non-empty entries that will be read

--- a/internal/structures/entity_list.go
+++ b/internal/structures/entity_list.go
@@ -13,15 +13,15 @@ import (
 )
 
 const (
-	// excludePrefix is the prefix that is used to mark channel exclusions, i.e.
-	// for export or when downloading conversations.
+	// excludePrefix is the prefix that is used to mark channel
+	// exclusions, i.e. for export or when downloading conversations.
 	excludePrefix = "^"
 	filePrefix    = "@"
-	timeSeparator = "|"
+	timeSeparator = "/"
 	timeFmt       = "2006-01-02T15:04:05"
 
-	// maxFileEntries is the maximum non-empty entries that will be read from
-	// the file.
+	// maxFileEntries is the maximum non-empty entries that will be read
+	// from the file.
 	maxFileEntries = 1048576
 )
 

--- a/internal/structures/entity_list_test.go
+++ b/internal/structures/entity_list_test.go
@@ -105,7 +105,6 @@ func TestMakeEntityList(t *testing.T) {
 			args{[]string{"one", "^two", "three"}},
 			&EntityList{
 				index: map[string]*EntityItem{
-
 					"one": {
 						Id:      "one",
 						Include: true,
@@ -175,7 +174,6 @@ func TestMakeEntityList(t *testing.T) {
 			args{[]string{"one", "^two", "three", "", "four", "^"}},
 			&EntityList{
 				index: map[string]*EntityItem{
-
 					"four": {
 						Id:      "four",
 						Include: true,
@@ -216,7 +214,7 @@ func TestMakeEntityList(t *testing.T) {
 		},
 		{
 			"with date limits",
-			args{[]string{"one||", "^two||", "three|bad|2024-01-10T23:02:12", "four|2023-12-10T23:02:12|2024-01-10T23:02:12", "^five|2023-12-10T23:02:12|2024-01-10T23:02:12", "six|2023-12-10T23:02:12|2024-01-10T23:02:12||", "seven|2024-04-07T23:02:12"}},
+			args{[]string{"one,,", "^two,,", "three,bad,2024-01-10T23:02:12", "four,2023-12-10T23:02:12,2024-01-10T23:02:12", "^five,2023-12-10T23:02:12,2024-01-10T23:02:12", "six,2023-12-10T23:02:12,2024-01-10T23:02:12,,", "seven,2024-04-07T23:02:12"}},
 			&EntityList{
 				index: map[string]*EntityItem{
 					"one": {
@@ -496,7 +494,6 @@ func TestEntityList_HasExcludes(t *testing.T) {
 }
 
 func TestEntityList_IsEmpty(t *testing.T) {
-
 	tests := []struct {
 		name string
 		args []string
@@ -594,20 +591,20 @@ func Test_buildEntityIndex(t *testing.T) {
 		{
 			"with dates",
 			args{[]string{
-				"one||",
-				"^two||",
-				"three|bad|2024-01-10T23:02:12",
-				"four|2023-12-10T23:02:12|2024-01-10T23:02:12",
-				"^five|2023-12-10T23:02:12|2024-01-10T23:02:12",
-				"six|2023-12-10T23:02:12|2024-01-10T23:02:12||",
+				"one,,",
+				"^two,,",
+				"three,bad,2024-01-10T23:02:12",
+				"four,2023-12-10T23:02:12,2024-01-10T23:02:12",
+				"^five,2023-12-10T23:02:12,2024-01-10T23:02:12",
+				"six,2023-12-10T23:02:12,2024-01-10T23:02:12,,",
 			}},
 			map[string]bool{
-				"one||":                         true,
-				"two||":                         false,
-				"three|bad|2024-01-10T23:02:12": true,
-				"four|2023-12-10T23:02:12|2024-01-10T23:02:12":  true,
-				"five|2023-12-10T23:02:12|2024-01-10T23:02:12":  false,
-				"six|2023-12-10T23:02:12|2024-01-10T23:02:12||": true,
+				"one,,":                         true,
+				"two,,":                         false,
+				"three,bad,2024-01-10T23:02:12": true,
+				"four,2023-12-10T23:02:12,2024-01-10T23:02:12":  true,
+				"five,2023-12-10T23:02:12,2024-01-10T23:02:12":  false,
+				"six,2023-12-10T23:02:12,2024-01-10T23:02:12,,": true,
 			},
 			false,
 		},

--- a/internal/viewer/source/filestorage.go
+++ b/internal/viewer/source/filestorage.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"io/fs"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -47,7 +48,7 @@ func (r *fstMattermost) FS() fs.FS {
 }
 
 func (r *fstMattermost) File(id string, name string) (string, error) {
-	pth := filepath.Join(id, name)
+	pth := path.Join(id, name)
 	_, err := fs.Stat(r.fs, pth)
 	if err != nil {
 		return "", err
@@ -79,7 +80,7 @@ func newStandardStorage(rootfs fs.FS, idx map[string]string) *fstStandard {
 // buildFileIndex walks the fsys, finding all "attachments" subdirectories, and
 // indexes files in them.
 func buildFileIndex(fsys fs.FS, dir string) (map[string]string, error) {
-	var idx = make(map[string]string) // maps the file id to the file name
+	idx := make(map[string]string) // maps the file id to the file name
 	if err := fs.WalkDir(fsys, dir, func(pth string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -174,7 +175,7 @@ func newDumpStorage(fsys fs.FS) (*fstDump, error) {
 
 // indexDump indexes the files in the dump format.
 func indexDump(fsys fs.FS) (map[string]string, error) {
-	var idx = make(map[string]string)
+	idx := make(map[string]string)
 	// 1. find all json files in the root directory, and use their names as the
 	// channel IDs.
 	var chans []string

--- a/internal/viewer/source/filestorage_test.go
+++ b/internal/viewer/source/filestorage_test.go
@@ -1,0 +1,183 @@
+package source
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_fstMattermost_File(t *testing.T) {
+	dir := t.TempDir()
+	// Create a file in the __uploads directory.
+	uploads := filepath.Join(dir, mmuploads, "file_id1")
+	err := os.MkdirAll(uploads, 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(uploads, "filename.ext"), []byte("file contents"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsys := os.DirFS(dir)
+	sub, err := fs.Sub(fsys, mmuploads)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		fs fs.FS
+	}
+	type args struct {
+		id   string
+		name string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "file exists",
+			fields: fields{
+				fs: sub,
+			},
+			args: args{
+				id:   "file_id1",
+				name: "filename.ext",
+			},
+			want:    "file_id1/filename.ext",
+			wantErr: false,
+		},
+		{
+			name: "file does not exist",
+			fields: fields{
+				fs: sub,
+			},
+			args: args{
+				id:   "file_id1",
+				name: "nonexistent.ext",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &fstMattermost{
+				fs: tt.fields.fs,
+			}
+			got, err := r.File(tt.args.id, tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fstMattermost.File() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("fstMattermost.File() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_fstStandard_File(t *testing.T) {
+	type fields struct {
+		fs  fs.FS
+		idx map[string]string
+	}
+	type args struct {
+		id  string
+		in1 string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &fstStandard{
+				fs:  tt.fields.fs,
+				idx: tt.fields.idx,
+			}
+			got, err := r.File(tt.args.id, tt.args.in1)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fstStandard.File() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("fstStandard.File() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_fstNotFound_File(t *testing.T) {
+	type args struct {
+		id   string
+		name string
+	}
+	tests := []struct {
+		name    string
+		f       fstNotFound
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := fstNotFound{}
+			got, err := f.File(tt.args.id, tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fstNotFound.File() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("fstNotFound.File() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_fstDump_File(t *testing.T) {
+	type fields struct {
+		fs  fs.FS
+		idx map[string]string
+	}
+	type args struct {
+		id   string
+		name string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &fstDump{
+				fs:  tt.fields.fs,
+				idx: tt.fields.idx,
+			}
+			got, err := r.File(tt.args.id, tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fstDump.File() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("fstDump.File() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- **documentation**
- **add more doc**
- **Updating docs**
- **fix for windows paths**

Slackdump view wasn't working properly on Windows.  The problem rooted
in using filepath.Join on a fs.FS.  Even though it was an os.DirFS and
Windows, it expected the Unix path separators.  Fixed by replacing the
filepath.Join with path.Join.
