### PR TITLE
Add resume flag to not update complete looking threads

### DIFF
--- a/cmd/slackdump/internal/resume/resume.go
+++ b/cmd/slackdump/internal/resume/resume.go
@@ -69,6 +69,14 @@ type ResumeParams struct {
 	// new threads on historical messages, otherwise, new threads on old messages
 	// will not be fetched.
 	Lookback *extDuration
+	// SkipCompleteThreads skips fetching threads where the DB already has
+	// all replies (DB count matches API reply_count).
+	// Benefit: Significantly faster resume - skips API calls for threads that
+	// appear complete, reducing both time and API rate limit usage.
+	// Risk: Does not detect edited/deleted messages - only compares counts.
+	// If a message was modified or removed on Slack, this flag will still skip
+	// the thread. Use only when you're certain threads are append-only.
+	SkipCompleteThreads bool
 }
 
 var resumeFlags = ResumeParams{
@@ -81,6 +89,7 @@ func init() {
 	CmdResume.Flag.BoolVar(&resumeFlags.IncludeThreads, "threads", false, "include threads (slow, and flaky business)")
 	CmdResume.Flag.BoolVar(&resumeFlags.RecordOnlyNewUsers, "only-new-users", true, "record only new or updated users")
 	CmdResume.Flag.Var(resumeFlags.Lookback, "lookback", "lookback window `duration`")
+	CmdResume.Flag.BoolVar(&resumeFlags.SkipCompleteThreads, "skip-complete-threads", false, "skip threads where DB already has all replies (faster, but won't detect edits/deletes)")
 }
 
 func runResume(ctx context.Context, cmd *base.Command, args []string) error {
@@ -159,7 +168,11 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 	}
 	// inclusive is false, because we don't want to include the latest message
 	// which is already in the database.
-	ctrl, err := archive.DBController(ctx, cmd.Name(), wconn, client, dir, cf, []stream.Option{stream.OptInclusive(false)}, dbase.WithOnlyNewOrChangedUsers(resumeFlags.RecordOnlyNewUsers))
+	streamOpts := []stream.Option{stream.OptInclusive(false)}
+	if resumeFlags.SkipCompleteThreads {
+		streamOpts = append(streamOpts, stream.OptSkipCompleteThreads(true))
+	}
+	ctrl, err := archive.DBController(ctx, cmd.Name(), wconn, client, dir, cf, streamOpts, dbase.WithOnlyNewOrChangedUsers(resumeFlags.RecordOnlyNewUsers))
 	if err != nil {
 		base.SetExitStatus(base.SInitializationError)
 		return fmt.Errorf("error creating archive controller: %w", err)

--- a/internal/chunk/backend/dbase/dbase.go
+++ b/internal/chunk/backend/dbase/dbase.go
@@ -207,6 +207,17 @@ func (d *DBP) IsCompleteThread(ctx context.Context, channelID, threadID string) 
 	return n > 0, nil
 }
 
+// CountThread returns the number of messages in a thread from the database.
+func (d *DBP) CountThread(ctx context.Context, channelID, threadID string) (int64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	count, err := d.mr.CountThread(ctx, d.conn, channelID, threadID)
+	if err != nil {
+		return 0, fmt.Errorf("countThread: %w", err)
+	}
+	return count, nil
+}
+
 // Source returns the connection that can be used safely as a source.
 func (d *DBP) Source() *Source {
 	return &Source{

--- a/internal/chunk/backend/dbase/repository/dbmessage.go
+++ b/internal/chunk/backend/dbase/repository/dbmessage.go
@@ -209,7 +209,27 @@ func (r messageRepository) CountThread(ctx context.Context, conn sqlx.QueryerCon
 	if err != nil {
 		return 0, fmt.Errorf("countThread fasttime: %w", err)
 	}
-	return r.countTypeWhere(ctx, conn, queryParams{Where: r.threadCond(), Binds: []any{channelID, parentID}}, chunk.CMessages, chunk.CThreadMessages)
+	// Count UNIQUE messages in the thread across all chunks/sessions.
+	// Includes the parent message.
+	// Uses DISTINCT on TS because resume may create duplicate entries for the same message.
+	// This is needed for resume to correctly detect complete threads.
+	const stmt = `
+		SELECT COUNT(DISTINCT M.TS)
+		FROM MESSAGE M
+		JOIN CHUNK C ON M.CHUNK_ID = C.ID
+		WHERE C.TYPE_ID IN (?, ?)
+		  AND M.CHANNEL_ID = ?
+		  AND M.PARENT_ID = ?
+		  AND (
+			JSON_EXTRACT(M.DATA, '$.subtype') IS NULL
+			OR (JSON_EXTRACT(M.DATA, '$.subtype') = 'thread_broadcast' AND C.TYPE_ID = 1)
+		  )
+	`
+	var n int64
+	if err := conn.QueryRowxContext(ctx, rebind(conn, stmt), chunk.CMessages, chunk.CThreadMessages, channelID, parentID).Scan(&n); err != nil {
+		return 0, fmt.Errorf("countThread: %w", err)
+	}
+	return n, nil
 }
 
 func (r messageRepository) AllForThread(ctx context.Context, conn sqlx.QueryerContext, channelID, threadID string) (iter.Seq2[DBMessage, error], error) {

--- a/internal/chunk/backend/directory/conversations.go
+++ b/internal/chunk/backend/directory/conversations.go
@@ -240,6 +240,11 @@ func (cv *Conversations) Close() error {
 	return cv.t.CloseAll()
 }
 
+// CountThread returns an error - directory backend does not support counting.
+func (cv *Conversations) CountThread(ctx context.Context, channelID, threadTS string) (int64, error) {
+	return 0, errors.New("CountThread not supported by directory backend - use database backend")
+}
+
 func (cv *Conversations) debugtrace(ctx context.Context, fmt string, args ...any) {
 	trace.Logf(ctx, "debug", fmt, args...)
 }

--- a/internal/chunk/control/control.go
+++ b/internal/chunk/control/control.go
@@ -69,6 +69,9 @@ func (c *Controller) newConvTransformer(ctx context.Context) *conversationTransf
 // [structures.NewEntityList] function.
 func (c *Controller) Run(ctx context.Context, list *structures.EntityList) error {
 	rec := chunk.NewCustomRecorder(c.erc)
+	if ct, ok := c.erc.(chunk.CountThreader); ok {
+		rec = chunk.NewCustomRecorder(c.erc, chunk.WithCountThreader(ct))
+	}
 	defer rec.Close()
 
 	// got to do some explanation here: the order of processors is important:
@@ -83,6 +86,9 @@ func (c *Controller) Run(ctx context.Context, list *structures.EntityList) error
 // the data. Call this if you don't need to track channel completion etc.
 func (c *Controller) RunNoTransform(ctx context.Context, list *structures.EntityList) error {
 	rec := chunk.NewCustomRecorder(c.erc)
+	if ct, ok := c.erc.(chunk.CountThreader); ok {
+		rec = chunk.NewCustomRecorder(c.erc, chunk.WithCountThreader(ct))
+	}
 	defer rec.Close()
 
 	conv := processor.PrependFiler(rec, c.filer)

--- a/internal/chunk/recorder.go
+++ b/internal/chunk/recorder.go
@@ -25,10 +25,16 @@ import (
 	"github.com/rusq/slack"
 )
 
+// CountThreader is the interface for counting thread messages.
+type CountThreader interface {
+	CountThread(ctx context.Context, channelID, threadTS string) (int64, error)
+}
+
 // Recorder records all the data it receives into a writer.
 type Recorder struct {
-	mu  sync.Mutex
-	enc Encoder // encoder to use for the chunks
+	mu    sync.Mutex
+	enc   Encoder       // encoder to use for the chunks
+	count CountThreader // optional delegate for CountThread
 }
 
 // Encoder is the interface that wraps the Encode method.
@@ -262,4 +268,19 @@ func (rec *Recorder) SearchFiles(ctx context.Context, query string, sf []slack.F
 		return err
 	}
 	return nil
+}
+
+// WithCountThreader sets the delegate for CountThread operations.
+func WithCountThreader(ct CountThreader) Option {
+	return func(r *Recorder) {
+		r.count = ct
+	}
+}
+
+// CountThread returns the count from the delegate if set, otherwise 0.
+func (rec *Recorder) CountThread(ctx context.Context, channelID, threadTS string) (int64, error) {
+	if rec.count != nil {
+		return rec.count.CountThread(ctx, channelID, threadTS)
+	}
+	return 0, nil
 }

--- a/mocks/mock_processor/mock_processor.go
+++ b/mocks/mock_processor/mock_processor.go
@@ -83,6 +83,21 @@ func (mr *MockConversationsMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConversations)(nil).Close))
 }
 
+// CountThread mocks base method.
+func (m *MockConversations) CountThread(ctx context.Context, channelID, threadTS string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountThread", ctx, channelID, threadTS)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountThread indicates an expected call of CountThread.
+func (mr *MockConversationsMockRecorder) CountThread(ctx, channelID, threadTS any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountThread", reflect.TypeOf((*MockConversations)(nil).CountThread), ctx, channelID, threadTS)
+}
+
 // Files mocks base method.
 func (m *MockConversations) Files(ctx context.Context, channel *slack.Channel, parent slack.Message, ff []slack.File) error {
 	m.ctrl.T.Helper()

--- a/processor/discarder.go
+++ b/processor/discarder.go
@@ -67,6 +67,10 @@ func (d *Printer) ChannelUsers(_ context.Context, ch string, threadID string, u 
 	return nil
 }
 
+func (d *Printer) CountThread(_ context.Context, channelID, threadTS string) (int64, error) {
+	return 0, nil
+}
+
 func (d *Printer) Close() error {
 	slog.Info("Discarder closing")
 	return nil

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -31,6 +31,9 @@ type Conversations interface {
 	Filer
 	ChannelInformer
 
+	// CountThread returns the number of messages in a thread from the database.
+	CountThread(ctx context.Context, channelID, threadTS string) (int64, error)
+
 	io.Closer
 }
 
@@ -331,6 +334,11 @@ func (w *JointConversations) ThreadMessages(ctx context.Context, channelID strin
 		}
 	}
 	return errs
+}
+
+// CountThread executes the CountThread on the Conversations processor.
+func (w *JointConversations) CountThread(ctx context.Context, channelID, threadTS string) (int64, error) {
+	return w.c.CountThread(ctx, channelID, threadTS)
 }
 
 // Close closes all the io.Closer instances in the slice.

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -283,7 +283,7 @@ func (cs *Stream) thread(ctx context.Context, req request, callback func(mm []sl
 // procChanMsg processes the message slice mm, for each threaded message, it
 // sends the thread request on threadC.  It returns thread count in the mm and
 // error if any.
-func procChanMsg(ctx context.Context, proc processor.Conversations, threadC chan<- request, channel *slack.Channel, isLast bool, mm []slack.Message) (int, error) {
+func (cs *Stream) procChanMsg(ctx context.Context, proc processor.Conversations, threadC chan<- request, channel *slack.Channel, isLast bool, mm []slack.Message) (int, error) {
 	trs := make([]request, 0, len(mm))
 	for i := range mm {
 		// collecting threads to get their count.  But we don't start
@@ -292,6 +292,26 @@ func procChanMsg(ctx context.Context, proc processor.Conversations, threadC chan
 		// start processing the channel and will have the initial reference
 		// count, if it needs it.
 		if mm[i].ThreadTimestamp != "" && mm[i].SubType != structures.SubTypeThreadBroadcast && mm[i].LatestReply != structures.LatestReplyNoReplies {
+			// Check if we should skip complete threads
+			if cs.skipCompleteThreads {
+				dbCount, err := proc.CountThread(ctx, channel.ID, mm[i].ThreadTimestamp)
+				slog.DebugContext(ctx, "thread check",
+					"skipCompleteThreads", cs.skipCompleteThreads,
+					"channel_id", channel.ID,
+					"thread_ts", mm[i].ThreadTimestamp,
+					"dbCount", dbCount,
+					"replyCount", mm[i].ReplyCount,
+					"err", err)
+				// dbCount includes parent message, Slack's replyCount excludes it, so add 1
+		if err == nil && int(dbCount) == mm[i].ReplyCount+1 {
+					slog.DebugContext(ctx, "skipping complete thread",
+						"channel_id", channel.ID,
+						"thread_ts", mm[i].ThreadTimestamp,
+						"reply_count", mm[i].ReplyCount)
+					continue
+				}
+			}
+
 			slog.DebugContext(ctx, "- message", "i", i, "thread", mm[i].Timestamp, "thread_ts", mm[i].ThreadTimestamp, "channel_id", channel.ID, "is_last", isLast, "msg_count", len(mm))
 			trs = append(trs, request{
 				sl: &structures.SlackLink{

--- a/stream/conversation_test.go
+++ b/stream/conversation_test.go
@@ -137,7 +137,8 @@ func Test_procChanMsg(t *testing.T) {
 			if tt.expectFn != nil {
 				tt.expectFn(mp)
 			}
-			got, err := procChanMsg(tt.args.ctx, mp, tt.args.threadC, tt.args.channel, tt.args.isLast, tt.args.mm)
+			cs := &Stream{skipCompleteThreads: false}
+			got, err := cs.procChanMsg(tt.args.ctx, mp, tt.args.threadC, tt.args.channel, tt.args.isLast, tt.args.mm)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("procChanMsg() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -50,15 +50,16 @@ const (
 // Stream is used to fetch conversations from Slack.  It is safe for concurrent
 // use.
 type Stream struct {
-	oldest, latest time.Time
-	client         client.Slack
-	limits         rateLimits
-	chanCache      *chanCache
-	userCache      *userCache
-	fastSearch     bool
-	inclusive      bool
-	failChnlNotFnd bool // if true, will fail if channel not found
-	resultFn       []func(sr Result) error
+	oldest, latest      time.Time
+	client              client.Slack
+	limits              rateLimits
+	chanCache           *chanCache
+	userCache           *userCache
+	fastSearch          bool
+	inclusive           bool
+	failChnlNotFnd      bool // if true, will fail if channel not found
+	resultFn            []func(sr Result) error
+	skipCompleteThreads bool // if true, skip threads where DB count matches API reply_count
 }
 
 // ResultType helps to identify the type of the result, so that the callback
@@ -175,6 +176,15 @@ func OptInclusive(b bool) Option {
 func OptFailOnNonCritError(b bool) Option {
 	return func(cs *Stream) {
 		cs.failChnlNotFnd = b
+	}
+}
+
+// OptSkipCompleteThreads enables skipping threads where the database already
+// has all replies (DB count matches API reply_count).  This speeds up resume
+// operations but won't detect edited/deleted messages.
+func OptSkipCompleteThreads(b bool) Option {
+	return func(cs *Stream) {
+		cs.skipCompleteThreads = b
 	}
 }
 

--- a/stream/stream_workers.go
+++ b/stream/stream_workers.go
@@ -55,7 +55,7 @@ func (cs *Stream) channelWorker(ctx context.Context, proc processor.Conversation
 			}
 
 			if err := cs.channel(ctx, req, func(mm []slack.Message, isLast bool) error {
-				n, err := procChanMsg(ctx, proc, threadC, channel, isLast, mm)
+				n, err := cs.procChanMsg(ctx, proc, threadC, channel, isLast, mm)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Add new `skip-complete-threads` to `resume` when using `-threads`.

It safes API calls and therefore speeds up slackdump by not re-checking threads when the message returned by the Slack API equals the thread messages found in the DB.

On the downside it will miss any updates/deletes/changed reactions of messages in a slack thread. It is therefore an optional feature flag.