### PR TITLE
Quick fix for list commands not having YesMan flag enabled

### DIFF
--- a/cmd/slackdump/internal/list/common.go
+++ b/cmd/slackdump/internal/list/common.go
@@ -19,7 +19,7 @@ import (
 	"github.com/rusq/slackdump/v3/types"
 )
 
-const flagMask = cfg.OmitAll &^ cfg.OmitAuthFlags &^ cfg.OmitCacheDir &^ cfg.OmitWorkspaceFlag
+const flagMask = cfg.OmitAll &^ cfg.OmitAuthFlags &^ cfg.OmitCacheDir &^ cfg.OmitWorkspaceFlag &^ cfg.OmitYesManFlag
 
 // CmdList is the list command.  The logic is in the subcommands.
 var CmdList = &base.Command{


### PR DESCRIPTION
List commands write a file to disk, and with the recent change they were asking
for overwrite confirmation. Flag `-y` wasn't enabled for list commands, and now
it is.
