### PR TITLE
Add support for -files=true|false to emoji command

### DIFF
--- a/cmd/slackdump/internal/archive/search.go
+++ b/cmd/slackdump/internal/archive/search.go
@@ -38,7 +38,7 @@ var CmdSearch = &base.Command{
 //go:embed assets/search.md
 var searchMD string
 
-const flagMask = cfg.OmitUserCacheFlag | cfg.OmitCacheDir | cfg.OmitTimeframeFlag | cfg.OmitCustomUserFlags | cfg.OmitDownloadAvatarsFlag
+const flagMask = cfg.OmitUserCacheFlag | cfg.OmitCacheDir | cfg.OmitTimeframeFlag | cfg.OmitCustomUserFlags | cfg.OmitWithAvatarsFlag
 
 var cmdSearchMessages = &base.Command{
 	UsageLine:   "slackdump search messages [flags] <query terms>",

--- a/cmd/slackdump/internal/cfg/cfg.go
+++ b/cmd/slackdump/internal/cfg/cfg.go
@@ -100,7 +100,7 @@ type FlagMask uint16
 const (
 	DefaultFlags  FlagMask = 0
 	OmitAuthFlags FlagMask = 1 << iota
-	OmitDownloadFlag
+	OmitWithFilesFlag
 	OmitConfigFlag
 	OmitOutputFlag
 	OmitCacheDir
@@ -110,11 +110,11 @@ const (
 	OmitChunkCacheFlag
 	OmitCustomUserFlags
 	OmitRecordFilesFlag
-	OmitDownloadAvatarsFlag
+	OmitWithAvatarsFlag
 	OmitChunkFileMode
 
 	OmitAll = OmitConfigFlag |
-		OmitDownloadFlag |
+		OmitWithFilesFlag |
 		OmitOutputFlag |
 		OmitCacheDir |
 		OmitWorkspaceFlag |
@@ -124,7 +124,7 @@ const (
 		OmitChunkCacheFlag |
 		OmitCustomUserFlags |
 		OmitRecordFilesFlag |
-		OmitDownloadAvatarsFlag |
+		OmitWithAvatarsFlag |
 		OmitChunkFileMode
 )
 
@@ -145,13 +145,13 @@ func SetBaseFlags(fs *flag.FlagSet, mask FlagMask) {
 		fs.StringVar(&MachineIDOvr, "machine-id", osenv.Secret("MACHINE_ID_OVERRIDE", ""), "override the machine ID for encryption")
 		fs.BoolVar(&NoEncryption, "no-encryption", osenv.Value("DISABLE_ENCRYPTION", false), "disable encryption for cache and credential files")
 	}
-	if mask&OmitDownloadFlag == 0 {
+	if mask&OmitWithFilesFlag == 0 {
 		fs.BoolVar(&WithFiles, "files", true, "enables file attachments download (to disable, specify: -files=false)")
 		if mask&OmitRecordFilesFlag == 0 {
 			fs.BoolVar(&RecordFiles, "files-rec", false, "include file chunks in chunk files")
 		}
 	}
-	if mask&OmitDownloadAvatarsFlag == 0 {
+	if mask&OmitWithAvatarsFlag == 0 {
 		fs.BoolVar(&WithAvatars, "avatars", false, "enables user avatar download (placed in __avatars directory)")
 	}
 	if mask&OmitConfigFlag == 0 {

--- a/cmd/slackdump/internal/convertcmd/convert.go
+++ b/cmd/slackdump/internal/convertcmd/convert.go
@@ -22,7 +22,7 @@ var CmdConvert = &base.Command{
 	Short:       "convert slackdump chunks to various formats",
 	Long:        convertMd,
 	CustomFlags: false,
-	FlagMask:    cfg.OmitAll & ^cfg.OmitDownloadFlag &^ cfg.OmitOutputFlag &^ cfg.OmitDownloadAvatarsFlag,
+	FlagMask:    cfg.OmitAll & ^cfg.OmitWithFilesFlag &^ cfg.OmitOutputFlag &^ cfg.OmitWithAvatarsFlag,
 	PrintFlags:  true,
 }
 

--- a/cmd/slackdump/internal/diag/record.go
+++ b/cmd/slackdump/internal/diag/record.go
@@ -37,7 +37,7 @@ Records the data from a channel in a chunk record format.
 
 See also: slackdump tool obfuscate
 `,
-	FlagMask:    cfg.OmitOutputFlag | cfg.OmitDownloadFlag,
+	FlagMask:    cfg.OmitOutputFlag | cfg.OmitWithFilesFlag,
 	PrintFlags:  true,
 	RequireAuth: true,
 }

--- a/cmd/slackdump/internal/diag/v1.go
+++ b/cmd/slackdump/internal/diag/v1.go
@@ -30,7 +30,7 @@ Slackdump v1.0.x are rare in the wild, but if you have one, you can use this
 command to convert it to current dump format to be able to use it with the
 viewer and other commands.`,
 	CustomFlags: false,
-	FlagMask:    cfg.OmitAll &^ cfg.OmitOutputFlag &^ cfg.OmitDownloadFlag,
+	FlagMask:    cfg.OmitAll &^ cfg.OmitOutputFlag &^ cfg.OmitWithFilesFlag,
 	PrintFlags:  true,
 	RequireAuth: false,
 	HideWizard:  true,

--- a/cmd/slackdump/internal/dump/dump.go
+++ b/cmd/slackdump/internal/dump/dump.go
@@ -42,7 +42,7 @@ var CmdDump = &base.Command{
 	Long:        dumpMd,
 	RequireAuth: true,
 	PrintFlags:  true,
-	FlagMask:    cfg.OmitCustomUserFlags | cfg.OmitRecordFilesFlag | cfg.OmitDownloadAvatarsFlag,
+	FlagMask:    cfg.OmitCustomUserFlags | cfg.OmitRecordFilesFlag | cfg.OmitWithAvatarsFlag,
 }
 
 func init() {

--- a/cmd/slackdump/internal/emoji/emoji.go
+++ b/cmd/slackdump/internal/emoji/emoji.go
@@ -29,7 +29,7 @@ var CmdEmoji = &base.Command{
 	UsageLine:   "slackdump emoji [flags]",
 	Short:       "download workspace emoticons ಠ_ಠ",
 	Long:        emojiMD,
-	FlagMask:    cfg.OmitAll &^ cfg.OmitAuthFlags &^ cfg.OmitOutputFlag &^ cfg.OmitWorkspaceFlag,
+	FlagMask:    cfg.OmitAll &^ cfg.OmitAuthFlags &^ cfg.OmitOutputFlag &^ cfg.OmitWorkspaceFlag &^ cfg.OmitWithFilesFlag,
 	RequireAuth: true,
 	PrintFlags:  true,
 }
@@ -50,7 +50,6 @@ func init() {
 	CmdEmoji.Wizard = wizard
 	CmdEmoji.Flag.BoolVar(&cmdFlags.FailFast, "ignore-errors", true, "ignore download errors (skip failed emojis)")
 	CmdEmoji.Flag.BoolVar(&cmdFlags.full, "full", false, "fetch emojis using Edge API to get full emoji information, including usernames")
-	CmdEmoji.Flag.BoolVar(&cmdFlags.NoDownload, "no-download", false, "do not download emojis, just the index")
 }
 
 func run(ctx context.Context, cmd *base.Command, args []string) error {
@@ -65,6 +64,8 @@ func run(ctx context.Context, cmd *base.Command, args []string) error {
 		base.SetExitStatus(base.SApplicationError)
 		return err
 	}
+
+	cmdFlags.WithFiles = cfg.WithFiles
 
 	start := time.Now()
 	r, cl := statusReporter()

--- a/cmd/slackdump/internal/emoji/emojidl/emoedge.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoedge.go
@@ -56,11 +56,9 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 	)
 
 	// Async download pipeline.
-	workerFn := worker
-	if opt.NoDownload {
-		// if opt.NoDownload is set, we don't download the emojis, just
-		// send them to the result channel.
-		workerFn = nofetchworker
+	workerFn := nofetchworker
+	if opt.WithFiles {
+		workerFn = worker
 	}
 
 	// 1. generator, send emojis into the emojiC channel.

--- a/cmd/slackdump/internal/emoji/emojidl/emoji.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoji.go
@@ -45,8 +45,8 @@ type EmojiDumper interface {
 }
 
 type Options struct {
-	FailFast   bool
-	NoDownload bool
+	FailFast  bool
+	WithFiles bool
 }
 
 // DlFS downloads all emojis from the workspace and saves them to the fsa.
@@ -67,12 +67,12 @@ func DlFS(ctx context.Context, sess EmojiDumper, fsa fsadapter.FS, opt *Options,
 		return fmt.Errorf("failed writing emoji index: %w", err)
 	}
 
-	if opt.NoDownload {
-		return nil
-	} else {
+	if opt.WithFiles {
 		if err := fetch(ctx, fsa, emojis, opt.FailFast, cb); err != nil {
 			return fmt.Errorf("failed downloading emojis: %w", err)
 		}
+	} else {
+		return nil
 	}
 	return nil
 }

--- a/cmd/slackdump/internal/emoji/emojidl/emoji_test.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoji_test.go
@@ -258,9 +258,9 @@ func Test_download(t *testing.T) {
 	tmpdir := t.TempDir()
 
 	type args struct {
-		ctx      context.Context
-		output   string
-		failFast bool
+		ctx    context.Context
+		output string
+		opts   *Options
 	}
 	tests := []struct {
 		name    string
@@ -272,9 +272,12 @@ func Test_download(t *testing.T) {
 		{
 			"save to directory",
 			args{
-				ctx:      context.Background(),
-				output:   tmpdir,
-				failFast: true,
+				ctx:    context.Background(),
+				output: tmpdir,
+				opts: &Options{
+					FailFast:  true,
+					WithFiles: true,
+				},
 			},
 			emptyFetchFn,
 			func(m *MockEmojiDumper) {
@@ -289,9 +292,12 @@ func Test_download(t *testing.T) {
 		{
 			"save to zip file",
 			args{
-				ctx:      context.Background(),
-				output:   filepath.Join(tmpdir, "test.zip"),
-				failFast: true,
+				ctx:    context.Background(),
+				output: filepath.Join(tmpdir, "test.zip"),
+				opts: &Options{
+					FailFast:  true,
+					WithFiles: true,
+				},
 			},
 			emptyFetchFn,
 			func(m *MockEmojiDumper) {
@@ -306,9 +312,12 @@ func Test_download(t *testing.T) {
 		{
 			"fails on fetch error with fail fast",
 			args{
-				ctx:      context.Background(),
-				output:   tmpdir,
-				failFast: true,
+				ctx:    context.Background(),
+				output: tmpdir,
+				opts: &Options{
+					FailFast:  true,
+					WithFiles: true,
+				},
 			},
 			errorFetchFn,
 			func(m *MockEmojiDumper) {
@@ -323,9 +332,12 @@ func Test_download(t *testing.T) {
 		{
 			"fails on DumpEmojis error",
 			args{
-				ctx:      context.Background(),
-				output:   tmpdir,
-				failFast: false,
+				ctx:    context.Background(),
+				output: tmpdir,
+				opts: &Options{
+					FailFast:  false,
+					WithFiles: true,
+				},
 			},
 			errorFetchFn,
 			func(m *MockEmojiDumper) {
@@ -346,7 +358,7 @@ func Test_download(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer fs.Close()
-			if err := DlFS(tt.args.ctx, sess, fs, tt.args.failFast, nil); (err != nil) != tt.wantErr {
+			if err := DlFS(tt.args.ctx, sess, fs, tt.args.opts, nil); (err != nil) != tt.wantErr {
 				t.Errorf("download() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/cmd/slackdump/internal/emoji/wizard.go
+++ b/cmd/slackdump/internal/emoji/wizard.go
@@ -3,6 +3,7 @@ package emoji
 import (
 	"context"
 
+	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/cfgui"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/dumpui"
@@ -37,9 +38,9 @@ func (o *options) configuration() cfgui.Configuration {
 			Params: []cfgui.Parameter{
 				{
 					Name:        "Do Not Download",
-					Value:       cfgui.Checkbox(o.NoDownload),
+					Value:       cfgui.Checkbox(cfg.WithFiles),
 					Description: "Do not download, any emojis, just get the index",
-					Updater:     updaters.NewBool(&o.NoDownload),
+					Updater:     updaters.NewBool(&cfg.WithFiles),
 				},
 				{
 					Name:        "Ignore Download Errors",

--- a/cmd/slackdump/internal/emoji/wizard.go
+++ b/cmd/slackdump/internal/emoji/wizard.go
@@ -36,10 +36,16 @@ func (o *options) configuration() cfgui.Configuration {
 			Name: "Download Options",
 			Params: []cfgui.Parameter{
 				{
+					Name:        "Do Not Download",
+					Value:       cfgui.Checkbox(o.NoDownload),
+					Description: "Do not download, any emojis, just get the index",
+					Updater:     updaters.NewBool(&o.NoDownload),
+				},
+				{
 					Name:        "Ignore Download Errors",
-					Value:       cfgui.Checkbox(o.ignoreErrors),
+					Value:       cfgui.Checkbox(o.FailFast),
 					Description: "Ignore download errors and continue",
-					Updater:     updaters.NewBool(&o.ignoreErrors),
+					Updater:     updaters.NewBool(&o.FailFast),
 				},
 			},
 		},

--- a/cmd/slackdump/internal/export/v3_test.go
+++ b/cmd/slackdump/internal/export/v3_test.go
@@ -73,7 +73,8 @@ func Test_exportV3(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		output := filepath.Join(baseDir, "output.zip")
+		dir := t.TempDir()
+		output := filepath.Join(dir, "output.zip")
 		fsa, err := fsadapter.New(output)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
- Support for `-files=true|false`
- Enable `-workspace` flag.

Fixes #487.

Future improvements: modification of the edge Emoji download function to adhere to rate limits.
