### PR TITLE
Dumb terminal detection + add terminal info to diag output

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"runtime/trace"
 
@@ -129,11 +128,6 @@ func (s simpleProvider) Test(ctx context.Context) (*slack.AuthTestResponse, erro
 
 func (s simpleProvider) HTTPClient() (*http.Client, error) {
 	return chttp.New(SlackURL, s.Cookies())
-}
-
-func IsDocker() bool {
-	_, err := os.Stat("/.dockerenv")
-	return err == nil
 }
 
 func pleaseWait(ctx context.Context, msg string) func() {

--- a/auth/auth_ui/huh.go
+++ b/auth/auth_ui/huh.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/huh"
 	"github.com/rusq/slackauth"
+
 	"github.com/rusq/slackdump/v3/internal/structures"
 )
 
@@ -95,13 +96,13 @@ func init() {
 }
 
 func (*Huh) RequestLoginType(ctx context.Context, w io.Writer, workspace string) (LoginOpts, error) {
-	var ret = LoginOpts{
+	ret := LoginOpts{
 		Workspace:   workspace,
 		Type:        LInteractive,
 		BrowserPath: "",
 	}
 
-	var opts = make([]huh.Option[LoginType], 0, len(methods))
+	opts := make([]huh.Option[LoginType], 0, len(methods))
 	for _, m := range methods {
 		opts = append(opts, huh.NewOption(m.String(), m.Type))
 	}
@@ -173,7 +174,7 @@ func chooseBrowser(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var opts = make([]huh.Option[int], 0, len(browsers))
+	opts := make([]huh.Option[int], 0, len(browsers))
 	for i, b := range browsers {
 		opts = append(opts, huh.NewOption(b.Name, i))
 	}

--- a/auth/browser.go
+++ b/auth/browser.go
@@ -9,11 +9,14 @@ import (
 
 	"github.com/rusq/slackdump/v3/auth/auth_ui"
 	"github.com/rusq/slackdump/v3/auth/browser"
+	"github.com/rusq/slackdump/v3/internal/osext"
 	"github.com/rusq/slackdump/v3/internal/structures"
 )
 
-var _ Provider = PlaywrightAuth{}
-var defaultFlow = &auth_ui.Huh{}
+var (
+	_           Provider = PlaywrightAuth{}
+	defaultFlow          = &auth_ui.Huh{}
+)
 
 // PlaywrightAuth is the playwright browser authentication provider.
 //
@@ -39,7 +42,7 @@ type BrowserAuthUI interface {
 }
 
 func NewPlaywrightAuth(ctx context.Context, opts ...Option) (PlaywrightAuth, error) {
-	var br = PlaywrightAuth{
+	br := PlaywrightAuth{
 		opts: options{
 			playwrightOptions: playwrightOptions{
 				flow:         defaultFlow,
@@ -51,8 +54,8 @@ func NewPlaywrightAuth(ctx context.Context, opts ...Option) (PlaywrightAuth, err
 	for _, opt := range opts {
 		opt(&br.opts)
 	}
-	if IsDocker() {
-		return PlaywrightAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in docker, use token/cookie auth instead"}
+	if osext.IsDocker() || !osext.IsInteractive() {
+		return PlaywrightAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in docker or dumb terminals, use token/cookie auth instead"}
 	}
 
 	if br.opts.workspace == "" {

--- a/auth/rod.go
+++ b/auth/rod.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rusq/slackauth"
 
 	"github.com/rusq/slackdump/v3/auth/auth_ui"
+	"github.com/rusq/slackdump/v3/internal/osext"
 	"github.com/rusq/slackdump/v3/internal/structures"
 )
 
@@ -76,6 +77,9 @@ type browserAuthUIExt interface {
 
 // NewRODAuth constructs new RodAuth provider.
 func NewRODAuth(ctx context.Context, opts ...Option) (RodAuth, error) {
+	if osext.IsDocker() || !osext.IsInteractive() {
+		return RodAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in dumb terminals, use token/cookie auth instead"}
+	}
 	r := RodAuth{
 		opts: options{
 			rodOpts: rodOpts{

--- a/cmd/slackdump/internal/diag/info.go
+++ b/cmd/slackdump/internal/diag/info.go
@@ -13,10 +13,10 @@ import (
 
 // cmdInfo is the information command.
 var cmdInfo = &base.Command{
-	UsageLine:  "slackdump tools info",
+	UsageLine:  "slackdump tools info [flags]",
 	Short:      "show information about Slackdump environment",
 	Run:        runInfo,
-	FlagMask:   cfg.OmitAll,
+	FlagMask:   cfg.OmitAll &^ cfg.OmitCacheDir,
 	PrintFlags: true,
 
 	Long: `# Info Command

--- a/cmd/slackdump/internal/diag/info/os.go
+++ b/cmd/slackdump/internal/diag/info/os.go
@@ -4,19 +4,21 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/rusq/slackdump/v3/auth"
+	"github.com/rusq/slackdump/v3/internal/osext"
 )
 
 type OSInfo struct {
-	OS        string `json:"os"`
-	Arch      string `json:"arch"`
-	IsDocker  bool   `json:"is_docker"`
-	IsXactive bool   `json:"is_x_active"`
+	OS            string `json:"os"`
+	Arch          string `json:"arch"`
+	IsDocker      bool   `json:"is_docker"`
+	IsXactive     bool   `json:"is_x_active"`
+	IsInteractive bool   `json:"is_interactive"`
 }
 
 func (inf *OSInfo) collect(PathReplFunc) {
 	inf.OS = runtime.GOOS
 	inf.Arch = runtime.GOARCH
-	inf.IsDocker = auth.IsDocker()
+	inf.IsDocker = osext.IsDocker()
 	inf.IsXactive = os.Getenv("DISPLAY") != ""
+	inf.IsInteractive = osext.IsInteractive()
 }

--- a/cmd/slackdump/internal/format/format.go
+++ b/cmd/slackdump/internal/format/format.go
@@ -42,7 +42,7 @@ a human readable format.  The command takes the format type and the file to
 convert as arguments.
 `, // TODO: add more info
 	CustomFlags: false,
-	FlagMask:    cfg.OmitAll & ^cfg.OmitWorkspaceFlag,
+	FlagMask:    cfg.OmitAll &^ cfg.OmitWorkspaceFlag,
 	PrintFlags:  true,
 	RequireAuth: true,
 }

--- a/cmd/slackdump/internal/workspace/workspace.go
+++ b/cmd/slackdump/internal/workspace/workspace.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/workspace/workspaceui"
 	"github.com/rusq/slackdump/v3/internal/cache"
+	"github.com/rusq/slackdump/v3/internal/osext"
 )
 
 const baseCommand = "slackdump workspace"
@@ -177,6 +178,9 @@ func CurrentOrNewProviderCtx(ctx context.Context) (context.Context, error) {
 	prov, err := authCurrent(ctx, cachedir, cfg.Workspace, cfg.LegacyBrowser)
 	if err != nil {
 		if errors.Is(err, cache.ErrNoWorkspaces) {
+			if !osext.IsInteractive() {
+				return ctx, errors.New("running on dumb terminal, cannot create a new workspace")
+			}
 			// ask to create a new workspace
 			if err := showUI(ctx, workspaceui.WithQuickLogin(), workspaceui.WithTitle("No workspaces, please choose a login method")); err != nil {
 				return ctx, fmt.Errorf("auth error: %w", err)

--- a/cmd/slackdump/internal/workspace/workspace.go
+++ b/cmd/slackdump/internal/workspace/workspace.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/workspace/workspaceui"
 	"github.com/rusq/slackdump/v3/internal/cache"
-	"github.com/rusq/slackdump/v3/internal/osext"
 )
 
 const baseCommand = "slackdump workspace"
@@ -178,9 +177,6 @@ func CurrentOrNewProviderCtx(ctx context.Context) (context.Context, error) {
 	prov, err := authCurrent(ctx, cachedir, cfg.Workspace, cfg.LegacyBrowser)
 	if err != nil {
 		if errors.Is(err, cache.ErrNoWorkspaces) {
-			if !osext.IsInteractive() {
-				return ctx, errors.New("running on dumb terminal, cannot create a new workspace")
-			}
 			// ask to create a new workspace
 			if err := showUI(ctx, workspaceui.WithQuickLogin(), workspaceui.WithTitle("No workspaces, please choose a login method")); err != nil {
 				return ctx, fmt.Errorf("auth error: %w", err)

--- a/cmd/slackdump/internal/workspace/workspaceui/workspaceui.go
+++ b/cmd/slackdump/internal/workspace/workspaceui/workspaceui.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/cfgui"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/updaters"
 	"github.com/rusq/slackdump/v3/internal/cache"
+	"github.com/rusq/slackdump/v3/internal/osext"
 )
 
 //go:generate mockgen -package workspaceui -destination=test_mock_manager.go -source workspaceui.go manager
@@ -45,6 +46,9 @@ func WithQuickLogin() UIOption {
 // ShowUI shows the authentication menu.  If quicklogin is set to true,
 // it will quit after the user has successfully authenticated.
 func ShowUI(ctx context.Context, opts ...UIOption) error {
+	if !osext.IsInteractive() {
+		return errors.New("running on dumb terminal, cannot create a new workspace")
+	}
 	const (
 		actLogin       = "ezlogin"
 		actToken       = "token"

--- a/cmd/slackdump/main.go
+++ b/cmd/slackdump/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/joho/godotenv"
 	"github.com/rusq/tracer"
-	"golang.org/x/term"
 
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/apiconfig"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/archive"
@@ -34,6 +33,7 @@ import (
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/view"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/wizard"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/workspace"
+	"github.com/rusq/slackdump/v3/internal/osext"
 )
 
 func init() {
@@ -66,7 +66,7 @@ func init() {
 }
 
 func main() {
-	if isRoot() {
+	if osext.IsRoot() {
 		slog.Warn("slackdump:  courageously running as root, hope you know what you're doing")
 	}
 
@@ -75,7 +75,7 @@ func main() {
 
 	args := flag.Args()
 	if len(args) < 1 {
-		if !isInteractive() {
+		if !osext.IsInteractive() {
 			base.Usage()
 			// Usage terminates the program.
 		}
@@ -333,14 +333,4 @@ func whatDo() (choice, error) {
 		).Value(&ans))).WithTheme(ui.HuhTheme()).WithKeyMap(ui.DefaultHuhKeymap).Run()
 
 	return ans, err
-}
-
-// isInteractive returns true if the program is running in the interactive
-// terminal.
-func isInteractive() bool {
-	return term.IsTerminal(int(os.Stdout.Fd())) && term.IsTerminal(int(os.Stdin.Fd())) && os.Getenv("TERM") != "dumb"
-}
-
-func isRoot() bool {
-	return os.Geteuid() == 0
 }

--- a/internal/osext/osext.go
+++ b/internal/osext/osext.go
@@ -3,6 +3,7 @@ package osext
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -33,4 +34,10 @@ func Caller(steps int) string {
 		name = filepath.Base(runtime.FuncForPC(pc).Name())
 	}
 	return name
+}
+
+// IsDocker returns true if the process is running in a docker container.
+func IsDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
 }

--- a/internal/osext/terminal.go
+++ b/internal/osext/terminal.go
@@ -1,0 +1,13 @@
+package osext
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// isInteractive returns true if the program is running in the interactive
+// terminal.
+func IsInteractive() bool {
+	return term.IsTerminal(int(os.Stdout.Fd())) && term.IsTerminal(int(os.Stdin.Fd())) && os.Getenv("TERM") != "dumb"
+}

--- a/internal/osext/user.go
+++ b/internal/osext/user.go
@@ -1,0 +1,7 @@
+package osext
+
+import "os"
+
+func IsRoot() bool {
+	return os.Geteuid() == 0
+}


### PR DESCRIPTION
- tools info:
  - wire the -no-encryption and -machine-id flags to `tools info` to be able to test auth (-auth)
- move environment detection to osext and update references
- rod and playwright now refuse to run on dumb terminals
