### PR TITLE
skip-complete-threads resume flag

### DIFF
--- a/cmd/slackdump/internal/resume/resume.go
+++ b/cmd/slackdump/internal/resume/resume.go
@@ -69,6 +69,10 @@ type ResumeParams struct {
 	// new threads on historical messages, otherwise, new threads on old messages
 	// will not be fetched.
 	Lookback *extDuration
+	// SkipCompleteThreads skips threads where the database already holds all
+	// replies (DB count == API reply_count + 1).  Faster, but won't detect
+	// edited or deleted messages.  Use only when threads are append-only.
+	SkipCompleteThreads bool
 }
 
 var resumeFlags = ResumeParams{
@@ -81,6 +85,7 @@ func init() {
 	CmdResume.Flag.BoolVar(&resumeFlags.IncludeThreads, "threads", false, "include threads (slow, and flaky business)")
 	CmdResume.Flag.BoolVar(&resumeFlags.RecordOnlyNewUsers, "only-new-users", true, "record only new or updated users")
 	CmdResume.Flag.Var(resumeFlags.Lookback, "lookback", "lookback window `duration`")
+	CmdResume.Flag.BoolVar(&resumeFlags.SkipCompleteThreads, "skip-complete-threads", false, "skip threads where DB already has all replies (faster, but won't detect edits/deletes)")
 }
 
 func runResume(ctx context.Context, cmd *base.Command, args []string) error {
@@ -159,7 +164,11 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 	}
 	// inclusive is false, because we don't want to include the latest message
 	// which is already in the database.
-	ctrl, err := archive.DBController(ctx, cmd.Name(), wconn, client, dir, cf, []stream.Option{stream.OptInclusive(false)}, dbase.WithOnlyNewOrChangedUsers(resumeFlags.RecordOnlyNewUsers))
+	streamOpts := []stream.Option{stream.OptInclusive(false)}
+	if resumeFlags.SkipCompleteThreads {
+		streamOpts = append(streamOpts, stream.OptSkipThreadFunc(dbase.NewThreadSkipper(wconn)))
+	}
+	ctrl, err := archive.DBController(ctx, cmd.Name(), wconn, client, dir, cf, streamOpts, dbase.WithOnlyNewOrChangedUsers(resumeFlags.RecordOnlyNewUsers))
 	if err != nil {
 		base.SetExitStatus(base.SInitializationError)
 		return fmt.Errorf("error creating archive controller: %w", err)

--- a/internal/chunk/backend/dbase/dbase.go
+++ b/internal/chunk/backend/dbase/dbase.go
@@ -207,6 +207,21 @@ func (d *DBP) IsCompleteThread(ctx context.Context, channelID, threadID string) 
 	return n > 0, nil
 }
 
+// NewThreadSkipper returns a predicate suitable for stream.OptSkipThreadFunc.
+// It returns true (skip) when the DB already holds replyCount+1 messages for
+// the thread (parent message included), meaning the thread appears complete.
+// Returns false on any error so that the thread is re-fetched safely.
+func NewThreadSkipper(conn *sqlx.DB) func(ctx context.Context, channelID, threadTS string, replyCount int) bool {
+	mr := repository.NewMessageRepository()
+	return func(ctx context.Context, channelID, threadTS string, replyCount int) bool {
+		n, err := mr.CountThread(ctx, conn, channelID, threadTS)
+		if err != nil {
+			return false
+		}
+		return int(n) == replyCount+1
+	}
+}
+
 // Source returns the connection that can be used safely as a source.
 func (d *DBP) Source() *Source {
 	return &Source{

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -283,7 +283,7 @@ func (cs *Stream) thread(ctx context.Context, req request, callback func(mm []sl
 // procChanMsg processes the message slice mm, for each threaded message, it
 // sends the thread request on threadC.  It returns thread count in the mm and
 // error if any.
-func procChanMsg(ctx context.Context, proc processor.Conversations, threadC chan<- request, channel *slack.Channel, isLast bool, mm []slack.Message) (int, error) {
+func (cs *Stream) procChanMsg(ctx context.Context, proc processor.Conversations, threadC chan<- request, channel *slack.Channel, isLast bool, mm []slack.Message) (int, error) {
 	trs := make([]request, 0, len(mm))
 	for i := range mm {
 		// collecting threads to get their count.  But we don't start
@@ -292,6 +292,10 @@ func procChanMsg(ctx context.Context, proc processor.Conversations, threadC chan
 		// start processing the channel and will have the initial reference
 		// count, if it needs it.
 		if mm[i].ThreadTimestamp != "" && mm[i].SubType != structures.SubTypeThreadBroadcast && mm[i].LatestReply != structures.LatestReplyNoReplies {
+			if cs.skipThread != nil && cs.skipThread(ctx, channel.ID, mm[i].ThreadTimestamp, mm[i].ReplyCount) {
+				slog.DebugContext(ctx, "skipping complete thread", "channel_id", channel.ID, "thread_ts", mm[i].ThreadTimestamp, "reply_count", mm[i].ReplyCount)
+				continue
+			}
 			slog.DebugContext(ctx, "- message", "i", i, "thread", mm[i].Timestamp, "thread_ts", mm[i].ThreadTimestamp, "channel_id", channel.ID, "is_last", isLast, "msg_count", len(mm))
 			trs = append(trs, request{
 				sl: &structures.SlackLink{

--- a/stream/conversation_test.go
+++ b/stream/conversation_test.go
@@ -137,7 +137,7 @@ func Test_procChanMsg(t *testing.T) {
 			if tt.expectFn != nil {
 				tt.expectFn(mp)
 			}
-			got, err := procChanMsg(tt.args.ctx, mp, tt.args.threadC, tt.args.channel, tt.args.isLast, tt.args.mm)
+			got, err := (&Stream{}).procChanMsg(tt.args.ctx, mp, tt.args.threadC, tt.args.channel, tt.args.isLast, tt.args.mm)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("procChanMsg() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -59,6 +59,7 @@ type Stream struct {
 	inclusive      bool
 	failChnlNotFnd bool // if true, will fail if channel not found
 	resultFn       []func(sr Result) error
+	skipThread     func(ctx context.Context, channelID, threadTS string, replyCount int) bool
 }
 
 // ResultType helps to identify the type of the result, so that the callback
@@ -175,6 +176,16 @@ func OptInclusive(b bool) Option {
 func OptFailOnNonCritError(b bool) Option {
 	return func(cs *Stream) {
 		cs.failChnlNotFnd = b
+	}
+}
+
+// OptSkipThreadFunc sets a predicate that is called for each thread head message
+// during channel processing.  If it returns true, the thread is skipped (no API
+// call is made).  Returns false on any error (safe default: re-fetch the thread).
+// Intended for resume operations to skip threads already complete in the database.
+func OptSkipThreadFunc(fn func(ctx context.Context, channelID, threadTS string, replyCount int) bool) Option {
+	return func(cs *Stream) {
+		cs.skipThread = fn
 	}
 }
 

--- a/stream/stream_workers.go
+++ b/stream/stream_workers.go
@@ -55,7 +55,7 @@ func (cs *Stream) channelWorker(ctx context.Context, proc processor.Conversation
 			}
 
 			if err := cs.channel(ctx, req, func(mm []slack.Message, isLast bool) error {
-				n, err := procChanMsg(ctx, proc, threadC, channel, isLast, mm)
+				n, err := cs.procChanMsg(ctx, proc, threadC, channel, isLast, mm)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This PR builds on #678 by @volker-fr.

If the `resume` is executed with `-skip-complete-threads` flag, the new logic
will compare the `reply_count` on the thread parent message with the number of
messages already stored in the database, and skip processing if it matches.

The tradeoff, as described in #678, is will skip historical threads that had
updated or deleted messages.

Main reason for reimplementation is to make it smaller and less invasive, I'll
post more details in the comment on #678.
