### PR TITLE
add a flag to record file chunks in archives

### DIFF
--- a/cmd/slackdump/internal/archive/archive.go
+++ b/cmd/slackdump/internal/archive/archive.go
@@ -77,14 +77,14 @@ func RunArchive(ctx context.Context, cmd *base.Command, args []string) error {
 		lg,
 	)
 	defer stop()
-	// we are using the same file subprocessor as the mattermost export.
+	// archive format has files stored in mattermost format.
 	subproc := fileproc.NewExport(fileproc.STmattermost, dl)
 	ctrl := control.New(
 		cd,
 		stream,
 		control.WithLogger(lg),
 		control.WithFiler(subproc),
-		control.WithFlags(control.Flags{MemberOnly: cfg.MemberOnly}),
+		control.WithFlags(control.Flags{MemberOnly: cfg.MemberOnly, RecordFiles: cfg.RecordFiles}),
 	)
 	if err := ctrl.Run(ctx, list); err != nil {
 		base.SetExitStatus(base.SApplicationError)

--- a/cmd/slackdump/internal/archive/archive_wizard.go
+++ b/cmd/slackdump/internal/archive/archive_wizard.go
@@ -3,11 +3,9 @@ package archive
 import (
 	"context"
 
-	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/cfgui"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/dumpui"
-	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/updaters"
 	"github.com/rusq/slackdump/v3/internal/structures"
 )
 
@@ -35,13 +33,8 @@ func configuration() cfgui.Configuration {
 			Name: "Optional parameters",
 			Params: []cfgui.Parameter{
 				cfgui.ChannelIDs(&entryList, false),
-				{
-					Name:        "Member Only",
-					Value:       cfgui.Checkbox(cfg.MemberOnly),
-					Description: "Export only channels, which current user belongs to",
-					Inline:      true,
-					Updater:     updaters.NewBool(&cfg.MemberOnly),
-				},
+				cfgui.MemberOnly(),
+				cfgui.RecordFiles(),
 			},
 		},
 	}

--- a/cmd/slackdump/internal/archive/search.go
+++ b/cmd/slackdump/internal/archive/search.go
@@ -43,7 +43,7 @@ var cmdSearchMessages = &base.Command{
 	Short:       "records search results matching the given query",
 	Long:        `Searches for messages matching criteria.`,
 	RequireAuth: true,
-	FlagMask:    flagMask,
+	FlagMask:    flagMask | cfg.OmitRecordFilesFlag,
 	Run:         runSearchMsg,
 	PrintFlags:  true,
 }
@@ -175,7 +175,7 @@ func initController(ctx context.Context, args []string) (*control.Controller, fu
 	var (
 		subproc = fileproc.NewExport(fileproc.STmattermost, dl)
 		stream  = sess.Stream(sopts...)
-		ctrl    = control.New(cd, stream, control.WithLogger(lg), control.WithFiler(subproc))
+		ctrl    = control.New(cd, stream, control.WithLogger(lg), control.WithFiler(subproc), control.WithFlags(control.Flags{RecordFiles: cfg.RecordFiles}))
 	)
 	return ctrl, stop, nil
 }

--- a/cmd/slackdump/internal/archive/search_wizard.go
+++ b/cmd/slackdump/internal/archive/search_wizard.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
+
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/cfgui"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/dumpui"
@@ -84,6 +85,7 @@ func searchCfg() cfgui.Configuration {
 						}
 					}, &action).Title("Search Scope")),
 				},
+				cfgui.RecordFiles(),
 			},
 		},
 	}

--- a/cmd/slackdump/internal/cfg/cfg.go
+++ b/cmd/slackdump/internal/cfg/cfg.go
@@ -123,9 +123,9 @@ func SetBaseFlags(fs *flag.FlagSet, mask FlagMask) {
 		fs.BoolVar(&LoadSecrets, "load-env", false, "load secrets from the .env, .env.txt or secrets.txt file")
 	}
 	if mask&OmitDownloadFlag == 0 {
-		fs.BoolVar(&DownloadFiles, "files", true, "enables file attachments (to disable, specify: -files=false)")
+		fs.BoolVar(&DownloadFiles, "files", true, "enables file attachments download (to disable, specify: -files=false)")
 	}
