### PR TITLE
Bare list output format

### DIFF
--- a/cmd/slackdump/internal/cfg/cfg.go
+++ b/cmd/slackdump/internal/cfg/cfg.go
@@ -74,6 +74,7 @@ func enableLogColors(strNocolor string) {
 		// skip enabling color
 		return
 	}
+	pterm.DefaultLogger.Writer = os.Stderr
 	handler := pterm.NewSlogHandler(&pterm.DefaultLogger)
 	sl := slog.New(handler)
 	Log = sl

--- a/cmd/slackdump/internal/list/common.go
+++ b/cmd/slackdump/internal/list/common.go
@@ -67,6 +67,7 @@ type commonOpts struct {
 	listType format.Type
 	quiet    bool // quiet mode:  don't print anything on the screen, just save the file
 	nosave   bool // nosave mode:  don't save the data to a file, just print it to the screen
+	bare     bool
 }
 
 var commonFlags = commonOpts{
@@ -84,6 +85,7 @@ func addCommonFlags(fs *flag.FlagSet) {
 	fs.Var(&commonFlags.listType, "format", fmt.Sprintf("listing format, should be one of: %v", format.All()))
 	fs.BoolVar(&commonFlags.quiet, "q", false, "quiet mode:  don't print anything on the screen, just save the file")
 	fs.BoolVar(&commonFlags.nosave, "no-json", false, "don't save the data to a file, just print it to the screen")
+	fs.BoolVar(&commonFlags.bare, "b", false, "use bare format: just the user or channel ID, no headers")
 }
 
 func list[T any](ctx context.Context, sess *slackdump.Session, l lister[T], filename string) error {
@@ -97,7 +99,7 @@ func list[T any](ctx context.Context, sess *slackdump.Session, l lister[T], file
 	}
 
 	if !commonFlags.quiet {
-		if err := fmtPrint(ctx, os.Stdout, l.Data(), commonFlags.listType, l.Users()); err != nil {
+		if err := fmtPrint(ctx, os.Stdout, l.Data(), commonFlags.listType, l.Users(), commonFlags.bare); err != nil {
 			return err
 		}
 	}
@@ -106,7 +108,7 @@ func list[T any](ctx context.Context, sess *slackdump.Session, l lister[T], file
 		if filename == "" {
 			filename = makeFilename(l.Type(), sess.Info().TeamID, extForType(commonFlags.listType))
 		}
-		if err := saveData(ctx, l.Data(), filename, commonFlags.listType, l.Users()); err != nil {
+		if err := saveData(ctx, l.Data(), filename, commonFlags.listType, l.Users(), commonFlags.bare); err != nil {
 			return err
 		}
 	}
@@ -127,14 +129,14 @@ func extForType(typ format.Type) string {
 }
 
 // saveData saves the given data to the given filename.
-func saveData(ctx context.Context, data any, filename string, typ format.Type, users []slack.User) error {
+func saveData(ctx context.Context, data any, filename string, typ format.Type, users []slack.User, bare bool) error {
 	// save to a filesystem.
 	f, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
 	defer f.Close()
-	if err := fmtPrint(ctx, f, data, typ, users); err != nil {
+	if err := fmtPrint(ctx, f, data, typ, users, bare); err != nil {
 		return err
 	}
 	cfg.Log.InfoContext(ctx, "Data saved", "filename", filename)
@@ -145,13 +147,13 @@ func saveData(ctx context.Context, data any, filename string, typ format.Type, u
 // fmtPrint prints the given data to the given writer, using the given format.
 // It should be supplied with prepopulated users, as it may need to look up
 // users by ID.
-func fmtPrint(ctx context.Context, w io.Writer, a any, typ format.Type, u []slack.User) error {
+func fmtPrint(ctx context.Context, w io.Writer, a any, typ format.Type, u []slack.User, bare bool) error {
 	// get the converter
 	initFn, ok := format.Converters[typ]
 	if !ok {
 		return fmt.Errorf("unknown converter type: %s", typ)
 	}
-	cvt := initFn()
+	cvt := initFn(format.WithBareFormat(bare))
 
 	// currently there's no list function for conversations, because it
 	// requires additional options, and I don't want to clutter the flags -

--- a/cmd/slackdump/internal/list/wizard.go
+++ b/cmd/slackdump/internal/list/wizard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/charmbracelet/huh"
+
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/bootstrap"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/golang/base"
 	"github.com/rusq/slackdump/v3/cmd/slackdump/internal/ui/cfgui"
@@ -152,6 +153,12 @@ func (l *commonOpts) configuration() cfgui.Configuration {
 					Value:       cfgui.Checkbox(l.nosave),
 					Description: "Don't save the data to a file, just print it to the screen",
 					Updater:     updaters.NewBool(&l.nosave),
+				},
+				{
+					Name:        "Bare Format",
+					Value:       cfgui.Checkbox(l.bare),
+					Description: "Use bare format: just the user or channel ID, no headers",
+					Updater:     updaters.NewBool(&l.bare),
 				},
 			},
 		},

--- a/internal/format/csv.go
+++ b/internal/format/csv.go
@@ -73,6 +73,23 @@ func (c *CSV) Channels(ctx context.Context, w io.Writer, u []slack.User, chans [
 	csv := c.mkwriter(w)
 	defer csv.Flush()
 
+	if c.opts.bare {
+		return c.channelsBare(ctx, csv, u, chans)
+	} else {
+		return c.channelsFull(ctx, csv, u, chans)
+	}
+}
+
+func (c *CSV) channelsBare(_ context.Context, csv *csv.Writer, _ []slack.User, chans []slack.Channel) error {
+	for _, u := range chans {
+		if err := csv.Write([]string{u.ID}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *CSV) channelsFull(_ context.Context, csv *csv.Writer, u []slack.User, chans []slack.Channel) error {
 	if err := csv.Write([]string{
 		"ID",
 		"Name",
@@ -123,6 +140,23 @@ func (c *CSV) Users(ctx context.Context, w io.Writer, users []slack.User) error 
 	csv := c.mkwriter(w)
 	defer csv.Flush()
 
+	if c.opts.bare {
+		return c.usersBare(ctx, csv, users)
+	} else {
+		return c.usersFull(ctx, csv, users)
+	}
+}
+
+func (c *CSV) usersBare(_ context.Context, csv *csv.Writer, users []slack.User) error {
+	for _, u := range users {
+		if err := csv.Write([]string{u.ID}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *CSV) usersFull(_ context.Context, csv *csv.Writer, users []slack.User) error {
 	if err := csv.Write([]string{
 		"ID",
 		"Team ID",

--- a/internal/format/csv.go
+++ b/internal/format/csv.go
@@ -81,8 +81,8 @@ func (c *CSV) Channels(ctx context.Context, w io.Writer, u []slack.User, chans [
 }
 
 func (c *CSV) channelsBare(_ context.Context, csv *csv.Writer, _ []slack.User, chans []slack.Channel) error {
-	for _, u := range chans {
-		if err := csv.Write([]string{u.ID}); err != nil {
+	for _, c := range chans {
+		if err := csv.Write([]string{c.ID}); err != nil {
 			return err
 		}
 	}
@@ -106,17 +106,17 @@ func (c *CSV) channelsFull(_ context.Context, csv *csv.Writer, u []slack.User, c
 
 	ui := types.Users(u).IndexByID()
 
-	for _, u := range chans {
+	for _, c := range chans {
 		if err := csv.Write([]string{
-			u.ID,
-			NVL(u.Name, ui.DisplayName(u.User)),
-			_ft(int64(u.Created)),
-			_fb(u.IsArchived),
-			_fb(u.IsChannel),
-			_fb(u.IsMpIM),
-			_fb(u.IsPrivate),
-			_fb(u.IsIM),
-			u.Purpose.Value,
+			c.ID,
+			NVL(c.Name, ui.DisplayName(c.User)),
+			_ft(int64(c.Created)),
+			_fb(c.IsArchived),
+			_fb(c.IsChannel),
+			_fb(c.IsMpIM),
+			_fb(c.IsPrivate),
+			_fb(c.IsIM),
+			c.Purpose.Value,
 		}); err != nil {
 			return err
 		}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -68,6 +68,7 @@ type options struct {
 	textOptions
 	csvOptions
 	jsonOptions
+	bare bool // bare output format
 }
 
 // Option is the converter option.
@@ -84,6 +85,14 @@ func (e *Type) Set(v string) error {
 		}
 	}
 	return fmt.Errorf("unknown converter: %s", v)
+}
+
+// WithBareFormat allows to set the bare output format for the formatter that
+// supports it.
+func WithBareFormat(b bool) Option {
+	return func(o *options) {
+		o.bare = b
+	}
 }
 
 // userReplacer returns a replacer that replaces all user IDs with their

--- a/internal/format/text.go
+++ b/internal/format/text.go
@@ -100,6 +100,20 @@ func (txt *Text) txtConversations(w io.Writer, m []types.Message, prefix string,
 }
 
 func (txt *Text) Users(ctx context.Context, w io.Writer, u []slack.User) error {
+	if txt.opts.bare {
+		return txt.usersBare(ctx, w, u)
+	}
+	return txt.usersFull(ctx, w, u)
+}
+
+func (txt *Text) usersBare(_ context.Context, w io.Writer, u []slack.User) error {
+	for i := range u {
+		fmt.Fprintf(w, "%s\n", u[i].ID)
+	}
+	return nil
+}
+
+func (txt *Text) usersFull(_ context.Context, w io.Writer, u []slack.User) error {
 	const strFormat = "%s\t%s\t%s\t%s\t%s\t%s\n"
 	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	defer writer.Flush()
@@ -150,6 +164,20 @@ func (txt *Text) Users(ctx context.Context, w io.Writer, u []slack.User) error {
 }
 
 func (txt *Text) Channels(ctx context.Context, w io.Writer, u []slack.User, cc []slack.Channel) error {
+	if txt.opts.bare {
+		return txt.channelsBare(ctx, w, u, cc)
+	}
+	return txt.channelsFull(ctx, w, u, cc)
+}
+
+func (txt *Text) channelsBare(_ context.Context, w io.Writer, _ []slack.User, cc []slack.Channel) error {
+	for i := range cc {
+		fmt.Fprintf(w, "%s\n", cc[i].ID)
+	}
+	return nil
+}
+
+func (txt *Text) channelsFull(_ context.Context, w io.Writer, u []slack.User, cc []slack.Channel) error {
 	const strFormat = "%s\t%s\t%s\n"
 
 	ui := structures.NewUserIndex(u)


### PR DESCRIPTION
Fixes i491.

- Introduces `-b` flag for `list users` and `list channels` commands, that will enable the
  "bare output format".  Only user or channel IDs will be printed, one per line.
