### PR TITLE
Universal formatter (supports any source)

### DIFF
--- a/cmd/slackdump/internal/convertcmd/to_dump.go
+++ b/cmd/slackdump/internal/convertcmd/to_dump.go
@@ -39,5 +39,10 @@ func toDump(ctx context.Context, srcpath, trgloc string, cflg convertflags) erro
 
 	conv := convert.NewToDump(src, fsa, convert.DumpWithIncludeFiles(filesEnabled), convert.DumpWithLogger(cfg.Log))
 
-	return conv.Convert(ctx)
+	if err := conv.Convert(ctx); err != nil {
+		return err
+	}
+
+	cfg.Log.InfoContext(ctx, "converted", "source", srcpath, "target", trgloc)
+	return nil
 }

--- a/cmd/slackdump/internal/dump/dump.go
+++ b/cmd/slackdump/internal/dump/dump.go
@@ -131,7 +131,7 @@ func RunDump(ctx context.Context, _ *base.Command, args []string) error {
 		base.SetExitStatus(base.SApplicationError)
 		return err
 	}
-	lg.InfoContext(ctx, "conversation dump finished", "count", p.list.IncludeCount(), "took", time.Since(start))
+	lg.InfoContext(ctx, "conversation dump finished", "output", cfg.Output, "count", p.list.IncludeCount(), "took", time.Since(start))
 	return nil
 }
 

