### PR TITLE
resume: add warning for -threads + -skip-complete-threads, add missin…

### DIFF
--- a/cmd/slackdump/internal/resume/resume.go
+++ b/cmd/slackdump/internal/resume/resume.go
@@ -117,6 +117,9 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 		return fmt.Errorf("source type %q does not support resume, use 'slackdump convert -f database' to convert it", src.Type())
 	}
 
+	if resumeFlags.IncludeThreads && resumeFlags.SkipCompleteThreads {
+		slog.WarnContext(ctx, "threads whose parent message is older than the lookback window will not be checked for new replies")
+	}
 	latest, err := latest(ctx, src, resumeFlags.IncludeThreads, resumeFlags.SkipCompleteThreads, time.Duration((*duration.Duration)(resumeFlags.Lookback).ToTimeDuration()), list)
 	if err != nil {
 		base.SetExitStatus(base.SApplicationError)
@@ -208,8 +211,6 @@ func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCo
 
 	ei := make([]structures.EntityItem, 0, len(latest))
 	for sl, ts := range latest {
-		// When -threads + -skip-complete-threads, skip thread items from DB
-		// and let them be discovered via channel scanning with skip logic
 		if sl.IsThread() && (!includeThreads || skipCompleteThreads) {
 			continue
 		}

--- a/cmd/slackdump/internal/resume/resume_test.go
+++ b/cmd/slackdump/internal/resume/resume_test.go
@@ -438,6 +438,25 @@ func Test_latest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "returns latest status with thread, includeThreads false and skipCompleteThreads true",
+			args: args{
+				ctx:                 t.Context(),
+				includeThreads:      false,
+				skipCompleteThreads: true,
+				lookBack:            0,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C123"}:                      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					{Channel: "C456", ThreadTS: "123.456"}: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+				}, nil)
+			},
+			want: structures.NewEntityListFromItems(
+				structures.EntityItem{Id: "C123", Oldest: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
+			),
+			wantErr: false,
+		},
+		{
 			name: "returns latest status with thread and skipCompleteThreads true",
 			args: args{
 				ctx:                  t.Context(),


### PR DESCRIPTION
…g test

Add a runtime slog.WarnContext when both flags are set so users are informed that threads outside the lookback window will be silently skipped.

Remove redundant inline comment that duplicated the struct doc and flag description. Add missing test case for includeThreads=false + skipCompleteThreads=true combination.