### PR TITLE
client: only use edge client with xoxc tokens

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -126,7 +126,7 @@ func New(ctx context.Context, prov auth.Provider, opts ...Option) (*Client, erro
 		hcl:    hcl,
 	}
 
-	if opt.enterprise || wi.EnterpriseID != "" {
+	if (opt.enterprise || wi.EnterpriseID != "") && auth.IsClientToken(prov.SlackToken()) {
 		ecl, err := edge.NewWithInfo(wi, prov)
 		if err != nil {
 			return nil, errors.Join(err, chttp.Close(hcl))

--- a/internal/client/edge.go
+++ b/internal/client/edge.go
@@ -18,6 +18,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/rusq/chttp/v2"
 
@@ -28,6 +29,9 @@ import (
 // NewEdge returns a new *Client that is guaranteed to have an edge (enterprise)
 // connection.  Use c.Edge() to obtain the underlying *edge.Client.
 func NewEdge(ctx context.Context, prov auth.Provider, opts ...Option) (*Client, error) {
+	if !auth.IsClientToken(prov.SlackToken()) {
+		return nil, fmt.Errorf("edge client requires a client token (xoxc-)")
+	}
 	hcl, scl, wi, err := newSlackClient(ctx, prov)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Detect if a client token (xoxc-) is being used before initializing the Edge client. This prevents 'not_allowed_token_type' errors on Enterprise workspaces when using standard Bot (xoxb-) or User (xoxp-) tokens, as the undocumented Edge APIs strictly require client tokens.