### PR TITLE
global config file picker expected yaml

### DIFF
--- a/cmd/slackdump/internal/apiconfig/apiconfig.go
+++ b/cmd/slackdump/internal/apiconfig/apiconfig.go
@@ -29,6 +29,8 @@ configuration file.
 	},
 }
 
+var ConfigExts = []string{"*.toml", "*.tml"}
+
 var ErrConfigInvalid = errors.New("config validation failed")
 
 // Load reads, parses and validates the config file.
@@ -83,7 +85,7 @@ func printErrors(w io.Writer, err error) error {
 	}
 
 	var wErr error
-	var printErr = func(format string, a ...any) {
+	printErr := func(format string, a ...any) {
 		if wErr != nil {
 			return
 		}

--- a/cmd/slackdump/internal/apiconfig/check.go
+++ b/cmd/slackdump/internal/apiconfig/check.go
@@ -57,7 +57,7 @@ func CheckFile(filename string) error {
 }
 
 func wizConfigCheck(ctx context.Context, cmd *base.Command, args []string) error {
-	f := filemgr.New(os.DirFS("."), ".", 15, "*.toml", "*.tml")
+	f := filemgr.New(os.DirFS("."), ".", 15, ConfigExts...)
 	f.Focus()
 	f.ShowHelp = true
 	f.Style = filemgr.Style{

--- a/cmd/slackdump/internal/man/assets/syntax.md
+++ b/cmd/slackdump/internal/man/assets/syntax.md
@@ -5,17 +5,35 @@ you to include or exclude specific channels from an operation.  This
 document explains the inclusive and exclusive modes, their syntax,
 and provides examples for practical use.
 
+## Executive Summary
+
+- Entities are separated by spaces on the CLI, and by new lines in files.
+- __FILES__: Use the `@` prefix for files, example: `@channels.txt`.
+  - each line in the file should contain a channel or thread ID or URL of a
+    channel or thread, or a comment if the line starts with `#`.
+  - it supports the same syntax as the command line for time ranges and
+    exclusion.
+- __EXCLUSION__: Use the `^` prefix for exclusions, example: `^C123`.
+- __TIME RANGE__: Time range parameters are optional but can refine your export
+  or archive operation.
+  - Time ranges are specified as `time_from` and `time_to` in
+    `YYYY-MM-DDTHH:MM:SS` format.
+  - They should be separated by commas without spaces.
+
 ## Syntax
 
 Slackdump accepts channel IDs or URLs as arguments, separated by
-spaces.  The **channel ID** is the last part of the channel URL.
-For example, in the URL:
+spaces, if specified on the command line, and by new line characters,
+if supplied in a file.  URLs and IDs can be used interchangeably:
+
+Here's the Slack Channel URL, where the **channel ID** is the last part of the
+URL:
 
 ```
-https://xxx.slack.com/archives/C12345678
+https://xxx.slack.com/archives/C051D4052
 ```
 
-the channel ID is `C12345678`.
+the channel ID is `C051D4052`.
 
 To get a list of all available channel IDs, run:
 ```bash
@@ -27,14 +45,16 @@ The syntax for specifying entities is as follows:
 [[prefix]term[,[time_from],[time_to]]|@file]
 ```
 
-Please note that there are no spaces before or after the commas
-",".
+Please note that there are no spaces before or after the commas ",".
 
 Where:
 - `prefix`: Determines how the channel is processed.
   - No prefix: Include the channel in the operation.
   - `^`: Exclude the channel from the operation.
-- `term`: The channel ID, URL, or filename.
+- `term`: can be one of the following:
+  - Channel ID (i.e. C051D4052)
+  - Thread ID i.e. "C051D4052:1665917454.731419",
+  - URL of the channel or thread(see above)
 - `time_from` and `time_to`: Optional parameters specifying the time range for
   the operation in `YYYY-MM-DDTHH:MM:SS` format.
   - If only `time_from` is specified, the operation includes all messages
@@ -43,12 +63,14 @@ Where:
     that time.
   - If both are specified, the operation includes messages within that time
     range.
-- `@file`: A file containing channel IDs or URLs, with each entry on a new
-  line.
+- `@file`: A file containing channel or thread IDs or URLs:
+  - each entry on a new line;
+  - comments start with `#`, and should be on a new line;
+  - empty lines are skipped.
 
 ## Examples
 
-### 1. Exporting Specific Channels
+### 1. Exporting Specific Channels or Threads
 
 To include only specific channels in the operation:
 
@@ -58,7 +80,17 @@ slackdump export C12401724 https://xxx.slack.com/archives/C4812934
 
 This command exports **only** channels `C12401724` and `C4812934`.
 
-### 2. Exclude Specific Channels
+To include specific threads you can provide the thread URL:
+```bash
+slackdump dump \
+    https://ora600.slack.com/archives/C051D4052/p1665917454731419
+```
+or use the Slackdump thread notation:
+```bash
+slackdump export C051D4052:1665917454.731419
+```
+
+### 2. Exclude Specific Channels or Threads
 
 To exclude one or more channels, prefix them with ^.  For example,
 to export everything except channel C123456:
@@ -70,8 +102,8 @@ This excludes `C123456` while exporting the rest.
 
 ### 3. Using a File for Channel Lists
 
-You can specify a file containing channel IDs or URLs.  To include
-channels from a file:
+You can specify a file containing channel IDs or URLs.  The file should contain
+IDs, one per line. To include channels from a file:
 
 ```bash
 slackdump archive @data.txt
@@ -83,6 +115,14 @@ example:
 slackdump archive @data.txt ^C123456
 ```
 This command includes channels listed in data.txt but excludes C123456.
+
+Sample file:
+```text
+# This is a comment
+C123456
+^C123457
+https://ora600.slack.com/archives/C051D4052/p1665917454731419
+```
 
 ### 4. Using Time Ranges
 
@@ -108,13 +148,4 @@ After some date:
 ```bash
 slackdump archive C123456,,2022-01-31T23:59:59
 ```
-
-## TL;DR
-
-- Use the `@` prefix for files and the `^` prefix for exclusions.
-- Time range parameters are optional but can refine your export or
-  archive operation.
-  - Time ranges are specified as `time_from` and `time_to` in
-    `YYYY-MM-DDTHH:MM:SS` format.
-  - They should be separated by commas without spaces.
 

--- a/cmd/slackdump/internal/ui/cfgui/configuration.go
+++ b/cmd/slackdump/internal/ui/cfgui/configuration.go
@@ -82,7 +82,7 @@ func globalConfig() Configuration {
 					Description: "API limits file",
 					Updater: updaters.NewFilepickModel(
 						&cfg.ConfigFile,
-						filemgr.New(os.DirFS("."), ".", 15, "*.toml", "*.tml"),
+						filemgr.New(os.DirFS("."), ".", 15, apiconfig.ConfigExts...),
 						validateAPIconfig,
 					),
 				},

--- a/cmd/slackdump/internal/ui/cfgui/configuration.go
+++ b/cmd/slackdump/internal/ui/cfgui/configuration.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/rusq/rbubbles/filemgr"
+
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/apiconfig"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/updaters"
@@ -81,7 +82,7 @@ func globalConfig() Configuration {
 					Description: "API limits file",
 					Updater: updaters.NewFilepickModel(
 						&cfg.ConfigFile,
-						filemgr.New(os.DirFS("."), ".", 15, "*.yaml", "*.yml"),
+						filemgr.New(os.DirFS("."), ".", 15, "*.toml", "*.tml"),
 						validateAPIconfig,
 					),
 				},


### PR DESCRIPTION
Update the file picker in the Global Config wizard page to search for TOML instead of YAML files.
