### PR TITLE
Bump Slackauth to support flatpaks of Brave and Chromium

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/rusq/osenv/v2 v2.0.1
 	github.com/rusq/rbubbles v0.0.2
 	github.com/rusq/slack v0.9.6-0.20250408103104-dd80d1b6337f
-	github.com/rusq/slackauth v0.7.0
+	github.com/rusq/slackauth v0.7.1
 	github.com/rusq/tagops v0.1.1
 	github.com/rusq/tracer v1.0.1
 	github.com/schollz/progressbar/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/rusq/slack v0.9.6-0.20250408103104-dd80d1b6337f h1:w4klfw1A3iZv5qWg1Y
 github.com/rusq/slack v0.9.6-0.20250408103104-dd80d1b6337f/go.mod h1:gULX17QqyNX4BF001nHKlSe0uKYI+MAKiDQ7oi80BYI=
 github.com/rusq/slackauth v0.7.0 h1:BLqrehKIbs2z4exc38zXecganFrqgnJIJQnL+cYdoFY=
 github.com/rusq/slackauth v0.7.0/go.mod h1:UOqfnUaJeygO9rYShAhsLxAZjbbEBNaLZpsdw03W3R0=
+github.com/rusq/slackauth v0.7.1 h1:D4peflZtHSyQFh5pLeBI8n0f12enuA9D25mA0KaHo8o=
+github.com/rusq/slackauth v0.7.1/go.mod h1:UOqfnUaJeygO9rYShAhsLxAZjbbEBNaLZpsdw03W3R0=
 github.com/rusq/tagops v0.1.1 h1:R5MHPR822lSg3LFr0RS3DFS0CapRiqtuHVD5NlOMOvY=
 github.com/rusq/tagops v0.1.1/go.mod h1:mUJ5WoHxrSv9wreCrHQkAeMevt5aXFadlOdLM6UsoHc=
 github.com/rusq/tracer v1.0.1 h1:5u4PCV8NGO97VuAINQA4gOVRkPoqHimLE2jpezRVNMU=


### PR DESCRIPTION
Note: I can't test this, as I don't have an ubuntu machine.

Original issue: https://github.com/rusq/slackauth/issues/23