-	if mask&OmitRecordFilesFlag == 0 {
+	if mask&OmitRecordFilesFlag == 0 && mask&OmitDownloadFlag == 0 {
 		fs.BoolVar(&RecordFiles, "files-rec", false, "include file chunks in chunk files")
 	}
 	if mask&OmitConfigFlag == 0 {

--- a/cmd/slackdump/internal/cfg/cfg.go
+++ b/cmd/slackdump/internal/cfg/cfg.go
@@ -42,6 +42,7 @@ var (
 
 	MemberOnly    bool
 	DownloadFiles bool
+	RecordFiles   bool // record file chunks in chunk files.
 
 	// Oldest is the default timestamp of the oldest message to fetch, that is
 	// used by the dump and export commands.
@@ -88,6 +89,7 @@ const (
 	OmitTimeframeFlag
 	OmitChunkCacheFlag
 	OmitMemberOnlyFlag
+	OmitRecordFilesFlag
 
 	OmitAll = OmitConfigFlag |
 		OmitDownloadFlag |
@@ -98,7 +100,8 @@ const (
 		OmitUserCacheFlag |
 		OmitTimeframeFlag |
 		OmitChunkCacheFlag |
-		OmitMemberOnlyFlag
+		OmitMemberOnlyFlag |
+		OmitRecordFilesFlag
 )
 
 // SetBaseFlags sets base flags
@@ -121,6 +124,9 @@ func SetBaseFlags(fs *flag.FlagSet, mask FlagMask) {
 	}
 	if mask&OmitDownloadFlag == 0 {
 		fs.BoolVar(&DownloadFiles, "files", true, "enables file attachments (to disable, specify: -files=false)")
+	}
+	if mask&OmitRecordFilesFlag == 0 {
+		fs.BoolVar(&RecordFiles, "files-rec", false, "include file chunks in chunk files")
 	}
 	if mask&OmitConfigFlag == 0 {
 		fs.StringVar(&ConfigFile, "api-config", "", "configuration `file` with Slack API limits overrides.\nYou can generate one with default values with 'slackdump config new`")

--- a/cmd/slackdump/internal/dump/dump.go
+++ b/cmd/slackdump/internal/dump/dump.go
@@ -38,7 +38,7 @@ var CmdDump = &base.Command{
 	Long:        dumpMd,
 	RequireAuth: true,
 	PrintFlags:  true,
-	FlagMask:    cfg.OmitMemberOnlyFlag,
+	FlagMask:    cfg.OmitMemberOnlyFlag | cfg.OmitRecordFilesFlag,
 }
 
 func init() {

--- a/cmd/slackdump/internal/export/export.go
+++ b/cmd/slackdump/internal/export/export.go
@@ -23,7 +23,7 @@ var CmdExport = &base.Command{
 	Wizard:      nil,
 	UsageLine:   "slackdump export",
 	Short:       "exports the Slack Workspace or individual conversations",
-	FlagMask:    cfg.OmitUserCacheFlag,
+	FlagMask:    cfg.OmitUserCacheFlag | cfg.OmitRecordFilesFlag,
 	Long:        mdExport, // TODO: add long description
 	CustomFlags: false,
 	PrintFlags:  true,

--- a/cmd/slackdump/internal/export/v3.go
+++ b/cmd/slackdump/internal/export/v3.go
@@ -71,7 +71,8 @@ func export(ctx context.Context, sess *slackdump.Session, fsa fsadapter.FS, list
 	)
 
 	flags := control.Flags{
-		MemberOnly: cfg.MemberOnly,
+		MemberOnly:  cfg.MemberOnly,
+		RecordFiles: false, // archive format is transitory, don't need extra info.
 	}
 	ctr := control.New(
 		chunkdir,

--- a/cmd/slackdump/internal/export/wizard.go
+++ b/cmd/slackdump/internal/export/wizard.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/charmbracelet/huh"
 
-	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/cfgui"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/dumpui"
@@ -51,13 +50,7 @@ func (fl *exportFlags) configuration() cfgui.Configuration {
 							huh.NewOption("Disable", fileproc.STnone),
 						)),
 				},
-				{
-					Name:        "Member Only",
-					Value:       cfgui.Checkbox(cfg.MemberOnly),
-					Description: "Export only channels, which current user belongs to",
-					Inline:      true,
-					Updater:     updaters.NewBool(&cfg.MemberOnly),
-				},
+				cfgui.MemberOnly(),
 				{
 					Name:        "Export Token",
 					Value:       fl.ExportToken,

--- a/cmd/slackdump/internal/ui/cfgui/common_params.go
+++ b/cmd/slackdump/internal/ui/cfgui/common_params.go
@@ -1,6 +1,7 @@
 package cfgui
 
 import (
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/updaters"
 	"github.com/rusq/slackdump/v3/internal/structures"
 )
@@ -20,5 +21,25 @@ func ChannelIDs(v *string, required bool) Parameter {
 		Description: descr,
 		Inline:      true,
 		Updater:     updaters.NewString(v, "", false, structures.ValidateEntityList),
+	}
+}
+
+// MemberOnly returns a checkbox parameter for Member Only flag.
+func MemberOnly() Parameter {
+	return Parameter{
+		Name:        "Member Only",
+		Value:       Checkbox(cfg.MemberOnly),
+		Description: "Export only channels, which current user belongs to",
+		Updater:     updaters.NewBool(&cfg.MemberOnly),
+	}
+}
+
+// RecordFiles returns a checkbox parameter for Record Files flag.
+func RecordFiles() Parameter {
+	return Parameter{
+		Name:        "Record Files",
+		Value:       Checkbox(cfg.RecordFiles),
+		Description: "Record file chunks in chunk files",
+		Updater:     updaters.NewBool(&cfg.RecordFiles),
 	}
 }

--- a/internal/chunk/control/control.go
+++ b/internal/chunk/control/control.go
@@ -93,7 +93,8 @@ func New(cd *chunk.Directory, s Streamer, opts ...Option) *Controller {
 
 // Flags are the controller flags.
 type Flags struct {
-	MemberOnly bool
+	MemberOnly  bool
+	RecordFiles bool
 }
 
 // Error is a controller error.
@@ -174,7 +175,7 @@ func (c *Controller) Run(ctx context.Context, list *structures.EntityList) error
 	}
 	// conversations goroutine
 	{
-		conv, err := dirproc.NewConversation(c.cd, c.filer, c.tf)
+		conv, err := dirproc.NewConversation(c.cd, c.filer, c.tf, dirproc.WithRecordFiles(c.flags.RecordFiles))
 		if err != nil {
 			return fmt.Errorf("error initialising conversation processor: %w", err)
 		}

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/rusq/slack"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
+
+	"github.com/rusq/slackdump/v3/internal/fixtures"
 )
 
 const (
@@ -189,6 +191,7 @@ func TestWithRetry(t *testing.T) {
 	}
 	// setting fast wait function
 	t.Run("500 error handling", func(t *testing.T) {
+		fixtures.SkipOnWindows(t)
 		setWaitFunc(func(attempt int) time.Duration { return 50 * time.Millisecond })
 		t.Cleanup(func() { setWaitFunc(cubicWait) })
 

--- a/internal/viewer/source/export_test.go
+++ b/internal/viewer/source/export_test.go
@@ -120,6 +120,7 @@ func TestExport_AllMessages(t *testing.T) {
 func Test_buildFileIndex(t *testing.T) {
 	testpath := filepath.Join("..", "..", "..", "tmp", "stdexport")
 	fixtures.SkipIfNotExist(t, testpath)
+	fixtures.SkipInCI(t)
 
 	type args struct {
 		fsys fs.FS


### PR DESCRIPTION
- Add a -files-rec flag that allows to record file chunks in the archive.  This is generally not required, as the files are retained in the messages within message chunks.  Adding this for completeness.