### PR TITLE
treat json errors as warnings

### DIFF
--- a/internal/chunk/directory.go
+++ b/internal/chunk/directory.go
@@ -152,7 +152,7 @@ func collectAll[T any](ctx context.Context, d *Directory, numwrk int, fn func(na
 			if err != nil {
 				var jsonErr *json.SyntaxError
 				if errors.As(err, &jsonErr) {
-					slog.Warn("collectAll: json error", "file", name, "error", err.Error())
+					slog.Warn("invalid JSON", "file", name, "error", err.Error())
 					return nil
 				}
 				return fmt.Errorf("collectAll: error in %s: %w", name, err)
@@ -262,6 +262,13 @@ func (d *Directory) Walk(fn func(name string, f *File, err error) error) error {
 			return fn(path, nil, err)
 		}
 		cf, err := cachedFromReader(f, d.wantCache)
+		if err != nil {
+			var jsonErr *json.SyntaxError
+			if errors.As(err, &jsonErr) {
+				slog.Warn("invalid JSON", "file", path, "error", err.Error())
+				return nil
+			}
+		}
 		return fn(path, cf, err)
 	})
 }

--- a/internal/chunk/file.go
+++ b/internal/chunk/file.go
@@ -242,14 +242,14 @@ func (f *File) AllChannelInfos() ([]slack.Channel, error) {
 	}
 	for i := range chans {
 		if chans[i].IsArchived || chans[i].NumMembers == 0 {
-			slog.Default().Debug("skipping empty or archived channel", "i", i, "id", chans[i].ID)
+			slog.Debug("skipping empty or archived channel", "i", i, "id", chans[i].ID)
 			continue
 		}
 		members, err := f.ChannelUsers(chans[i].ID)
 		if err != nil {
 			if errors.Is(err, ErrNotFound) {
 				// ignoring missing channel users
-				slog.Default().Warn("no users", "channel_id", chans[i].ID, "error", err)
+				slog.Warn("no users", "channel_id", chans[i].ID, "error", err)
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
Re: #501.

Treat JSON errors as warning while parsing Channels during view or conversion.

Problematic files will be skipped.
