### PR TITLE
Fix typo in README.md: s/::/:/

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Run `slackdump help` to see all available options:
 
 ## Installation and Quickstart
 
-On macOS, you can install Slackdump with Homebrew::
+On macOS, you can install Slackdump with Homebrew:
 
 ```shell
 brew install slackdump


### PR DESCRIPTION
Fix a typo in `README.md` where there's an extra colon character.