### PR TITLE
Undeprecate STD storage type

### DIFF
--- a/cmd/slackdump/internal/export/v3.go
+++ b/cmd/slackdump/internal/export/v3.go
@@ -54,9 +54,6 @@ func export(ctx context.Context, sess *slackdump.Session, fsa fsadapter.FS, list
 
 	// starting the downloader
 	dlEnabled := cfg.DownloadFiles && params.ExportStorageType != fileproc.STnone
-	if dlEnabled && params.ExportStorageType == fileproc.STstandard {
-		lg.WarnContext(ctx, "Standard storage type is deprecated, and will be removed in future.  Use Mattermost instead.")
-	}
 	fdl := fileproc.NewDownloader(ctx, dlEnabled, sess.Client(), fsa, lg)
 	fp := fileproc.NewExport(params.ExportStorageType, fdl)
 	avdl := fileproc.NewDownloader(ctx, cfg.DownloadAvatars, sess.Client(), fsa, lg)

--- a/internal/chunk/transform/fileproc/sp_export.go
+++ b/internal/chunk/transform/fileproc/sp_export.go
@@ -17,8 +17,6 @@ import (
 // NewExport initialises an export file subprocessor based on the given export
 // type.  This subprocessor can be later plugged into the
 // [expproc.Conversations] processor.
-//
-// Deprecated: use [New] instead.
 func NewExport(typ StorageType, dl Downloader) processor.Filer {
 	switch typ {
 	case STstandard:

--- a/internal/chunk/transform/fileproc/storagetype.go
+++ b/internal/chunk/transform/fileproc/storagetype.go
@@ -13,9 +13,6 @@ type StorageType uint8
 const (
 	STnone StorageType = iota
 	// STstandard is the storage type for the standard file storage.
-	//
-	// Deprecated: should be used only for reading existing archives.  For new
-	// use [STmattermost] instead.
 	STstandard
 	// STmattermost is the storage type for Mattermost.
 	STmattermost


### PR DESCRIPTION
Appears it's being used by slack-export-viewer, and maybe other tools, see #436.
