### PR TITLE
Courageously run as root, but warn.

### DIFF
--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -68,7 +68,7 @@ func init() {
 
 func main() {
 	if isRoot() {
-		log.Fatal("slackdump:  cowardly refusing to run as root")
+		slog.Warn("slackdump:  courageously running as root, hope you know what you're doing")
 	}
 
 	flag.Usage = base.Usage


### PR DESCRIPTION
In response to #415.

Running as a user in Docker introduces a lot of unnecessary complexity.
