### PR TITLE
Implement single/multi-user export conversion modes

### DIFF
--- a/cmd/slackdump/internal/convertcmd/convert.go
+++ b/cmd/slackdump/internal/convertcmd/convert.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rusq/slackdump/v4/cmd/slackdump/internal/bootstrap"
 	"github.com/rusq/slackdump/v4/cmd/slackdump/internal/cfg"
 	"github.com/rusq/slackdump/v4/cmd/slackdump/internal/golang/base"
+	"github.com/rusq/slackdump/v4/internal/structures"
 )
 
 //go:embed assets/convert.md
@@ -66,12 +67,14 @@ type convertflags struct {
 	includeFiles   bool
 	includeAvatars bool
 	outStorageType source.StorageType
+	dmMode         structures.DMMode
 	sessionID      int64 // sessionID for database->chunk conversion
 	outputfmt      datafmt
 }
 
 var params = convertflags{
 	outStorageType: source.STmattermost,
+	dmMode:         structures.DMSingle,
 	sessionID:      1,
 	outputfmt:      Fexport,
 }
@@ -80,6 +83,7 @@ func init() {
 	CmdConvert.Flag.Var(&params.outStorageType, "storage", "storage type")
 	CmdConvert.Flag.Var(&params.outputfmt, "format", "output `format`")
 	CmdConvert.Flag.Var(&params.outputfmt, "f", "shorthand for -format")
+	CmdConvert.Flag.Var(&params.dmMode, "dm-mode", "DM export mode: single or multi")
 	CmdConvert.Flag.Int64Var(&params.sessionID, "session", params.sessionID, "session `id` for database->chunk conversion")
 }
 

--- a/cmd/slackdump/internal/convertcmd/to_export.go
+++ b/cmd/slackdump/internal/convertcmd/to_export.go
@@ -67,6 +67,7 @@ func toExport(ctx context.Context, src, trg string, cflg convertflags) error {
 		fsa,
 		convert.WithIncludeFiles(includeFiles),
 		convert.WithIncludeAvatars(includeAvatars),
+		convert.WithDMMode(cflg.dmMode),
 		convert.WithTrgFileLoc(sttFn),
 		convert.WithLogger(cfg.Log),
 	)

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/rusq/slackdump/v4/internal/structures"
 	"github.com/rusq/slackdump/v4/source"
 
 	"github.com/rusq/slack"
@@ -57,6 +58,8 @@ type options struct {
 	trgFileLoc func(*slack.Channel, *slack.File) string
 	// avtrFileLoc should return the avatar file location.
 	avtrFileLoc func(*slack.User) string
+	// dmMode controls how single-member IMs are serialized into dms.json.
+	dmMode structures.DMMode
 	// lg is the logger
 	lg *slog.Logger
 }
@@ -95,6 +98,15 @@ func WithLogger(lg *slog.Logger) Option {
 	return func(c *options) {
 		if lg != nil {
 			c.lg = lg
+		}
+	}
+}
+
+// WithDMMode sets the DM serialization mode for export conversion.
+func WithDMMode(mode structures.DMMode) Option {
+	return func(c *options) {
+		if mode != "" {
+			c.dmMode = mode
 		}
 	}
 }

--- a/internal/convert/export.go
+++ b/internal/convert/export.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/rusq/slackdump/v4/internal/convert/transform"
 	"github.com/rusq/slackdump/v4/internal/convert/transform/fileproc"
+	"github.com/rusq/slackdump/v4/internal/structures"
 	"github.com/rusq/slackdump/v4/source"
 )
 
