### PR TITLE
Add support for channel canvases

### DIFF
--- a/clienter_mock_test.go
+++ b/clienter_mock_test.go
@@ -120,6 +120,23 @@ func (mr *MockSlackerMockRecorder) GetConversationsContext(ctx, params any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConversationsContext", reflect.TypeOf((*MockSlacker)(nil).GetConversationsContext), ctx, params)
 }
 
+// GetFileInfoContext mocks base method.
+func (m *MockSlacker) GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFileInfoContext", ctx, fileID, count, page)
+	ret0, _ := ret[0].(*slack.File)
+	ret1, _ := ret[1].([]slack.Comment)
+	ret2, _ := ret[2].(*slack.Paging)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// GetFileInfoContext indicates an expected call of GetFileInfoContext.
+func (mr *MockSlackerMockRecorder) GetFileInfoContext(ctx, fileID, count, page any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileInfoContext", reflect.TypeOf((*MockSlacker)(nil).GetFileInfoContext), ctx, fileID, count, page)
+}
+
 // GetStarredContext mocks base method.
 func (m *MockSlacker) GetStarredContext(ctx context.Context, params slack.StarsParameters) ([]slack.StarredItem, *slack.Paging, error) {
 	m.ctrl.T.Helper()
@@ -344,6 +361,23 @@ func (m *mockClienter) GetFileContext(ctx context.Context, downloadURL string, w
 func (mr *mockClienterMockRecorder) GetFileContext(ctx, downloadURL, writer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileContext", reflect.TypeOf((*mockClienter)(nil).GetFileContext), ctx, downloadURL, writer)
+}
+
+// GetFileInfoContext mocks base method.
+func (m *mockClienter) GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFileInfoContext", ctx, fileID, count, page)
+	ret0, _ := ret[0].(*slack.File)
+	ret1, _ := ret[1].([]slack.Comment)
+	ret2, _ := ret[2].(*slack.Paging)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// GetFileInfoContext indicates an expected call of GetFileInfoContext.
+func (mr *mockClienterMockRecorder) GetFileInfoContext(ctx, fileID, count, page any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileInfoContext", reflect.TypeOf((*mockClienter)(nil).GetFileInfoContext), ctx, fileID, count, page)
 }
 
 // GetStarredContext mocks base method.

--- a/internal/chunk/dirproc/conversations.go
+++ b/internal/chunk/dirproc/conversations.go
@@ -8,6 +8,7 @@ import (
 	"runtime/trace"
 
 	"github.com/rusq/slack"
+
 	"github.com/rusq/slackdump/v3/internal/chunk"
 	"github.com/rusq/slackdump/v3/processor"
 )

--- a/internal/chunk/transform/fileproc/fileproc.go
+++ b/internal/chunk/transform/fileproc/fileproc.go
@@ -44,7 +44,7 @@ func NewSubprocessor(dl Downloader, fp func(ci *slack.Channel, f *slack.File) st
 	}
 }
 
-func (b Subprocessor) Files(ctx context.Context, channel *slack.Channel, msg slack.Message, ff []slack.File) error {
+func (b Subprocessor) Files(ctx context.Context, channel *slack.Channel, _ slack.Message, ff []slack.File) error {
 	for _, f := range ff {
 		if !IsValid(&f) {
 			continue

--- a/internal/edge/wrapper.go
+++ b/internal/edge/wrapper.go
@@ -81,3 +81,7 @@ func (w *Wrapper) SearchMessagesContext(ctx context.Context, query string, param
 func (w *Wrapper) SearchFilesContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchFiles, error) {
 	return w.cl.SearchFilesContext(ctx, query, params)
 }
+
+func (w *Wrapper) GetFileInfoContext(ctx context.Context, fileID string, count int, page int) (*slack.File, []slack.Comment, *slack.Paging, error) {
+	return w.cl.GetFileInfoContext(ctx, fileID, count, page)
+}

--- a/slackdump.go
+++ b/slackdump.go
@@ -56,6 +56,8 @@ type Slacker interface {
 
 	SearchMessagesContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchMessages, error)
 	SearchFilesContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchFiles, error)
+
+	GetFileInfoContext(ctx context.Context, fileID string, count int, page int) (*slack.File, []slack.Comment, *slack.Paging, error)
 }
 
 // clienter is the interface with some functions of slack.Client with the sole

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -171,6 +171,7 @@ func (we *Result) Unwrap() error {
 	return we.Err
 }
 
+// channel fetches the channel data as defined in req, calling callback function for each API response.
 func (cs *Stream) channel(ctx context.Context, req request, callback func(mm []slack.Message, isLast bool) error) error {
 	ctx, task := trace.NewTask(ctx, "channel")
 	defer task.End()

--- a/stream/mock_stream/mock_stream.go
+++ b/stream/mock_stream/mock_stream.go
@@ -119,6 +119,23 @@ func (mr *MockSlackerMockRecorder) GetConversationsContext(ctx, params any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConversationsContext", reflect.TypeOf((*MockSlacker)(nil).GetConversationsContext), ctx, params)
 }
 
+// GetFileInfoContext mocks base method.
+func (m *MockSlacker) GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFileInfoContext", ctx, fileID, count, page)
+	ret0, _ := ret[0].(*slack.File)
+	ret1, _ := ret[1].([]slack.Comment)
+	ret2, _ := ret[2].(*slack.Paging)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// GetFileInfoContext indicates an expected call of GetFileInfoContext.
+func (mr *MockSlackerMockRecorder) GetFileInfoContext(ctx, fileID, count, page any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileInfoContext", reflect.TypeOf((*MockSlacker)(nil).GetFileInfoContext), ctx, fileID, count, page)
+}
+
 // GetStarredContext mocks base method.
 func (m *MockSlacker) GetStarredContext(ctx context.Context, params slack.StarsParameters) ([]slack.StarredItem, *slack.Paging, error) {
 	m.ctrl.T.Helper()

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -47,6 +47,7 @@ type Slacker interface {
 
 	SearchMessagesContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchMessages, error)
 	SearchFilesContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchFiles, error)
+	GetFileInfoContext(ctx context.Context, fileID string, count int, page int) (*slack.File, []slack.Comment, *slack.Paging, error)
 }
 
 // Stream is used to fetch conversations from Slack.  It is safe for concurrent

--- a/stream/stream_workers_test.go
+++ b/stream/stream_workers_test.go
@@ -1,0 +1,118 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rusq/slack"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/rusq/slackdump/v3/internal/fixtures"
+	"github.com/rusq/slackdump/v3/mocks/mock_processor"
+	"github.com/rusq/slackdump/v3/stream/mock_stream"
+)
+
+func TestStream_canvas(t *testing.T) {
+	testChannel := fixtures.Load[[]*slack.Channel](fixtures.TestChannels)[0]
+	type args struct {
+		ctx context.Context
+		// proc    processor.Conversations
+		channel *slack.Channel
+		fileId  string
+	}
+	tests := []struct {
+		name     string
+		fields   *Stream
+		args     args
+		expectFn func(ms *mock_stream.MockSlacker, mc *mock_processor.MockConversations)
+		wantErr  bool
+	}{
+		{
+			name:   "file ID is empty",
+			fields: &Stream{},
+			args: args{
+				ctx:     context.Background(),
+				channel: &slack.Channel{},
+				fileId:  "",
+			},
+			wantErr: false,
+		},
+		{
+			name:   "getfileinfocontext returns an error",
+			fields: &Stream{},
+			args: args{
+				ctx:    context.Background(),
+				fileId: "F123456",
+			},
+			expectFn: func(ms *mock_stream.MockSlacker, mc *mock_processor.MockConversations) {
+				ms.EXPECT().GetFileInfoContext(gomock.Any(), "F123456", 0, 1).Return(nil, nil, nil, errors.New("getfileinfocontext error"))
+			},
+			wantErr: true,
+		},
+		{
+			name:   "file not found",
+			fields: &Stream{},
+			args: args{
+				ctx:    context.Background(),
+				fileId: "F123456",
+			},
+			expectFn: func(ms *mock_stream.MockSlacker, mc *mock_processor.MockConversations) {
+				ms.EXPECT().GetFileInfoContext(gomock.Any(), "F123456", 0, 1).Return(nil, nil, nil, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name:   "success",
+			fields: &Stream{},
+			args: args{
+				ctx:     context.Background(),
+				channel: testChannel,
+				fileId:  "F123456",
+			},
+			expectFn: func(ms *mock_stream.MockSlacker, mc *mock_processor.MockConversations) {
+				ms.EXPECT().
+					GetFileInfoContext(gomock.Any(), "F123456", 0, 1).
+					Return(&slack.File{ID: "F123456"}, nil, nil, nil)
+				mc.EXPECT().
+					Files(gomock.Any(), testChannel, slack.Message{}, []slack.File{{ID: "F123456"}}).
+					Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:   "processor returns an error",
+			fields: &Stream{},
+			args: args{
+				ctx:     context.Background(),
+				channel: testChannel,
+				fileId:  "F123456",
+			},
+			expectFn: func(ms *mock_stream.MockSlacker, mc *mock_processor.MockConversations) {
+				ms.EXPECT().
+					GetFileInfoContext(gomock.Any(), "F123456", 0, 1).
+					Return(&slack.File{ID: "F123456"}, nil, nil, nil)
+				mc.EXPECT().
+					Files(gomock.Any(), testChannel, slack.Message{}, []slack.File{{ID: "F123456"}}).
+					Return(assert.AnError)
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ms := mock_stream.NewMockSlacker(ctrl)
+			mc := mock_processor.NewMockConversations(ctrl)
+			if tt.expectFn != nil {
+				tt.expectFn(ms, mc)
+			}
+			cs := tt.fields
+			cs.client = ms
+			if err := cs.canvas(tt.args.ctx, mc, tt.args.channel, tt.args.fileId); (err != nil) != tt.wantErr {
+				t.Errorf("Stream.canvas() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- **Channel canvas support**
- **add canvas test**

Canvases are treated as files.  If the canvas is found in
`channel.properties.canvas`, it is passed to file processor.

Slack returns canvases as HTML documents.

Fixes #225 
