### PR TITLE
download gifs as gifs

### DIFF
--- a/cmd/slackdump/internal/emoji/emoji.go
+++ b/cmd/slackdump/internal/emoji/emoji.go
@@ -29,7 +29,7 @@ var CmdEmoji = &base.Command{
 	UsageLine:   "slackdump emoji [flags]",
 	Short:       "download workspace emoticons ಠ_ಠ",
 	Long:        emojiMD,
-	FlagMask:    cfg.OmitAll &^ cfg.OmitAuthFlags,
+	FlagMask:    cfg.OmitAll &^ cfg.OmitAuthFlags &^ cfg.OmitOutputFlag,
 	RequireAuth: true,
 	PrintFlags:  true,
 }

--- a/cmd/slackdump/internal/emoji/emojidl/emoedge.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoedge.go
@@ -1,7 +1,7 @@
-// Package emojidl provides functions to dump the all slack emojis for a workspace.
-// It skips the "alias" emojis, so only original an emoji with an original name
-// is present. If you need to find the alias - lookup the index.json. The
-// directory structure is the following:
+// Package emojidl provides functions to dump the all slack emojis for a
+// workspace. It skips the "alias" emojis, so only original emoji with an
+// original name is present. If you need to find the alias - look it up in the
+// index.json. The directory structure is the following:
 //
 //	.
 //	+- emojis
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/rusq/fsadapter"
+
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/internal/edge"
 )
@@ -97,7 +98,7 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, failF
 		count = 0
 		total = <-totalC // if there's a generator error, this will receive 0.
 	)
-	var emojis = make(map[string]edge.Emoji, total)
+	emojis := make(map[string]edge.Emoji, total)
 LOOP:
 	for {
 		select {

--- a/cmd/slackdump/internal/emoji/emojidl/emoji.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoji.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 
 	"github.com/rusq/fsadapter"
+
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/internal/edge"
 )
@@ -54,7 +55,7 @@ func DlFS(ctx context.Context, sess EmojiDumper, fsa fsadapter.FS, failFast bool
 	if err != nil {
 		return fmt.Errorf("error marshalling emoji index: %w", err)
 	}
-	if err := fsa.WriteFile("index.json", bIndex, 0644); err != nil {
+	if err := fsa.WriteFile("index.json", bIndex, 0o644); err != nil {
 		return fmt.Errorf("failed writing emoji index: %w", err)
 	}
 
@@ -164,7 +165,8 @@ func fetchEmoji(ctx context.Context, fsa fsadapter.FS, dir string, name, uri str
 	}
 	defer resp.Body.Close()
 
-	filename := path.Join(dir, name+".png")
+	emojiExt := path.Ext(uri) // get the extension from the uri.
+	filename := path.Join(dir, name+emojiExt)
 	wc, err := fsa.Create(filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #452

- Download gifs as gifs, pngs as pngs.
- Output flag was omitted, restored.
