### PR TITLE
fix: Set content type for file downloads in viewer handler

### DIFF
--- a/internal/viewer/handlers.go
+++ b/internal/viewer/handlers.go
@@ -211,7 +211,6 @@ func (v *Viewer) fileHandler(w http.ResponseWriter, r *http.Request) {
 		filename = r.PathValue("filename")
 		ctx      = r.Context()
 	)
-
 	if id == "" || filename == "" || isInvalid(filename) || isInvalid(id) {
 		http.NotFound(w, r)
 		return


### PR DESCRIPTION
# Overview

Minor fix that resolves #569 by setting Content Header for all files to allow for successful serving of non-extension files (e.g Canvas files).

> [!TIP]
> See [Issue Comment](https://github.com/rusq/slackdump/issues/569#issuecomment-3530210386) for steps run and new behavior.

## Limitations ⚠️

### 1. Canvas Link

Canvases are only included in the `__uploads` directory in the dump file if a link to that canvas is included in the channel messages:

<img width="700" alt="Canvas link example" src="https://github.com/user-attachments/assets/b592568e-18a3-46e7-a43a-64765590c1e5" />

> [!NOTE]
> Without this link, the Canvas will be not included in the final dump file. 

### 2. Files in the Canvas

Files uploaded to the Canvas are not downloaded and are only represented as `File URL` links in the Canvas dump:

`__uploads/<Channel ID>/Example_Canvas`:
```html
<h1 id='temp:C:RVRac19dd8f6f69470d97606823c'>Example Canvas</h1>

<p id='temp:C:RVR614bc135fec24118aae3a9a89' class='line'>Example Text</p>

<p class='embedded-file'>File ID: F09TPE73WTA File URL: https://ohsucomputationalbio.slack.com/files/U042WA9K4DB/F09TPE73WTA/image.png</p>   <---- Example file is not downloaded
```

### 3. Test Failure

> [!CAUTION]
> All tests passing except for [Test_exportV3](https://github.com/rusq/slackdump/blob/v3.1.9/cmd/slackdump/internal/export/v3_test.go#L57) (need to investigate further...):
> 
> ```sh
> ➜ gh repo set-default rusq/slackdump
> ✓ Set rusq/slackdump as the default repository for the current directory
> 
> ➜ gh pr checkout 570
> Switched to branch 'fix/canvas-viewer'
> 
> ➜ make test
> go test -race -cover ./...
> ...
> --- FAIL: Test_exportV3 (0.00s)
>     --- FAIL: Test_exportV3/guest_user (0.00s)
>         v3_test.go:57: stat ../../../../tmp/guest: no such file or directory
> FAIL
> coverage: 2.9% of statements
> FAIL    github.com/rusq/slackdump/v3/cmd/slackdump/internal/export      0.771s
>         github.com/rusq/slackdump/v3/cmd/slackdump/internal/format      coverage: 0.0% of statements
> ...
> FAIL
> make: *** [test] Error 1
> 
> ```