### PR TITLE
Fix the callback function signature in unexpected EOF test

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
         types:
             - published
     push:
-        branches: [master]
+        branches: [master,v3.0.x]
 
 
 # reference:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
         types:
             - published
     push:
-        branches: [master,v3.0.x]
+        branches: [master, v3.0.x]
 
 
 # reference:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v3.0.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v3.0.x ]
 
 jobs:
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,9 +4,9 @@ name: Shellcheck
 
 on:
   push:
-    branches: [master]
+    branches: [master, v3.0.x]
   pull_request:
-    branches: [master]
+    branches: [master, v3.0.x]
 
 permissions:
   contents: read

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -304,7 +304,7 @@ func TestWithRetry(t *testing.T) {
 		var retries int
 
 		ctx := context.Background()
-		err := WithRetry(ctx, rate.NewLimiter(1, 1), 3, func(ctx context.Context) error {
+		err := WithRetry(ctx, rate.NewLimiter(1, 1), 3, func() error {
 			err := reterr[retries]
 			if err != nil {
 				retries++

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -303,6 +303,8 @@ func TestWithRetry(t *testing.T) {
 		reterr := []error{io.ErrUnexpectedEOF, io.ErrUnexpectedEOF, nil}
 		var retries int
 
+		// dummy line to trigger the build.
+
 		ctx := context.Background()
 		err := WithRetry(ctx, rate.NewLimiter(1, 1), 3, func() error {
 			err := reterr[retries]

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -302,9 +302,6 @@ func TestWithRetry(t *testing.T) {
 
 		reterr := []error{io.ErrUnexpectedEOF, io.ErrUnexpectedEOF, nil}
 		var retries int
-
-		// dummy line to trigger the build.
-
 		ctx := context.Background()
 		err := WithRetry(ctx, rate.NewLimiter(1, 1), 3, func() error {
 			err := reterr[retries]


### PR DESCRIPTION
Somehow this slipped through the CI tests - invalid function signature (from the future release) was committed into v3.0.x branch.

Fixes #471.