--- a/cmd/slackdump/internal/dump/dump.go
+++ b/cmd/slackdump/internal/dump/dump.go
@@ -94,7 +94,7 @@ func RunDump(ctx context.Context, _ *base.Command, args []string) error {
 	if opts.nameTemplate == "" {
 		opts.nameTemplate = nametmpl.Default
 	}
-	tmpl, err := nametmpl.New(opts.nameTemplate + ".json")
+	tmpl, err := nametmpl.New(opts.nameTemplate)
 	if err != nil {
 		base.SetExitStatus(base.SUserError)
 		return fmt.Errorf("file template error: %w", err)

--- a/cmd/slackdump/internal/format/dump.go
+++ b/cmd/slackdump/internal/format/dump.go
@@ -1,0 +1,226 @@
+package format
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"runtime/trace"
+
+	"github.com/rusq/slack"
+
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
+	"github.com/rusq/slackdump/v3/internal/cache"
+	"github.com/rusq/slackdump/v3/internal/format"
+	"github.com/rusq/slackdump/v3/types"
+)
+
+// formatJSONfile formats a single json file in the dump format.
+func formatJSONfile(ctx context.Context, w io.Writer, cvt format.Formatter, rs io.ReadSeeker) error {
+	ctx, task := trace.NewTask(ctx, "convert")
+	defer task.End()
+	lg := cfg.Log
+
+	dump, err := detectAndRead(rs)
+	if err != nil {
+		return ErrInvalidFormat
+	}
+	lg.InfoContext(ctx, "Successfully detected file type", "type", dump.filetype)
+
+	if dump.filetype == dtUsers {
+		// special case.  Users do not need to have users fetched from slack etc,
+		// because, well, because they are users already.
+		return cvt.Users(ctx, w, dump.users)
+	}
+
+	uu, err := getUsers(ctx, dump, flgOnline)
+	if err != nil {
+		return err
+	}
+
+	switch dump.filetype {
+	case dtChannels:
+		return cvt.Channels(ctx, w, uu, dump.channels)
+	case dtConversation:
+		return cvt.Conversation(ctx, w, uu, dump.conversation)
+	case dtUnknown:
+		fallthrough
+	default:
+	}
+	return errors.New("internal error: undetected type")
+}
+
+//go:generate stringer -type dumptype -trimprefix=dt
+type dumptype uint8
+
+const (
+	dtUnknown dumptype = iota
+	dtConversation
+	dtChannels
+	dtUsers
+)
+
+var ErrUnknown = errors.New("unknown file type")
+
+
+type idextractor interface {
+	UserIDs() []string
+}
+
+var ErrInvalidFormat = errors.New("not a dump JSON file")
+
+// dump represents a slack data dump.  Only one variable will be initialised
+// depending on the dumptype.
+type dump struct {
+	filetype     dumptype
+	users        types.Users
+	channels     types.Channels
+	conversation *types.Conversation
+}
+
+// detectAndRead detects the filetype by consequently trying to unmarshal the
+// data.  It will return [dump] that will have [dumptype] and one of the
+// member variables populated.  If it fails to detect the type it will return
+// ErrUnknown and set the dump filetype to dtUnknown.
+func detectAndRead(rs io.ReadSeeker) (*dump, error) {
+	d := new(dump)
+
+	if conv, err := unmarshal[types.Conversation](rs); err != nil && !isJSONTypeErr(err) {
+		return nil, err
+	} else if conv.ID != "" {
+		d.filetype = dtConversation
+		d.conversation = &conv
+		return d, nil
+	}
+
+	if ch, err := unmarshal[[]slack.Channel](rs); err != nil && !isJSONTypeErr(err) {
+		return nil, err
+	} else if len(ch) > 0 && ch[0].Creator != "" {
+		d.filetype = dtChannels
+		d.channels = ch
+		return d, nil
+	}
+
+	if u, err := unmarshal[[]slack.User](rs); err != nil && !isJSONTypeErr(err) {
+		return nil, err
+	} else if len(u) > 0 && u[0].RealName != "" {
+		d.filetype = dtUsers
+		d.users = u
+		return d, nil
+	}
+
+	// no luck
+	d.filetype = dtUnknown
+	return d, ErrUnknown
+}
+
+func isJSONTypeErr(err error) bool {
+	var e *json.UnmarshalTypeError
+	return errors.As(err, &e)
+}
+
+func (d dump) userIDs() []string {
+	var xt idextractor
+	switch d.filetype {
+	case dtConversation:
+		xt = d.conversation
+	case dtUsers:
+		xt = d.users
+	case dtChannels:
+		xt = d.channels
+	}
+	return xt.UserIDs()
+}
+
+func unmarshal[OUT any](rs io.ReadSeeker) (OUT, error) {
+	var ret OUT
+	if _, err := rs.Seek(0, io.SeekStart); err != nil {
+		return ret, err
+	}
+	defer rs.Seek(0, io.SeekStart)
+
+	dec := json.NewDecoder(rs)
+	if err := dec.Decode(&ret); err != nil {
+		return ret, err
+	}
+
+	return ret, nil
+}
+
+func getUsers(ctx context.Context, dmp *dump, isOnline bool) ([]slack.User, error) {
+	if isOnline {
+		return getUsersOnline(ctx)
+	}
+	rgn := trace.StartRegion(ctx, "userIDs")
+	ids := dmp.userIDs()
+	rgn.End()
+	if len(ids) == 0 {
+		return nil, errors.New("unable to extract user IDs")
+	}
+	trace.Logf(ctx, "getUsers", "number of users in this dump: %d", len(ids))
+	uu, err := searchCache(ctx, cfg.CacheDir(), ids)
+	if err != nil {
+		return nil, err
+	}
+	return uu, nil
+}
+
+func getUsersOnline(ctx context.Context) ([]slack.User, error) {
+	sess, err := bootstrap.SlackdumpSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return sess.GetUsers(ctx)
+}
+
+var errNoMatch = errors.New("no matching users")
+
+// searchCache searches the cache directory for cached workspace users that have
+// the same ids, and returns the user slice from that cache.
+func searchCache(ctx context.Context, cacheDir string, ids []string) ([]slack.User, error) {
+	_, task := trace.NewTask(ctx, "searchCache")
+	defer task.End()
+	m, err := cache.NewManager(cacheDir, cache.WithMachineID(cfg.MachineIDOvr), cache.WithNoEncryption(cfg.NoEncryption))
+	if err != nil {
+		return nil, err
+	}
+	var users []slack.User
+	err = m.WalkUsers(func(path string, r io.Reader) error {
+		var err1 error
+		users, err1 = matchUsers(r, ids)
+		if err1 != nil {
+			if errors.Is(err1, errNoMatch) {
+				return nil
+			}
+			return err1
+		}
+		slog.InfoContext(ctx, "matching file", "path", path)
+		return filepath.SkipDir
+	})
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+func matchUsers(r io.Reader, ids []string) ([]slack.User, error) {
+	const matchRatio = 0.5 // 50% of users must match.
+	uu, err := cache.ReadUsers(r)
+	if err != nil {
+		return nil, err
+	}
+	fileIDs := uu.IndexByID()
+	matchingCnt := 0 // matching users count
+	for _, id := range ids {
+		if fileIDs[id] != nil {
+			matchingCnt++
+		}
+	}
+	if float64(matchingCnt)/float64(len(ids)) < matchRatio {
+		return nil, errNoMatch
+	}
+	return uu, nil
+}

--- a/cmd/slackdump/internal/format/format.go
+++ b/cmd/slackdump/internal/format/format.go
@@ -4,24 +4,20 @@ package format
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime/trace"
+	"strings"
+	"time"
 
-	"github.com/rusq/slack"
-
-	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
+	"github.com/rusq/fsadapter"
 
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
-	"github.com/rusq/slackdump/v3/internal/cache"
 	"github.com/rusq/slackdump/v3/internal/format"
-	"github.com/rusq/slackdump/v3/types"
+	"github.com/rusq/slackdump/v3/internal/source"
+	"github.com/rusq/slackdump/v3/internal/structures"
 )
 
 // TODO this is hacky in the following ways:
@@ -42,32 +38,16 @@ a human readable format.  The command takes the format type and the file to
 convert as arguments.
 `, // TODO: add more info
 	CustomFlags: false,
-	FlagMask:    cfg.OmitAll &^ cfg.OmitWorkspaceFlag,
+	FlagMask:    cfg.OmitAll &^ cfg.OmitOutputFlag,
 	PrintFlags:  true,
 	RequireAuth: true,
 }
 
-//go:generate stringer -type dumptype -trimprefix=dt
-type dumptype uint8
-
-const (
-	dtUnknown dumptype = iota
-	dtConversation
-	dtChannels
-	dtUsers
-)
-
-var ErrUnknown = errors.New("unknown file type")
-
-var (
-	archive   string
-	online    bool
-	converter format.Formatter
-)
+// custom command flags
+var flgOnline bool
 
 func init() {
-	CmdFormat.Flag.StringVar(&archive, "archive", "", "access the file within the ZIP `archive.zip`")
-	CmdFormat.Flag.BoolVar(&online, "online", false, "get users from current workspace (workspace must be selected, or set with -w flag)")
+	CmdFormat.Flag.BoolVar(&flgOnline, "online", false, "get online users")
 }
 
 func runFormat(ctx context.Context, cmd *base.Command, args []string) error {
@@ -78,231 +58,77 @@ func runFormat(ctx context.Context, cmd *base.Command, args []string) error {
 
 	// determining the conversion type.
 	var convType format.Type
+	var formatter format.Formatter
 	if err := convType.Set(args[0]); err != nil {
 		base.SetExitStatus(base.SInvalidParameters)
 		return err
 	} else {
 		var ok bool
-		initConverter, ok := format.Converters[convType]
+		formatterInit, ok := format.Converters[convType]
 		if !ok {
 			base.SetExitStatus(base.SInvalidParameters)
 			return errors.New("unknown converter type")
 		}
-		converter = initConverter()
+		formatter = formatterInit()
 	}
 
-	var filename string
+	var input string
 	if len(args) > 1 {
-		filename = args[1]
+		input = args[1]
+	}
+	var el *structures.EntityList
+	if len(args) > 2 {
+		var err error
+		el, err = structures.NewEntityList(args[2:])
+		if err != nil {
+			base.SetExitStatus(base.SInvalidParameters)
+			return err
+		}
 	}
 
-	rsc, err := opendump(filename, archive)
+	fi, err := os.Stat(input)
 	if err != nil {
 		base.SetExitStatus(base.SUserError)
 		return err
 	}
-	defer rsc.Close()
 
-	if err := convert(ctx, os.Stdout, converter, rsc); err != nil {
-		if errors.Is(err, ErrUnknown) || errors.Is(err, ErrInvalidFormat) {
-			base.SetExitStatus(base.SInvalidParameters)
-		} else {
+	start := time.Now()
+	if fi.IsDir() || strings.ToLower(filepath.Ext(input)) == ".zip" {
+		src, err := source.Load(ctx, input)
+		if err != nil {
+			base.SetExitStatus(base.SUserError)
+			return err
+		}
+		defer src.Close()
+
+		fsa, err := fsadapter.New(cfg.Output)
+		if err != nil {
+			base.SetExitStatus(base.SUserError)
+			return err
+		}
+		defer fsa.Close()
+
+		if err := formatSrc(ctx, fsa, src, formatter, el); err != nil {
 			base.SetExitStatus(base.SApplicationError)
 		}
-		return err
+		cfg.Log.InfoContext(ctx, "formatted source", "format", convType.String(), "output", cfg.Output, "took", time.Since(start).String())
+	} else if strings.ToLower(filepath.Ext(input)) == ".json" {
+		f, err := os.Open(input)
+		if err != nil {
+			base.SetExitStatus(base.SUserError)
+		}
+		if err := formatJSONfile(ctx, os.Stdout, formatter, f); err != nil {
+			if errors.Is(err, ErrUnknown) || errors.Is(err, ErrInvalidFormat) {
+				base.SetExitStatus(base.SInvalidParameters)
+			} else {
+				base.SetExitStatus(base.SApplicationError)
+			}
+			return err
+		}
+		cfg.Log.InfoContext(ctx, "formatted file", "format", convType.String(), "took", time.Since(start).String())
+	} else {
+		base.SetExitStatus(base.SInvalidParameters)
+		return errors.New("unsupported input format")
 	}
 	return nil
-}
-
-type idextractor interface {
-	UserIDs() []string
-}
-
-var ErrInvalidFormat = errors.New("not a dump JSON file")
-
-func convert(ctx context.Context, w io.Writer, cvt format.Formatter, rs io.ReadSeeker) error {
-	ctx, task := trace.NewTask(ctx, "convert")
-	defer task.End()
-	lg := cfg.Log
-
-	dump, err := detectAndRead(rs)
-	if err != nil {
-		return ErrInvalidFormat
-	}
-	lg.InfoContext(ctx, "Successfully detected file type", "type", dump.filetype)
-
-	if dump.filetype == dtUsers {
-		// special case.  Users do not need to have users fetched from slack etc,
-		// because, well, because they are users already.
-		return cvt.Users(ctx, w, dump.users)
-	}
-
-	uu, err := getUsers(ctx, dump, online)
-	if err != nil {
-		return err
-	}
-
-	switch dump.filetype {
-	case dtChannels:
-		return cvt.Channels(ctx, w, uu, dump.channels)
-	case dtConversation:
-		return cvt.Conversation(ctx, w, uu, dump.conversation)
-	case dtUnknown:
-		fallthrough
-	default:
-	}
-	return errors.New("internal error: undetected type")
-}
-
-// dump represents a slack data dump.  Only one variable will be initialised
-// depending on the dumptype.
-type dump struct {
-	filetype     dumptype
-	users        types.Users
-	channels     types.Channels
-	conversation *types.Conversation
-}
-
-// detectAndRead detects the filetype by consequently trying to unmarshal the
-// data.  It will return [dump] that will have [dumptype] and one of the
-// member variables populated.  If it fails to detect the type it will return
-// ErrUnknown and set the dump filetype to dtUnknown.
-func detectAndRead(rs io.ReadSeeker) (*dump, error) {
-	d := new(dump)
-
-	if conv, err := unmarshal[types.Conversation](rs); err != nil && !isJSONTypeErr(err) {
-		return nil, err
-	} else if conv.ID != "" {
-		d.filetype = dtConversation
-		d.conversation = &conv
-		return d, nil
-	}
-
-	if ch, err := unmarshal[[]slack.Channel](rs); err != nil && !isJSONTypeErr(err) {
-		return nil, err
-	} else if len(ch) > 0 && ch[0].Creator != "" {
-		d.filetype = dtChannels
-		d.channels = ch
-		return d, nil
-	}
-
-	if u, err := unmarshal[[]slack.User](rs); err != nil && !isJSONTypeErr(err) {
-		return nil, err
-	} else if len(u) > 0 && u[0].RealName != "" {
-		d.filetype = dtUsers
-		d.users = u
-		return d, nil
-	}
-
-	// no luck
-	d.filetype = dtUnknown
-	return d, ErrUnknown
-}
-
-func isJSONTypeErr(err error) bool {
-	var e *json.UnmarshalTypeError
-	return errors.As(err, &e)
-}
-
-func (d dump) userIDs() []string {
-	var xt idextractor
-	switch d.filetype {
-	case dtConversation:
-		xt = d.conversation
-	case dtUsers:
-		xt = d.users
-	case dtChannels:
-		xt = d.channels
-	}
-	return xt.UserIDs()
-}
-
-func unmarshal[OUT any](rs io.ReadSeeker) (OUT, error) {
-	var ret OUT
-	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return ret, err
-	}
-	defer rs.Seek(0, io.SeekStart)
-
-	dec := json.NewDecoder(rs)
-	if err := dec.Decode(&ret); err != nil {
-		return ret, err
-	}
-
-	return ret, nil
-}
-
-func getUsers(ctx context.Context, dmp *dump, isOnline bool) ([]slack.User, error) {
-	if isOnline {
-		return getUsersOnline(ctx)
-	}
-	rgn := trace.StartRegion(ctx, "userIDs")
-	ids := dmp.userIDs()
-	rgn.End()
-	if len(ids) == 0 {
-		return nil, errors.New("unable to extract user IDs")
-	}
-	trace.Logf(ctx, "getUsers", "number of users in this dump: %d", len(ids))
-	uu, err := searchCache(ctx, cfg.CacheDir(), ids)
-	if err != nil {
-		return nil, err
-	}
-	return uu, nil
-}
-
-func getUsersOnline(ctx context.Context) ([]slack.User, error) {
-	sess, err := bootstrap.SlackdumpSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return sess.GetUsers(ctx)
-}
-
-var errNoMatch = errors.New("no matching users")
-
-// searchCache searches the cache directory for cached workspace users that have
-// the same ids, and returns the user slice from that cache.
-func searchCache(ctx context.Context, cacheDir string, ids []string) ([]slack.User, error) {
-	_, task := trace.NewTask(ctx, "searchCache")
-	defer task.End()
-	m, err := cache.NewManager(cacheDir, cache.WithMachineID(cfg.MachineIDOvr), cache.WithNoEncryption(cfg.NoEncryption))
-	if err != nil {
-		return nil, err
-	}
-	var users []slack.User
-	err = m.WalkUsers(func(path string, r io.Reader) error {
-		var err1 error
-		users, err1 = matchUsers(r, ids)
-		if err1 != nil {
-			if errors.Is(err1, errNoMatch) {
-				return nil
-			}
-			return err1
-		}
-		slog.InfoContext(ctx, "matching file", "path", path)
-		return filepath.SkipDir
-	})
-	if err != nil {
-		return nil, err
-	}
-	return users, nil
-}
-
-func matchUsers(r io.Reader, ids []string) ([]slack.User, error) {
-	const matchRatio = 0.5 // 50% of users must match.
-	uu, err := cache.ReadUsers(r)
-	if err != nil {
-		return nil, err
-	}
-	fileIDs := uu.IndexByID()
-	matchingCnt := 0 // matching users count
-	for _, id := range ids {
-		if fileIDs[id] != nil {
-			matchingCnt++
-		}
-	}
-	if float64(matchingCnt)/float64(len(ids)) < matchRatio {
-		return nil, errNoMatch
-	}
-	return uu, nil
 }

--- a/cmd/slackdump/internal/format/source.go
+++ b/cmd/slackdump/internal/format/source.go
@@ -1,0 +1,150 @@
+package format
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"runtime/trace"
+
+	"github.com/rusq/fsadapter"
+	"github.com/rusq/slack"
+
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
+	"github.com/rusq/slackdump/v3/internal/format"
+	"github.com/rusq/slackdump/v3/internal/source"
+	"github.com/rusq/slackdump/v3/internal/structures"
+	"github.com/rusq/slackdump/v3/types"
+)
+
+// formatSrc formats the source with the given formatter and writes the result
+// into fsa. If el is specified, it is used to filter the channels that are
+// formatted.
+func formatSrc(ctx context.Context, fsa fsadapter.FS, src source.Sourcer, formatter format.Formatter, el *structures.EntityList) error {
+	ctx, task := trace.NewTask(ctx, "format")
+	defer task.End()
+	lg := cfg.Log
+
+	// Get the source type and name.
+	srcType, srcName := src.Type(), src.Name()
+
+	fileext := formatter.Extension()
+
+	lg.InfoContext(ctx, "source", "type", srcType.String(), "name", srcName)
+	users, err := src.Users(ctx)
+	if err != nil {
+		lg.WarnContext(ctx, "users will not be resolved, no users in the source")
+	} else {
+		if err := withFile(fsa, "users"+fileext, func(w io.Writer) error {
+			return formatter.Users(ctx, w, users)
+		}); err != nil {
+			return err
+		}
+	}
+
+	channels, err := src.Channels(ctx)
+	if err != nil {
+		lg.WarnContext(ctx, "channels will not be formatted, no channels in the source")
+	} else {
+		if err := withFile(fsa, "channels"+fileext, func(w io.Writer) error {
+			return formatter.Channels(ctx, w, users, channels)
+		}); err != nil {
+			return err
+		}
+	}
+
+	// format messages
+	for _, ch := range channels {
+		if el != nil {
+			ch, ok := el.Get(ch.ID)
+			if !ok || !ch.Include {
+				continue
+			}
+		}
+		conv, err := getChannel(ctx, src, ch)
+		if err != nil {
+			if errors.Is(err, source.ErrNotFound) {
+				continue
+			}
+			lg.WarnContext(ctx, "failed to format channel", "channel", ch.ID, "error", err)
+			continue
+		}
+		if len(conv.Messages) == 0 {
+			continue
+		}
+		if err := withFile(fsa, ch.ID+fileext, func(w io.Writer) error {
+			return formatter.Conversation(ctx, w, users, &conv)
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getChannel(ctx context.Context, src source.Sourcer, ch slack.Channel) (types.Conversation, error) {
+	// check for entity list inclusion
+	conv := types.Conversation{
+		ID:   ch.ID,
+		Name: ch.Name,
+	}
+	it, err := src.AllMessages(ctx, ch.ID)
+	if err != nil {
+		return conv, err
+	}
+	for slackMsg, err := range it {
+		if err != nil {
+			return conv, err
+		}
+		msg := types.Message{Message: slackMsg}
+		if structures.IsThreadStart(&slackMsg) && !structures.IsEmptyThread(&slackMsg) {
+			thread, err := getThread(ctx, src, ch.ID, slackMsg.ThreadTimestamp)
+			if err != nil {
+				if errors.Is(err, source.ErrNotFound) || errors.Is(err, source.ErrNotSupported) {
+					// thread not found or not supported,ignore
+				} else {
+					return conv, err
+				}
+			} else {
+				msg.ThreadReplies = thread
+			}
+		}
+		conv.Messages = append(conv.Messages, msg)
+	}
+
+	return conv, nil
+}
+
+func getThread(ctx context.Context, src source.Sourcer, chanID string, ts string) ([]types.Message, error) {
+	itt, err := src.AllThreadMessages(ctx, chanID, ts)
+	if err != nil {
+		return nil, err
+	}
+	var mm []types.Message
+	for threadMsg, err := range itt {
+		if err != nil {
+			return nil, err
+		}
+		mm = append(mm, types.Message{Message: threadMsg})
+	}
+	return mm[1:], nil
+}
+
+// withFile opens a file for writing and calls the provided callback function.
+func withFile(fsa fsadapter.FS, filename string, cb func(w io.Writer) error) (err error) {
+	// Open the w for writing.
+	w, err := fsa.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", filename, err)
+	}
+	defer func() {
+		err = errors.Join(err, w.Close())
+	}()
+
+	// Call the function with the opened file.
+	if err := cb(w); err != nil {
+		return fmt.Errorf("failed to write to file %s: %w", filename, err)
+	}
+
+	return nil
+}

--- a/internal/format/csv.go
+++ b/internal/format/csv.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rusq/slack"
+
 	"github.com/rusq/slackdump/v3/types"
 )
 
@@ -35,6 +36,11 @@ func NewCSV(opts ...Option) Formatter {
 		fn(&settings)
 	}
 	return &CSV{settings}
+}
+
+// Extension returns the file extension for the formatter.
+func (c CSV) Extension() string {
+	return ".csv"
 }
 
 // timestamp, channel, username, text
@@ -117,7 +123,8 @@ func (c *CSV) Users(ctx context.Context, w io.Writer, users []slack.User) error 
 	csv := c.mkwriter(w)
 	defer csv.Flush()
 
-	if err := csv.Write([]string{"ID",
+	if err := csv.Write([]string{
+		"ID",
 		"Team ID",
 		"Name",
 		"Is Admin?",

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -60,6 +60,8 @@ type Formatter interface {
 	Conversation(ctx context.Context, w io.Writer, u []slack.User, conv *types.Conversation) error
 	Channels(ctx context.Context, w io.Writer, u []slack.User, chans []slack.Channel) error
 	Users(ctx context.Context, w io.Writer, u []slack.User) error
+	// Extension returns the file extension for the formatter.
+	Extension() string
 }
 
 type options struct {

--- a/internal/format/json.go
+++ b/internal/format/json.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/rusq/slack"
+
 	"github.com/rusq/slackdump/v3/types"
 )
 
@@ -31,6 +32,11 @@ func NewJSON(opts ...Option) Formatter {
 		fn(&settings)
 	}
 	return &JSON{opts: settings.jsonOptions}
+}
+
+// Extension returns the file extension for the formatter.
+func (j JSON) Extension() string {
+	return ".json"
 }
 
 func JSONPrefix(prefix string) Option {

--- a/internal/format/text.go
+++ b/internal/format/text.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/rusq/slack"
+
 	"github.com/rusq/slackdump/v3/internal/structures"
 	"github.com/rusq/slackdump/v3/types"
 )
@@ -45,11 +46,17 @@ func NewText(opts ...Option) Formatter {
 	settings := options{
 		textOptions: textOptions{
 			msgSplitAfter: defaultMsgSplitAfter,
-		}}
+		},
+	}
 	for _, fn := range opts {
 		fn(&settings)
 	}
 	return &Text{opts: settings}
+}
+
+// Extension returns the file extension for the formatter.
+func (txt Text) Extension() string {
+	return ".txt"
 }
 
 func (txt *Text) Conversation(ctx context.Context, w io.Writer, u []slack.User, conv *types.Conversation) error {
@@ -160,5 +167,4 @@ func (txt *Text) Channels(ctx context.Context, w io.Writer, u []slack.User, cc [
 		fmt.Fprintf(writer, strFormat, ch.ID, archived, who)
 	}
 	return nil
-
 }

--- a/internal/nametmpl/template.go
+++ b/internal/nametmpl/template.go
@@ -14,7 +14,7 @@ import (
 const filenameTmplName = "nametmpl"
 
 // Default is the default file naming template.
-const Default = `{{.ID}}{{ if .ThreadTS}}-{{.ThreadTS}}{{end}}.json`
+const Default = `{{.ID}}{{ if .ThreadTS}}-{{.ThreadTS}}{{end}}`
 
 // let's define some markers
 const (

--- a/internal/nametmpl/template.go
+++ b/internal/nametmpl/template.go
@@ -14,7 +14,7 @@ import (
 const filenameTmplName = "nametmpl"
 
 // Default is the default file naming template.
-const Default = `{{.ID}}{{ if .ThreadTS}}-{{.ThreadTS}}{{end}}`
+const Default = `{{.ID}}{{ if .ThreadTS}}-{{.ThreadTS}}{{end}}.json`
 
 // let's define some markers
 const (

--- a/internal/structures/entity_list.go
+++ b/internal/structures/entity_list.go
@@ -247,6 +247,16 @@ func (el *EntityList) Index() map[string]*EntityItem {
 	return el.index
 }
 
+func (el *EntityList) Get(id string) (*EntityItem, bool) {
+	if el == nil {
+		return nil, false
+	}
+	el.mu.RLock()
+	defer el.mu.RUnlock()
+	item, ok := el.index[id]
+	return item, ok
+}
+
 type EntityIndex map[string]bool
 
 // IsExcluded returns true if the entity is excluded (is in the list, and has


### PR DESCRIPTION
- **formatter for any source** - relates to #483 
- **fixes the discrepancy in handling the dump file naming between "dump" and "convert" command** - the drawback is that dump naming templates need to have extension defined in them, i.e. if your template was `{{.ID}}{{ if .ThreadTS}}-{{.ThreadTS}}{{end}}` it should be changed to `{{.ID}}{{ if .ThreadTS}}-{{.ThreadTS}}{{end}}.json`. (This applies only to dump output format)


