### PR TITLE
Fix for API not returning the whole thread, just the parent

### DIFF
--- a/cmd/slackdump/internal/cfg/cfg_test.go
+++ b/cmd/slackdump/internal/cfg/cfg_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rusq/slackdump/v3/auth/browser"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/rusq/slackdump/v3/auth/browser"
 )
 
 func TestSetBaseFlags(t *testing.T) {
@@ -100,8 +101,8 @@ func TestSetBaseFlags(t *testing.T) {
 		if !NoChunkCache {
 			t.Error("Expected NoChunkCache to be true, got false")
 		}
-		if Oldest.String() != "2022-01-01T00:00:00" {
-			t.Errorf("Expected Oldest to be '2022-01-01T00:00:00Z', got '%s'", Oldest.String())
+		if Oldest.String() != "2022-01-01" {
+			t.Errorf("Expected Oldest to be '2022-01-01', got '%s'", Oldest.String())
 		}
 		if Latest.String() != "2022-01-31T23:59:59" {
 			t.Errorf("Expected Latest to be '2022-01-31T23:59:59Z', got '%s'", Latest.String())

--- a/cmd/slackdump/internal/cfg/timevalue.go
+++ b/cmd/slackdump/internal/cfg/timevalue.go
@@ -3,9 +3,9 @@ package cfg
 import (
 	"flag"
 	"time"
-)
 
-const TimeLayout = "2006-01-02T15:04:05"
+	"github.com/rusq/slackdump/v3/internal/structures"
+)
 
 // TimeValue satisfies flag.Value, used for command line parsing.
 type TimeValue time.Time
@@ -13,10 +13,14 @@ type TimeValue time.Time
 var _ flag.Value = &TimeValue{}
 
 func (tv TimeValue) String() string {
-	if time.Time(tv).IsZero() {
+	t := time.Time(tv)
+	if t.IsZero() {
 		return ""
 	}
-	return time.Time(tv).Format(TimeLayout)
+	if t.Truncate(24 * time.Hour).Equal(t) {
+		return t.Format(structures.DateLayout)
+	}
+	return t.Format(structures.TimeLayout)
 }
 
 func (tv *TimeValue) Set(s string) error {
@@ -24,7 +28,7 @@ func (tv *TimeValue) Set(s string) error {
 		*tv = TimeValue(time.Time{})
 		return nil
 	}
-	if t, err := time.Parse(TimeLayout, s); err != nil {
+	if t, err := structures.TimeParse(s); err != nil {
 		return err
 	} else {
 		*tv = TimeValue(t)

--- a/cmd/slackdump/internal/cfg/timevalue_test.go
+++ b/cmd/slackdump/internal/cfg/timevalue_test.go
@@ -44,6 +44,13 @@ func TestTimeValue_Set(t *testing.T) {
 			tv(time.Time{}),
 			true,
 		},
+		{
+			"date value",
+			&TimeValue{},
+			args{"2009-09-16"},
+			tv(time.Date(2009, 9, 16, 0, 0, 0, 0, time.UTC)),
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,6 +78,11 @@ func TestTimeValue_String(t *testing.T) {
 			"valid value",
 			tv(time.Date(2009, 9, 16, 20, 30, 40, 0, time.UTC)),
 			"2009-09-16T20:30:40",
+		},
+		{
+			"round date",
+			tv(time.Date(2009, 9, 16, 0, 0, 0, 0, time.UTC)),
+			"2009-09-16",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/chunk/dirproc/conversations.go
+++ b/internal/chunk/dirproc/conversations.go
@@ -130,7 +130,7 @@ func (cv *Conversations) Messages(ctx context.Context, channelID string, numThre
 	ctx, task := trace.NewTask(ctx, "Messages")
 	defer task.End()
 
-	lg := cv.lg.With("in", "Messages", "channel_id", channelID, "num_threads", numThreads, "is_last", isLast, "len_messages", len(mm))
+	lg := cv.lg.With("in", "dirproc.Messages", "channel_id", channelID, "num_threads", numThreads, "is_last", isLast, "len_messages", len(mm))
 	lg.Debug("started")
 	cv.debugtrace(ctx, "%s: Messages: numThreads=%d, isLast=%t, len(mm)=%d", channelID, numThreads, isLast, len(mm))
 
@@ -177,8 +177,8 @@ func (cv *Conversations) ThreadMessages(ctx context.Context, channelID string, p
 	}
 	if isLast {
 		n := r.Dec()
-		lg.DebugContext(ctx, "count decreased, finalising", "by", 1, "current", n)
-		cv.debugtrace(ctx, "%s:%s: ThreadMessages: decreased by 1 to %d, finalising", id, parent.Timestamp, n)
+		lg.DebugContext(ctx, "count decreased", "by", 1, "current", n)
+		cv.debugtrace(ctx, "%s:%s: ThreadMessages: decreased by 1 to %d", id, parent.Timestamp, n)
 		return cv.finalise(ctx, id)
 	}
 	return nil

--- a/internal/chunk/file.go
+++ b/internal/chunk/file.go
@@ -126,7 +126,7 @@ func indexChunks(dec decoder) (index, error) {
 		idx[id] = append(idx[id], offset)
 	}
 
-	slog.Default().Debug("indexing chunks", "len(idx)", len(idx), "caller", osext.Caller(2), "took", time.Since(start).String(), "took", float64(len(idx))/time.Since(start).Seconds())
+	slog.Default().Debug("indexing chunks", "len(idx)", len(idx), "caller", osext.Caller(2), "took", time.Since(start).String(), "per_sec", float64(len(idx))/time.Since(start).Seconds())
 	return idx, nil
 }
 

--- a/internal/structures/entity_list.go
+++ b/internal/structures/entity_list.go
@@ -18,7 +18,8 @@ const (
 	excludePrefix = "^"
 	filePrefix    = "@"
 	timeSeparator = ","
-	timeFmt       = "2006-01-02T15:04:05"
+	TimeLayout    = "2006-01-02T15:04:05"
+	DateLayout    = time.DateOnly
 
 	// maxFileEntries is the maximum non-empty entries that will be read
 	// from the file.
@@ -45,11 +46,11 @@ func (ei *EntityItem) String() string {
 	sb.WriteString(ei.Id)
 	if !ei.Oldest.IsZero() {
 		sb.WriteString(timeSeparator)
-		sb.WriteString(ei.Oldest.Format(timeFmt))
+		sb.WriteString(ei.Oldest.Format(TimeLayout))
 	}
 	if !ei.Latest.IsZero() {
 		sb.WriteString(timeSeparator)
-		sb.WriteString(ei.Latest.Format(timeFmt))
+		sb.WriteString(ei.Latest.Format(TimeLayout))
 	}
 	return sb.String()
 }
@@ -214,10 +215,10 @@ func (el *EntityList) fromIndex(index map[string]bool) {
 			Include: include,
 		}
 		if len(parts) > 1 {
-			item.Oldest, _ = time.Parse(timeFmt, parts[1])
+			item.Oldest, _ = TimeParse(parts[1])
 		}
 		if len(parts) == 3 {
-			item.Latest, _ = time.Parse(timeFmt, parts[2])
+			item.Latest, _ = TimeParse(parts[2])
 		}
 
 		el.index[item.Id] = item
@@ -227,6 +228,15 @@ func (el *EntityList) fromIndex(index map[string]bool) {
 			el.hasExcludes = true
 		}
 	}
+}
+
+// TimeParse parses a string that can be either a date in 2006-01-02 layout or
+// time in 2006-01-02T15:04:05 layout.
+func TimeParse(s string) (t time.Time, err error) {
+	if t, err = time.Parse(TimeLayout, s); err == nil {
+		return
+	}
+	return time.Parse(DateLayout, s)
 }
 
 // Index returns a map where key is entity, and value show if the entity

--- a/internal/structures/entity_list_test.go
+++ b/internal/structures/entity_list_test.go
@@ -873,3 +873,52 @@ func TestNewEntityListFromItems(t *testing.T) {
 		})
 	}
 }
+
+func TestTimeParse(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantT   time.Time
+		wantErr bool
+	}{
+		{
+			"empty",
+			args{""},
+			time.Time{},
+			true,
+		},
+		{
+			"bad",
+			args{"bad"},
+			time.Time{},
+			true,
+		},
+		{
+			"ok",
+			args{"2024-01-10T23:02:12"},
+			time.Date(2024, time.January, 10, 23, 2, 12, 0, time.UTC),
+			false,
+		},
+		{
+			"ok",
+			args{"2024-01-10"},
+			time.Date(2024, time.January, 10, 0, 0, 0, 0, time.UTC),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotT, err := TimeParse(tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TimeParse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotT, tt.wantT) {
+				t.Errorf("TimeParse() = %v, want %v", gotT, tt.wantT)
+			}
+		})
+	}
+}

--- a/slackdump.1
+++ b/slackdump.1
@@ -181,14 +181,14 @@ Disables caching of chunks for the
 .Cm convert
 command.  This may be useful on small archives.  For big archives caching is
 beneficial, as it allows to reduce the processing time.
-.It Fl time-from Ar YYYY-MM-DDTHH:MI:SS
+.It Fl time-from Ar YYYY-MM-DDTHH:MI:SS | YYYY-MM-DD
 Allows to specify the start time.  The time is specified in the format
-.Dq YYYY-MM-DDTHH:MI:SS
+.Dq YYYY-MM-DDTHH:MI:SS, or YYYY-MM-DD if only the date is needed.
 where
 .Sq T
 is a literal character separating the date and time, for example
 .Dq 2020-12-311T23:59:59
-.It Fl time-to Ar YYYY-MM-DDTHH:MI:SS
+.It Fl time-to Ar YYYY-MM-DDTHH:MI:SS | YYYY-MM-DD
 Allows to specify the end time.  See the
 .Fl time-from
 flag for the format.

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -316,12 +316,12 @@ func procChanMsg(ctx context.Context, proc processor.Conversations, threadC chan
 func procThreadMsg(ctx context.Context, proc processor.Conversations, channel *slack.Channel, threadTS string, threadOnly bool, isLast bool, msgs []slack.Message) error {
 	lg := slog.With("channel_id", channel.ID, "thread_ts", threadTS, "is_last", isLast, "msg_count", len(msgs))
 	if len(msgs) == 0 {
-		lg.Debug("empty thread messages")
+		lg.Debug("empty thread messages, ignoring")
 		return nil
 	}
 	// slack returns the thread starter as the first message with every
 	// call, so we use it as a head message.
-	head, rest := msgs[0], []slack.Message{}
+	parent, rest := msgs[0], []slack.Message{}
 	if len(msgs) > 1 {
 		rest = msgs[1:]
 	}
@@ -329,8 +329,8 @@ func procThreadMsg(ctx context.Context, proc processor.Conversations, channel *s
 	if err := procFiles(ctx, proc, channel, rest...); err != nil {
 		return err
 	}
-	if err := proc.ThreadMessages(ctx, channel.ID, head, threadOnly, isLast, rest); err != nil {
-		return fmt.Errorf("failed to process thread message id=%s, thread_ts=%s: %w", head.Timestamp, threadTS, err)
+	if err := proc.ThreadMessages(ctx, channel.ID, parent, threadOnly, isLast, rest); err != nil {
+		return fmt.Errorf("failed to process thread message id=%s, thread_ts=%s: %w", parent.Timestamp, threadTS, err)
 	}
 	return nil
 }

--- a/stream/conversation_test.go
+++ b/stream/conversation_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/rusq/slack"
-	"github.com/rusq/slackdump/v3/internal/fixtures"
-	"github.com/rusq/slackdump/v3/mocks/mock_processor"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+
+	"github.com/rusq/slackdump/v3/internal/fixtures"
+	"github.com/rusq/slackdump/v3/mocks/mock_processor"
 )
 
 var TestChannel = &slack.Channel{
@@ -127,6 +128,194 @@ func Test_procChanMsg(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("procChanMsg() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func stuffProcWithFiles(mp *mock_processor.MockConversations, ch *slack.Channel, mm []slack.Message) {
+	for _, m := range mm {
+		if len(m.Files) > 0 {
+			mp.EXPECT().Files(gomock.Any(), ch, m, m.Files).Times(1)
+		}
+	}
+}
+
+func Test_procThreadMsg(t *testing.T) {
+	testMessages := fixtures.Load[[]slack.Message](fixtures.TestChannelEveryoneMessagesNativeExport)
+	type args struct {
+		ctx context.Context
+		// proc       processor.Conversations // supplied by test
+		channel    *slack.Channel
+		threadTS   string
+		threadOnly bool
+		isLast     bool
+		msgs       []slack.Message
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expectFn func(mp *mock_processor.MockConversations)
+		wantErr  bool
+	}{
+		{
+			"empty messages slice",
+			args{
+				context.Background(),
+				TestChannel,
+				"123456.789",
+				false,
+				true,
+				[]slack.Message{},
+			},
+			nil,
+			false,
+		},
+		{
+			"one message",
+			args{
+				context.Background(),
+				TestChannel,
+				"123456.789",
+				false,
+				true,
+				testMessages[0:1],
+			},
+			func(mp *mock_processor.MockConversations) {
+				mp.EXPECT().ThreadMessages(gomock.Any(), TestChannel.ID, testMessages[0], false, true, []slack.Message{}).Times(1)
+			},
+			false,
+		},
+		{
+			"all test messages",
+			args{
+				context.Background(),
+				TestChannel,
+				"123456.789",
+				false,
+				false,
+				testMessages,
+			},
+			func(mp *mock_processor.MockConversations) {
+				stuffProcWithFiles(mp, TestChannel, testMessages)
+				mp.EXPECT().ThreadMessages(gomock.Any(), TestChannel.ID, testMessages[0], false, false, testMessages[1:]).Times(1)
+			},
+			false,
+		},
+		{
+			"all test messages, files processor error",
+			args{
+				context.Background(),
+				TestChannel,
+				"123456.789",
+				false,
+				false,
+				testMessages,
+			},
+			func(mp *mock_processor.MockConversations) {
+				for _, m := range testMessages[1:] {
+					if len(m.Files) > 0 {
+						mp.EXPECT().Files(gomock.Any(), TestChannel, m, m.Files).Return(assert.AnError).Times(1)
+						break
+					}
+				}
+			},
+			true,
+		},
+		{
+			"all test messages, thread messages processor error",
+			args{
+				context.Background(),
+				TestChannel,
+				"123456.789",
+				false,
+				false,
+				testMessages,
+			},
+			func(mp *mock_processor.MockConversations) {
+				stuffProcWithFiles(mp, TestChannel, testMessages)
+				mp.EXPECT().ThreadMessages(gomock.Any(), TestChannel.ID, testMessages[0], false, false, testMessages[1:]).Return(assert.AnError).Times(1)
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mp := mock_processor.NewMockConversations(ctrl)
+			if tt.expectFn != nil {
+				tt.expectFn(mp)
+			}
+			if err := procThreadMsg(tt.args.ctx, mp, tt.args.channel, tt.args.threadTS, tt.args.threadOnly, tt.args.isLast, tt.args.msgs); (err != nil) != tt.wantErr {
+				t.Errorf("procThreadMsg() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_procFiles(t *testing.T) {
+	testMessages := fixtures.Load[[]slack.Message](fixtures.TestChannelEveryoneMessagesNativeExport)
+	type args struct {
+		ctx context.Context
+		// proc    processor.Filer // supplied by test
+		channel *slack.Channel
+		msgs    []slack.Message
+	}
+	tests := []struct {
+		name    string
+		args    args
+		expect  func(mp *mock_processor.MockConversations)
+		wantErr bool
+	}{
+		{
+			"empty messages slice",
+			args{
+				context.Background(),
+				TestChannel,
+				[]slack.Message{},
+			},
+			nil,
+			false,
+		},
+		{
+			"all ok",
+			args{
+				context.Background(),
+				TestChannel,
+				testMessages,
+			},
+			func(mp *mock_processor.MockConversations) {
+				stuffProcWithFiles(mp, TestChannel, testMessages)
+			},
+			false,
+		},
+		{
+			"files processor error",
+			args{
+				context.Background(),
+				TestChannel,
+				testMessages,
+			},
+			func(mp *mock_processor.MockConversations) {
+				for _, m := range testMessages {
+					if len(m.Files) > 0 {
+						mp.EXPECT().Files(gomock.Any(), TestChannel, m, m.Files).Return(assert.AnError).Times(1)
+						break
+					}
+				}
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mp := mock_processor.NewMockConversations(ctrl)
+			if tt.expect != nil {
+				tt.expect(mp)
+			}
+			if err := procFiles(tt.args.ctx, mp, tt.args.channel, tt.args.msgs...); (err != nil) != tt.wantErr {
+				t.Errorf("procFiles() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/utils/hammer.sh
+++ b/utils/hammer.sh
@@ -1,7 +1,7 @@
 #!/bin/ksh
 
 ATTEMPTS=${ATTEMPTS:=50}
-CMD="export -machine-id 123 -files -avatars -time-from=2025-01-23T00:00:00 -time-to=2025-01-25T00:00:00"
+CMD="export -machine-id 123 -files -avatars -time-from=2025-01-23T00:00:00 -time-to=2025-02-25T00:00:00"
 echo Building current version...
 go build ./cmd/slackdump
 if [ $? != 0 ] ; then


### PR DESCRIPTION
- Fixes #428 
- Remove the need to type the whole Date Time when only date is specified, i.e. "2019-01-31" vs before one had to specify full date time: "2019-01-31T00:00:00"
- Add tests to stream callback functions (thread, files)