### PR TITLE
Change the default listener address for viewer

### DIFF
--- a/cmd/slackdump/internal/view/view.go
+++ b/cmd/slackdump/internal/view/view.go
@@ -37,7 +37,7 @@ var CmdView = &base.Command{
 var listenAddr string
 
 func init() {
-	CmdView.Flag.StringVar(&listenAddr, "listen", "localhost:8080", "address to listen on")
+	CmdView.Flag.StringVar(&listenAddr, "listen", "127.0.0.1:8080", "address to listen on")
 }
 
 func RunView(ctx context.Context, cmd *base.Command, args []string) error {


### PR DESCRIPTION
- On some machines Chrome was expecting https on localhost.

Fixes #405, only-thread view support will be done separately.