### PR TITLE
resume: skip thread items in DB when using -threads + -skip-complete-threads

### DIFF
--- a/cmd/slackdump/internal/resume/resume.go
+++ b/cmd/slackdump/internal/resume/resume.go
@@ -72,6 +72,9 @@ type ResumeParams struct {
 	// SkipCompleteThreads skips threads where the database already holds all
 	// replies (DB count == API reply_count + 1).  Faster, but won't detect
 	// edited or deleted messages.  Use only when threads are append-only.
+	// Note: threads with parent messages older than the lookback window will
+	// not be checked for updates, as only channel messages within the lookback
+	// window are scanned to discover threads.
 	SkipCompleteThreads bool
 }
 
@@ -85,7 +88,7 @@ func init() {
 	CmdResume.Flag.BoolVar(&resumeFlags.IncludeThreads, "threads", false, "include threads (slow, and flaky business)")
 	CmdResume.Flag.BoolVar(&resumeFlags.RecordOnlyNewUsers, "only-new-users", true, "record only new or updated users")
 	CmdResume.Flag.Var(resumeFlags.Lookback, "lookback", "lookback window `duration`")
-	CmdResume.Flag.BoolVar(&resumeFlags.SkipCompleteThreads, "skip-complete-threads", false, "skip threads where DB already has all replies (faster, but won't detect edits/deletes)")
+	CmdResume.Flag.BoolVar(&resumeFlags.SkipCompleteThreads, "skip-complete-threads", false, "skip threads where DB already has all replies (faster, but won't detect edits/deletes or new replies to messages older than lookback window)")
 }
 
 func runResume(ctx context.Context, cmd *base.Command, args []string) error {
@@ -114,7 +117,7 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 		return fmt.Errorf("source type %q does not support resume, use 'slackdump convert -f database' to convert it", src.Type())
 	}
 
-	latest, err := latest(ctx, src, resumeFlags.IncludeThreads, time.Duration((*duration.Duration)(resumeFlags.Lookback).ToTimeDuration()), list)
+	latest, err := latest(ctx, src, resumeFlags.IncludeThreads, resumeFlags.SkipCompleteThreads, time.Duration((*duration.Duration)(resumeFlags.Lookback).ToTimeDuration()), list)
 	if err != nil {
 		base.SetExitStatus(base.SApplicationError)
 		return fmt.Errorf("error loading latest timestamps: %w", err)
@@ -187,7 +190,7 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 	return nil
 }
 
-func latest(ctx context.Context, src source.Resumer, includeThreads bool, lookBack time.Duration, other *structures.EntityList) (*structures.EntityList, error) {
+func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCompleteThreads bool, lookBack time.Duration, other *structures.EntityList) (*structures.EntityList, error) {
 	if lookBack > 0 {
 		lookBack = -lookBack
 	}
@@ -205,7 +208,9 @@ func latest(ctx context.Context, src source.Resumer, includeThreads bool, lookBa
 
 	ei := make([]structures.EntityItem, 0, len(latest))
 	for sl, ts := range latest {
-		if sl.IsThread() && !includeThreads {
+		// When -threads + -skip-complete-threads, skip thread items from DB
+		// and let them be discovered via channel scanning with skip logic
+		if sl.IsThread() && (!includeThreads || skipCompleteThreads) {
 			continue
 		}
 		item := structures.EntityItem{

--- a/cmd/slackdump/internal/resume/resume_test.go
+++ b/cmd/slackdump/internal/resume/resume_test.go
@@ -339,11 +339,11 @@ func Test_usersTeam(t *testing.T) {
 
 func Test_latest(t *testing.T) {
 	type args struct {
-		ctx context.Context
-		// src source.Resumer
-		includeThreads bool
-		lookBack       time.Duration
-		other          *structures.EntityList
+		ctx                context.Context
+		includeThreads     bool
+		skipCompleteThreads bool
+		lookBack           time.Duration
+		other              *structures.EntityList
 	}
 	tests := []struct {
 		name     string
@@ -355,9 +355,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "resumer error",
 			args: args{
-				ctx:            t.Context(),
-				includeThreads: false,
-				lookBack:       0,
+				ctx:                  t.Context(),
+				includeThreads:       false,
+				skipCompleteThreads: false,
+				lookBack:             0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(nil, assert.AnError)
@@ -368,9 +369,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "no entities",
 			args: args{
-				ctx:            t.Context(),
-				includeThreads: false,
-				lookBack:       0,
+				ctx:                  t.Context(),
+				includeThreads:       false,
+				skipCompleteThreads: false,
+				lookBack:             0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{}, nil)
@@ -381,9 +383,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "returns latest status",
 			args: args{
-				ctx:            t.Context(),
-				includeThreads: false,
-				lookBack:       0,
+				ctx:                  t.Context(),
+				includeThreads:       false,
+				skipCompleteThreads: false,
+				lookBack:             0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
@@ -398,9 +401,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "returns latest status with thread",
 			args: args{
-				ctx:            t.Context(),
-				includeThreads: true,
-				lookBack:       0,
+				ctx:                  t.Context(),
+				includeThreads:       true,
+				skipCompleteThreads: false,
+				lookBack:             0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
@@ -417,9 +421,29 @@ func Test_latest(t *testing.T) {
 		{
 			name: "returns latest status with thread, but includeThreads is false",
 			args: args{
-				ctx:            t.Context(),
-				includeThreads: false,
-				lookBack:       0,
+				ctx:                  t.Context(),
+				includeThreads:       false,
+				skipCompleteThreads: false,
+				lookBack:             0,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C123"}:                      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					{Channel: "C456", ThreadTS: "123.456"}: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+				}, nil)
+			},
+			want: structures.NewEntityListFromItems(
+				structures.EntityItem{Id: "C123", Oldest: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
+			),
+			wantErr: false,
+		},
+		{
+			name: "returns latest status with thread and skipCompleteThreads true",
+			args: args{
+				ctx:                  t.Context(),
+				includeThreads:       true,
+				skipCompleteThreads: true,
+				lookBack:             0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
@@ -440,7 +464,7 @@ func Test_latest(t *testing.T) {
 			if tt.expectFn != nil {
 				tt.expectFn(mr)
 			}
-			got, err := latest(tt.args.ctx, mr, tt.args.includeThreads, tt.args.lookBack, tt.args.other)
+			got, err := latest(tt.args.ctx, mr, tt.args.includeThreads, tt.args.skipCompleteThreads, tt.args.lookBack, tt.args.other)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("latest() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
When both -threads and -skip-complete-threads flags are set, skip processing explicit thread items from the database. Instead, only process channels and discover threads from channel messages with the skip logic applied.

This allows resume to check threads by looking at channel messages and only downloading threads that have new messages since the last archive.

Without it, every thread in the look back window in the DB will be checked which takes a lot of API calls and time. An alternative options would be to
- only look at threads where the channel message is not in the lookback window, but it might run those threads over and over again.
- push the lookback window back to the data of the initial channel message  identified in a thread.