### PR TITLE
Check for static folder relative to viewer module

### DIFF
--- a/internal/viewer/viewer.go
+++ b/internal/viewer/viewer.go
@@ -95,7 +95,7 @@ func New(ctx context.Context, addr string, r source.Sourcer) (*Viewer, error) {
 
 	mux := http.NewServeMux()
 
-	// Fetch our current directory in order to check for a static folder relative to this file
+	// Check for a static folder relative to this file
 	_, filename, _, _ := runtime.Caller(0)
 	currentDir := filepath.Dir(filename)
 	staticDir := filepath.Join(currentDir, "static")

--- a/internal/viewer/viewer.go
+++ b/internal/viewer/viewer.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/rusq/slackdump/v3/internal/source"
@@ -92,7 +94,13 @@ func New(ctx context.Context, addr string, r source.Sourcer) (*Viewer, error) {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
+
+	// Fetch our current directory in order to check for a static folder relative to this file
+	_, filename, _, _ := runtime.Caller(0)
+	currentDir := filepath.Dir(filename)
+	staticDir := filepath.Join(currentDir, "static")
+
+	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticDir))))
 	mux.HandleFunc("GET /", v.indexHandler)
 	// https: //ora600.slack.com/archives/CHY5HUESG
 	mux.HandleFunc("GET /archives/{id}", v.newFileHandler(v.channelHandler))


### PR DESCRIPTION
While there's a `/static/` path wired up in the viewer's HTTP server, it defaults to the root of the git repo(?) which is fairly unexpected.

The static folder may be used for #458 to serve eg; avatar placeholders but it's not immediately clear that will be the case.