### PR TITLE
Cater for string Attachment IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/rusq/fsadapter v1.1.0
 	github.com/rusq/osenv/v2 v2.0.1
 	github.com/rusq/rbubbles v0.0.2
-	github.com/rusq/slack v0.9.6-0.20250325121744-ce5571e08094
+	github.com/rusq/slack v0.9.6-0.20250408103104-dd80d1b6337f
 	github.com/rusq/slackauth v0.6.1
 	github.com/rusq/tagops v0.0.2
 	github.com/rusq/tracer v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,10 @@ github.com/rusq/slack v0.9.6-0.20241117083852-278084780c45 h1:tsZKbEaziqVowGaQ7z
 github.com/rusq/slack v0.9.6-0.20241117083852-278084780c45/go.mod h1:9O0zQAFN6W47z4KpTQbe6vOHOzBO76vMg1+gthPwaTI=
 github.com/rusq/slack v0.9.6-0.20250325121744-ce5571e08094 h1:362+9zlXvL8/HoaA90zGUYBfNA0fnjP5NRtQnA8QjTg=
 github.com/rusq/slack v0.9.6-0.20250325121744-ce5571e08094/go.mod h1:gULX17QqyNX4BF001nHKlSe0uKYI+MAKiDQ7oi80BYI=
+github.com/rusq/slack v0.9.6-0.20250408102249-dca10a4a8971 h1:2XW05HY/OlK+jn22MeYF4h6Zzvv1Vf3QM2TzjxhXDew=
+github.com/rusq/slack v0.9.6-0.20250408102249-dca10a4a8971/go.mod h1:gULX17QqyNX4BF001nHKlSe0uKYI+MAKiDQ7oi80BYI=
+github.com/rusq/slack v0.9.6-0.20250408103104-dd80d1b6337f h1:w4klfw1A3iZv5qWg1YHcRF2bJuRDV7aOpsF6sLLSs0A=
+github.com/rusq/slack v0.9.6-0.20250408103104-dd80d1b6337f/go.mod h1:gULX17QqyNX4BF001nHKlSe0uKYI+MAKiDQ7oi80BYI=
 github.com/rusq/slackauth v0.6.1 h1:s09G3WHSA1yz6H9dHT+Yo6DCZF34ClY31tQz849B++Q=
 github.com/rusq/slackauth v0.6.1/go.mod h1:wAtNCbeKH0pnaZnqJjG5RKY3e5BF9F2L/YTzhOjBIb0=
 github.com/rusq/tagops v0.0.2 h1:LkWsmpYSH5Q5IX3pv0Qm5PEKOtfjKqrwbJ3c19C1pvM=

--- a/internal/chunk/control/workers.go
+++ b/internal/chunk/control/workers.go
@@ -7,9 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/rusq/slackdump/v3/internal/convert/transform"
-
 	"github.com/rusq/slackdump/v3/internal/structures"
-
 	"github.com/rusq/slackdump/v3/processor"
 )
 

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -125,11 +125,11 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 	for res := range resultsC {
 		if err := res.Err; err != nil {
 			trace.Logf(ctx, "error", "type: %s, chan_id: %s, thread_ts: %s, error: %s", res.Type, res.ChannelID, res.ThreadTS, err.Error())
-			return err
+			return &res // res implements Error
 		}
 		for _, fn := range cs.resultFn {
 			if err := fn(res); err != nil {
-				return err
+				return fmt.Errorf("result %s, callback error: %w", res, err)
 			}
 		}
 	}
@@ -161,14 +161,6 @@ type request struct {
 	threadOnly bool
 	Oldest     time.Time
 	Latest     time.Time
-}
-
-func (we *Result) Error() string {
-	return fmt.Sprintf("%s channel %s: %v", we.Type, structures.SlackLink{Channel: we.ChannelID, ThreadTS: we.ThreadTS}, we.Err)
-}
-
-func (we *Result) Unwrap() error {
-	return we.Err
 }
 
 // channel fetches the channel data as defined in req, calling callback function for each API response.

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rusq/slackdump/v3/internal/client"
 	"github.com/rusq/slackdump/v3/internal/network"
+	"github.com/rusq/slackdump/v3/internal/structures"
 	"github.com/rusq/slackdump/v3/processor"
 )
 
@@ -91,15 +92,23 @@ type Result struct {
 	Err error
 }
 
-func (s Result) String() string {
-	switch s.Type {
+func (r *Result) Error() string {
+	return fmt.Sprintf("%s channel %s: %v", r.Type, structures.SlackLink{Channel: r.ChannelID, ThreadTS: r.ThreadTS}, r.Err)
+}
+
+func (r *Result) Unwrap() error {
+	return r.Err
+}
+
+func (r Result) String() string {
+	switch r.Type {
 	case RTSearch:
 		return "<search>"
 	default:
-		if s.ThreadTS == "" {
-			return "<" + s.ChannelID + ">"
+		if r.ThreadTS == "" {
+			return "<" + r.ChannelID + ">"
 		}
-		return fmt.Sprintf("<%s[%s:%s]>", s.Type, s.ChannelID, s.ThreadTS)
+		return fmt.Sprintf("<%s[%s:%s]>", r.Type, r.ChannelID, r.ThreadTS)
 	}
 }
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -92,15 +92,15 @@ type Result struct {
 	Err error
 }
 
-func (r *Result) Error() string {
+func (r Result) Error() string {
 	return fmt.Sprintf("%s channel %s: %v", r.Type, structures.SlackLink{Channel: r.ChannelID, ThreadTS: r.ThreadTS}, r.Err)
 }
 
-func (r *Result) Unwrap() error {
+func (r Result) Unwrap() error {
 	return r.Err
 }
 
-func (r *Result) String() string {
+func (r Result) String() string {
 	switch r.Type {
 	case RTSearch:
 		return "<search>"

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -100,7 +100,7 @@ func (r *Result) Unwrap() error {
 	return r.Err
 }
 
-func (r Result) String() string {
+func (r *Result) String() string {
 	switch r.Type {
 	case RTSearch:
 		return "<search>"


### PR DESCRIPTION
- **udpate the slack lib to handle string attachment id**
- **better streaming errors**

Fixes #492 