@@ -68,6 +69,7 @@ func NewToExport(src source.Sourcer, trg fsadapter.FS, opt ...Option) *ToExport 
 		opts: options{
 			includeFiles:   false,
 			includeAvatars: false,
+			dmMode:         structures.DMSingle,
 			trgFileLoc:     source.MattermostFilepath,
 			avtrFileLoc:    fileproc.AvatarPath,
 			lg:             slog.Default(),
@@ -130,6 +132,7 @@ func (c *ToExport) Convert(ctx context.Context) error {
 
 	tfopts := []transform.ExpCvtOption{
 		transform.ExpWithUsers(users),
+		transform.ExpWithDMMode(c.opts.dmMode),
 	}
 	// 1. generator
 	chC := sliceToChan(channels)

--- a/internal/convert/transform/export.go
+++ b/internal/convert/transform/export.go
@@ -51,17 +51,25 @@ func ExpWithUsers(users []slack.User) ExpCvtOption {
 	}
 }
 
+func ExpWithDMMode(mode structures.DMMode) ExpCvtOption {
+	return func(t *ExpConverter) {
+		t.dmMode = mode
+	}
+}
+
 type ExpConverter struct {
 	src     source.Sourcer
 	fsa     fsadapter.FS
 	users   atomic.Value
+	dmMode  structures.DMMode
 	msgFunc []msgUpdFunc
 }
 
 func NewExpConverter(src source.Sourcer, fsa fsadapter.FS, opt ...ExpCvtOption) *ExpConverter {
 	e := &ExpConverter{
-		src: src,
-		fsa: fsa,
+		src:    src,
+		fsa:    fsa,
+		dmMode: structures.DMSingle,
 	}
 	for _, o := range opt {
 		o(e)
@@ -193,7 +201,7 @@ func (e *ExpConverter) WriteIndex(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error indexing channels: %w", err)
 	}
-	eidx, err := structures.MakeExportIndex(chans, e.getUsers(), wsp.UserID)
+	eidx, err := structures.MakeExportIndex(chans, e.getUsers(), wsp.UserID, e.dmMode)
 	if err != nil {
 		return fmt.Errorf("error creating export index: %w", err)
 	}

--- a/internal/structures/index.go
+++ b/internal/structures/index.go
@@ -48,6 +48,35 @@ type DM struct {
 	Members []string `json:"members"`
 }
 
+// DMMode controls how 1-member IMs are serialized into dms.json.
+type DMMode string
+
+const (
+	// DMSingle serializes IMs for single-user exports, preserving the historic
+	// slackdump round-trip convention of [other_user, current_user].
+	DMSingle DMMode = "single"
+	// DMMulti preserves the observed IM membership for merged multi-user
+	// archives where a single archive-wide "me" is not meaningful.
+	DMMulti DMMode = "multi"
+)
+
+func (m *DMMode) Set(v string) error {
+	switch DMMode(strings.ToLower(v)) {
+	case DMSingle, DMMulti:
+		*m = DMMode(strings.ToLower(v))
+		return nil
+	default:
+		return fmt.Errorf("unknown dm mode: %s", v)
+	}
+}
+
+func (m DMMode) String() string {
+	if m == "" {
+		return string(DMSingle)
+	}
+	return string(m)
+}
+
 var (
 	ErrNoChannel = errors.New("empty channel data base")
 	ErrNoUsers   = errors.New("empty users data base")
@@ -57,7 +86,7 @@ var (
 // MakeExportIndex creates a channels and users index for export archive, splitting
 // channels in group/mpims/dms/public channels.  currentUserID should contain
 // the current user ID.
-func MakeExportIndex(channels []slack.Channel, users []slack.User, currentUserID string) (*ExportIndex, error) {
+func MakeExportIndex(channels []slack.Channel, users []slack.User, currentUserID string, dmMode DMMode) (*ExportIndex, error) {
 	if len(channels) == 0 {
 		return nil, ErrNoChannel
 	}
@@ -79,7 +108,7 @@ func MakeExportIndex(channels []slack.Channel, users []slack.User, currentUserID
 	for _, ch := range channels {
 		switch {
 		case ch.IsIM:
-			idx.DMs = append(idx.DMs, convertToDM(currentUserID, ch))
+			idx.DMs = append(idx.DMs, convertToDM(currentUserID, ch, dmMode))
 		case ch.IsMpIM:
 			if ch.NumMembers == 0 {
 				ch.NumMembers = len(ch.Members)
@@ -235,9 +264,9 @@ func except[S ~[]T, T comparable](s T, ss S, stopAfterIdx int) T {
 // user, it returns an empty string.  The user, who appears in "Members" slices
 // the most, is considered the current user.
 //
-// When there is a tie (e.g. a single DM where both members appear once),
-// the last member of the first DM is chosen as "me", because slackdump
-// exports DM members as [other_user, current_user].
+// When there is a tie, the last member of the first DM is chosen as "me" to
+// keep restores from single-user exports stable.  Multi-user exports are
+// best-effort with this heuristic, because dms.json has no archive-wide owner.
 func mostFrequentMember(dms []DM) string {
 	counts := make(map[string]int)
 	for _, dm := range dms {
@@ -266,23 +295,34 @@ func mostFrequentMember(dms []DM) string {
 		}
 	}
 	if tied > 1 && len(dms) > 0 && len(dms[0].Members) > 0 {
-		// When exported by slackdump, the DM members are typically ordered as
+		// Single-user exports typically order members as
 		// [other_user, current_user], so pick the last member as "me".
 		return dms[0].Members[len(dms[0].Members)-1]
 	}
 	return id
 }
 
-func convertToDM(me string, ch slack.Channel) DM {
+func convertToDM(me string, ch slack.Channel, mode DMMode) DM {
+	if mode == "" {
+		mode = DMSingle
+	}
 	d := DM{
 		ID:      ch.ID,
 		Created: int64(ch.Created),
 	}
 	switch len(ch.Members) {
 	case 0:
-		d.Members = []string{ch.User, me}
+		if mode == DMMulti {
+			d.Members = []string{ch.User, ch.User}
+		} else {
+			d.Members = []string{ch.User, me}
+		}
 	case 1:
-		d.Members = []string{ch.User, me}
+		if mode == DMMulti {
+			d.Members = []string{ch.User, ch.Members[0]}
+		} else {
+			d.Members = []string{ch.User, me}
+		}
 	default:
 		d.Members = normalizeDMMembers(me, ch.Members)
 	}

--- a/internal/structures/index_test.go
+++ b/internal/structures/index_test.go
@@ -469,6 +469,7 @@ func TestMakeExportIndex(t *testing.T) {
 		channels      []slack.Channel
 		users         []slack.User
 		currentUserID string
+		dmMode        DMMode
 	}
 	tests := []struct {
 		name    string
@@ -482,6 +483,7 @@ func TestMakeExportIndex(t *testing.T) {
 				fixtures.Load[[]slack.Channel](string(fixtures.TestExpReferenceChannelsJSON)),
 				fixtures.Load[[]slack.User](string(fixtures.TestExpUsersJSON)),
 				"UGTRHT2SH",
+				DMSingle,
 			},
 			&ExportIndex{
 				Channels: fixtures.Load[[]slack.Channel](string(fixtures.TestExpChannelsJSON)),
@@ -492,10 +494,43 @@ func TestMakeExportIndex(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"makes index in multi-user mode",
+			args{
+				[]slack.Channel{
+					{
+						GroupConversation: slack.GroupConversation{
+							Conversation: slack.Conversation{
+								ID:      "D01",
+								User:    "UOTHER123",
+								Created: slack.JSONTime(1568448961),
+								IsIM:    true,
+							},
+							Members: []string{"UOTHER123"},
+						},
+					},
+				},
+				[]slack.User{{ID: "UGTRHT2SH"}},
+				"UGTRHT2SH",
+				DMMulti,
+			},
+			&ExportIndex{
+				Channels: []slack.Channel{},
+				Groups:   []slack.Channel{},
+				MPIMs:    []slack.Channel{},
+				DMs: []DM{{
+					ID:      "D01",
+					Created: 1568448961,
+					Members: []string{"UOTHER123", "UOTHER123"},
+				}},
+				Users: []slack.User{{ID: "UGTRHT2SH"}},
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MakeExportIndex(tt.args.channels, tt.args.users, tt.args.currentUserID)
+			got, err := MakeExportIndex(tt.args.channels, tt.args.users, tt.args.currentUserID, tt.args.dmMode)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MakeExportIndex() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -599,8 +634,9 @@ func Test_dmsToChannels(t *testing.T) {
 
 func Test_convertToDM(t *testing.T) {
 	type args struct {
-		me string
-		ch slack.Channel
+		me   string
+		ch   slack.Channel
+		mode DMMode
 	}
 	tests := []struct {
 		name string
@@ -618,7 +654,7 @@ func Test_convertToDM(t *testing.T) {
 					},
 					Members: []string{"UNEERHWJJ", "UGTRHT2SH"},
 				},
-			}},
+			}, DMSingle},
 			DM{
 				ID:      "DNC8S27U5",
 				Created: 1568448961,
@@ -636,7 +672,7 @@ func Test_convertToDM(t *testing.T) {
 					},
 					Members: []string{"UGTRHT2SH", "UNEERHWJJ"},
 				},
-			}},
+			}, DMSingle},
 			DM{
 				ID:      "DNC8S27U5",
 				Created: 1568448961,
@@ -654,11 +690,29 @@ func Test_convertToDM(t *testing.T) {
 						IsIM:    true,
 					},
 				},
-			}},
+			}, DMSingle},
 			DM{
 				ID:      "DNC8S27U5",
 				Created: 1568448961,
 				Members: []string{"UNEERHWJJ", "UGTRHT2SH"},
+			},
+		},
+		{
+			"multi mode zero members uses ch.User for both",
+			args{"UGTRHT2SH", slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{
+						ID:      "DNC8S27U5",
+						User:    "UNEERHWJJ",
+						Created: slack.JSONTime(1568448961),
+						IsIM:    true,
+					},
+				},
+			}, DMMulti},
+			DM{
+				ID:      "DNC8S27U5",
+				Created: 1568448961,
+				Members: []string{"UNEERHWJJ", "UNEERHWJJ"},
 			},
 		},
 		{
@@ -673,11 +727,49 @@ func Test_convertToDM(t *testing.T) {
 					},
 					Members: []string{"UGTRHT2SH"},
 				},
-			}},
+			}, DMSingle},
 			DM{
 				ID:      "DNC8S27U5",
 				Created: 1568448961,
 				Members: []string{"UGTRHT2SH", "UGTRHT2SH"},
+			},
+		},
+		{
+			"single mode synthesizes current user for 1-member dm",
+			args{"UGTRHT2SH", slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{
+						ID:      "DNC8S27U5",
+						User:    "UOTHER123",
+						Created: slack.JSONTime(1568448961),
+						IsIM:    true,
+					},
+					Members: []string{"UOTHER123"},
+				},
+			}, DMSingle},
+			DM{
+				ID:      "DNC8S27U5",
+				Created: 1568448961,
+				Members: []string{"UOTHER123", "UGTRHT2SH"},
+			},
+		},
+		{
+			"multi mode preserves observed member for 1-member dm",
+			args{"UGTRHT2SH", slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{
+						ID:      "DNC8S27U5",
+						User:    "UOTHER123",
+						Created: slack.JSONTime(1568448961),
+						IsIM:    true,
+					},
+					Members: []string{"UOTHER123"},
+				},
+			}, DMMulti},
+			DM{
+				ID:      "DNC8S27U5",
+				Created: 1568448961,
+				Members: []string{"UOTHER123", "UOTHER123"},
 			},
 		},
 		{
@@ -691,7 +783,7 @@ func Test_convertToDM(t *testing.T) {
 						IsIM:    true,
 					},
 				},
-			}},
+			}, DMSingle},
 			DM{
 				ID:      "DNC8S27U5",
 				Created: 1568448961,
@@ -701,7 +793,7 @@ func Test_convertToDM(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := convertToDM(tt.args.me, tt.args.ch); !reflect.DeepEqual(got, tt.want) {
+			if got := convertToDM(tt.args.me, tt.args.ch, tt.args.mode); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("convertToDM() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Introduce a convert-scoped flag -dm-mode=single|multi, defaulting to single, to
make DM serialization policy explicit during export generation.

`single` preserves the current Slack-compatible / round-trip-oriented behavior
for 1-member IMs by synthesizing `[other_user, current_user]`. `multi` preserves
the observed channel membership for merged multi-token archives and treats
later restore of those DMs as best-effort rather than guaranteed round-trip
reconstruction.
