### PR TITLE
fix(format): prevent panic when thread has no replies in time range

### DIFF
--- a/cmd/slackdump/internal/format/source.go
+++ b/cmd/slackdump/internal/format/source.go
@@ -128,6 +128,11 @@ func getThread(ctx context.Context, src source.Sourcer, chanID string, ts string
 		}
 		mm = append(mm, types.Message{Message: threadMsg})
 	}
+	// Skip the parent message (first element) - return only replies.
+	// If there are no messages or only the parent, return empty slice.
+	if len(mm) <= 1 {
+		return nil, nil
+	}
 	return mm[1:], nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #599

When using `slackdump convert` with a time range filter, threads that have no replies within the specified time range cause a panic due to an out-of-bounds slice operation.

The `getThread` function returns `mm[1:]` to skip the parent message, but when there are no replies (only the parent or empty), this causes a panic.

## Changes

- Add bounds check before slicing to skip the parent message
- Return empty slice when there are no replies to process

## Test plan

- Run `slackdump convert` with a time range that excludes thread replies
- Verify no panic occurs and empty threads are handled gracefully