### PR TITLE
contrib: add Replit + Google Drive backup recipe

### DIFF
--- a/contrib/catalogue.yaml
+++ b/contrib/catalogue.yaml
@@ -41,3 +41,16 @@
   description: Prints user ID and a message
   dependencies:
     - python3
+- title: Replit + Google Drive backup uploader
+  path: replit_drive_backup
+  author: icgma
+  description: |
+    Resumable uploader that mirrors a slackdump `archive/` directory into
+    Google Drive, designed to run inside a Replit workspace.  Walks the
+    local archive, recreates the same folder tree on Drive, and uploads
+    every file with chunked resumable upload (handles 10+ GB archives,
+    survives restarts, re-initiates expired sessions, and ends with a
+    byte-exact reconciliation report).
+  dependencies:
+    - nodejs
+    - "@replit/connectors-sdk"

--- a/contrib/replit_drive_backup/README.md
+++ b/contrib/replit_drive_backup/README.md
@@ -1,0 +1,107 @@
+# Replit + Google Drive backup recipe
+
+Run [slackdump](https://github.com/rusq/slackdump) inside a Replit
+workspace and stream the resulting `archive/` directory to Google Drive
+without ever shipping a 10+ GB tarball through your laptop.
+
+This is useful when:
+
+- Your Slack workspace is large enough that a full archive would not
+  fit on the machine you usually run slackdump on.
+- You want the archive to live on Drive (cheap cold storage, easy to
+  share with teammates) rather than local disk.
+- You want the run to be unattended: kick it off in Replit, walk away,
+  come back to a directory on Drive that mirrors `archive/` exactly.
+
+The recipe consists of one Node.js script
+([`drive-upload-folder.mjs`](drive-upload-folder.mjs)) that walks the
+local archive directory, recreates the same folder tree on Drive, and
+uploads every file resumably.  A JSON manifest next to the script
+tracks per-file progress so you can stop and restart freely.
+
+## Prerequisites
+
+- A Replit workspace with the **Google Drive integration** enabled.
+  The script uses Replit's connector proxy
+  (`@replit/connectors-sdk`) so you do not need to manage OAuth
+  client credentials yourself.
+- slackdump has already produced an archive directory in the
+  workspace, for example via `slackdump archive -o ./archive`.
+- Node.js 18+ (already provided by Replit; the script uses global
+  `fetch`).
+- A Google Drive folder where the `archive/` subfolder should be
+  created.  Its folder ID is the part after `/folders/` in the
+  Drive URL.
+
+## Setup
+
+```bash
+# From this directory, install the one runtime dependency.
+npm install @replit/connectors-sdk
+```
+
+## Usage
+
+```bash
+DRIVE_PARENT_ID="<your-drive-folder-id>" \
+ARCHIVE_DIR="/path/to/archive" \
+node drive-upload-folder.mjs
+```
+
+The script prints progress every 5 seconds (file count, bytes,
+throughput, ETA) and writes a final reconciliation report comparing
+local file count and total bytes to what Drive reports.
+
+If the run is interrupted (you stopped it, the workspace got
+suspended, the network blipped), just run the same command again.
+The manifest tells the script which files are already done and which
+were partially uploaded; partial uploads resume from the byte offset
+the Drive session reports, not from zero.
+
+## Configuration
+
+All paths and tunables are env vars; defaults are friendly for the
+"`archive/` lives next to the script" case:
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `DRIVE_PARENT_ID` | (required) | Google Drive folder ID that will contain the `archive/` subfolder. |
+| `ARCHIVE_DIR` | `./archive` | Local archive root to mirror to Drive. |
+| `MANIFEST_PATH` | `./archive-upload-manifest.json` | Per-file resume state. Safe to keep across runs. |
+| `REPORT_PATH` | `./archive-upload-report.txt` | Final reconciliation report. |
+| `PROGRESS_INTERVAL_MS` | `5000` | How often to log progress. |
+| `CHUNK_SIZE_MB` | `64` | Resumable upload chunk size. Larger is faster on a clean line, smaller resumes more cheaply on a bad one. |
+
+## How it works
+
+The Replit connector proxy rejects request bodies larger than ~1 MB,
+so multipart uploads are not viable for real archive files.  Every
+file therefore uses Google Drive's resumable upload protocol:
+
+1. **Initiate session via the proxy.**  The proxy forwards a tiny
+   JSON metadata body to Drive and returns a session URL signed by
+   Google.
+2. **PUT file bytes directly to the session URL.**  This bypasses
+   the proxy entirely, so chunk size is bounded only by what your
+   network and Drive can sustain.
+3. **Save offset to the manifest after every chunk.**  On restart,
+   the script asks Drive for the canonical server offset before
+   continuing — the manifest is a hint, not the source of truth.
+4. **Re-initiate expired sessions transparently.**  Drive expires
+   resumable sessions after ~7 days; the script catches `404`/`410`
+   and starts a fresh session for the affected file.
+5. **Reconcile at the end.**  After the upload loop, the script
+   walks the destination on Drive and reports both file count and
+   total bytes, so you can verify byte-exact parity before deleting
+   the local archive.
+
+## Caveats
+
+- Drive Shared Drives have a 400,000-file limit per drive.  Very
+  large slackdump archives can approach this; consider tarring the
+  whole `archive/` directory and uploading that single file if you
+  hit the cap.
+- Files larger than ~5 TB cannot be uploaded to Drive at all (Google
+  limit).  This is well above any realistic slackdump archive.
+- The script does not delete files from Drive that no longer exist
+  locally; it is additive only.

--- a/contrib/replit_drive_backup/drive-upload-folder.mjs
+++ b/contrib/replit_drive_backup/drive-upload-folder.mjs
@@ -1,0 +1,554 @@
+/**
+ * drive-upload-folder.mjs
+ *
+ * Recursively uploads a slackdump archive directory to Google Drive,
+ * preserving the original folder structure.  Designed to run inside a
+ * Replit workspace, using the Replit Google Drive integration so that
+ * no OAuth client credentials need to be managed by hand.
+ *
+ * Strategy:
+ *   ALL files use the resumable upload flow, even small ones.  This is
+ *   because the Replit connector proxy rejects request bodies larger
+ *   than ~1 MB, which makes plain multipart upload unreliable.  With
+ *   resumable upload:
+ *     1. Initiation (small JSON body) goes through the proxy → returns
+ *        a session URL signed by Google.
+ *     2. The actual data is PUT directly to Google's session URL,
+ *        bypassing the proxy entirely.
+ *
+ * Features:
+ *   - Manifest-based resume: skips already-done files on restart.
+ *   - Mid-file resume: re-queries server offset and continues.
+ *   - Re-initiates expired resumable sessions (404/410) automatically.
+ *   - Exponential backoff on 5xx/429/network errors (up to 5 attempts).
+ *   - Periodic progress with throughput and ETA.
+ *   - Final reconciliation report comparing local vs Drive byte counts.
+ *
+ * Usage:
+ *   DRIVE_PARENT_ID=<your-folder-id> node drive-upload-folder.mjs
+ *
+ * Env overrides:
+ *   ARCHIVE_DIR          Local archive root (default: ./archive)
+ *   DRIVE_PARENT_ID      Drive folder ID to place archive/ under  (REQUIRED)
+ *   MANIFEST_PATH        Path to manifest JSON
+ *                        (default: ./archive-upload-manifest.json)
+ *   REPORT_PATH          Path to report output
+ *                        (default: ./archive-upload-report.txt)
+ *   PROGRESS_INTERVAL_MS Progress log interval in ms (default: 5000)
+ *   CHUNK_SIZE_MB        Chunk size in MB for resumable upload (default: 64)
+ *
+ * Requirements:
+ *   - Node.js 18+ (uses global fetch).
+ *   - The "@replit/connectors-sdk" package, installed in this directory.
+ *   - The Google Drive integration enabled in your Replit workspace.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { ReplitConnectors } from "@replit/connectors-sdk";
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+
+const ARCHIVE_DIR = process.env.ARCHIVE_DIR
+  || path.resolve(process.cwd(), "archive");
+const DRIVE_PARENT_ID = process.env.DRIVE_PARENT_ID;
+const MANIFEST_PATH = process.env.MANIFEST_PATH
+  || path.resolve(process.cwd(), "archive-upload-manifest.json");
+const REPORT_PATH = process.env.REPORT_PATH
+  || path.resolve(process.cwd(), "archive-upload-report.txt");
+const PROGRESS_INTERVAL_MS = parseInt(process.env.PROGRESS_INTERVAL_MS || "5000", 10);
+const RESUMABLE_CHUNK_SIZE = parseInt(process.env.CHUNK_SIZE_MB || "64", 10) * 1024 * 1024;
+const MAX_RETRIES = 5;
+
+if (!DRIVE_PARENT_ID) {
+  console.error("DRIVE_PARENT_ID env var is required (the Drive folder ID to place 'archive/' under).");
+  process.exit(2);
+}
+if (!fs.existsSync(ARCHIVE_DIR)) {
+  console.error(`ARCHIVE_DIR does not exist: ${ARCHIVE_DIR}`);
+  process.exit(2);
+}
+
+const connectors = new ReplitConnectors();
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+function guessMime(filename) {
+  const ext = path.extname(filename).toLowerCase();
+  const map = {
+    ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png",
+    ".gif": "image/gif", ".webp": "image/webp", ".svg": "image/svg+xml",
+    ".pdf": "application/pdf",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".xls": "application/vnd.ms-excel",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".doc": "application/msword",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".ppt": "application/vnd.ms-powerpoint",
+    ".zip": "application/zip", ".gz": "application/gzip", ".tar": "application/x-tar",
+    ".mp4": "video/mp4", ".mov": "video/quicktime", ".avi": "video/x-msvideo",
+    ".mp3": "audio/mpeg", ".wav": "audio/wav",
+    ".txt": "text/plain", ".csv": "text/csv", ".html": "text/html",
+    ".json": "application/json", ".sqlite": "application/x-sqlite3",
+  };
+  return map[ext] || "application/octet-stream";
+}
+
+// ─── Drive API (via connector proxy) ────────────────────────────────────────
+// Only metadata/control calls go through the proxy (small bodies).
+// File data is uploaded directly to Google's resumable session URL.
+
+async function proxyRequest(urlPath, options = {}) {
+  return connectors.proxy("google-drive", urlPath, options);
+}
+
+async function proxyJson(urlPath, options = {}) {
+  const res = await proxyRequest(urlPath, options);
+  const text = await res.text();
+  if (!res.ok) {
+    const err = Object.assign(
+      new Error(`Drive API ${res.status}: ${text.slice(0, 400)}`),
+      { status: res.status, body: text },
+    );
+    throw err;
+  }
+  return JSON.parse(text);
+}
+
+async function withRetry(label, fn) {
+  let lastErr;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      const status = err.status;
+      const retryable = !status || status === 429 || status >= 500;
+      if (!retryable) throw err;
+      lastErr = err;
+      const delay = Math.min(2000 * Math.pow(2, attempt - 1), 60000);
+      console.error(`  [retry ${attempt}/${MAX_RETRIES}] ${label}: ${String(err.message).slice(0, 100)} — wait ${delay}ms`);
+      await sleep(delay);
+    }
+  }
+  throw lastErr;
+}
+
+// ─── Folder management ──────────────────────────────────────────────────────
+
+const folderCache = new Map();
+
+async function ensureFolder(name, parentId) {
+  const key = `${parentId}/${name}`;
+  if (folderCache.has(key)) return folderCache.get(key);
+
+  const q = encodeURIComponent(
+    `name='${name.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}' and mimeType='application/vnd.google-apps.folder' and '${parentId}' in parents and trashed=false`,
+  );
+  const list = await withRetry(`list folder "${name}"`, () =>
+    proxyJson(`/drive/v3/files?q=${q}&fields=files(id,name)`),
+  );
+  if (list.files?.length > 0) {
+    folderCache.set(key, list.files[0].id);
+    return list.files[0].id;
+  }
+
+  const created = await withRetry(`create folder "${name}"`, () =>
+    proxyJson("/drive/v3/files", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, mimeType: "application/vnd.google-apps.folder", parents: [parentId] }),
+    }),
+  );
+  folderCache.set(key, created.id);
+  return created.id;
+}
+
+async function ensureFolderPath(relDir, rootId) {
+  if (!relDir) return rootId;
+  const parts = relDir.split("/").filter(Boolean);
+  let cur = rootId;
+  for (const p of parts) cur = await ensureFolder(p, cur);
+  return cur;
+}
+
+// ─── Resumable upload ───────────────────────────────────────────────────────
+
+async function initiateResumable(filename, fileSize, mimeType, parentFolderId) {
+  const metadata = JSON.stringify({ name: filename, parents: [parentFolderId] });
+  return withRetry(`initiate session "${filename}"`, async () => {
+    const res = await proxyRequest(
+      "/upload/drive/v3/files?uploadType=resumable&fields=id,name,size",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json; charset=UTF-8",
+          "X-Upload-Content-Type": mimeType,
+          "X-Upload-Content-Length": String(fileSize),
+        },
+        body: metadata,
+      },
+    );
+    const text = await res.text();
+    if (!res.ok) {
+      throw Object.assign(
+        new Error(`Initiate ${res.status}: ${text.slice(0, 300)}`),
+        { status: res.status },
+      );
+    }
+    const location = res.headers.get("location") || res.headers.get("Location");
+    if (location) return location;
+    try { const j = JSON.parse(text); if (j.uploadUrl) return j.uploadUrl; } catch (_) { /* not JSON */ }
+    throw new Error(`No Location in initiation response. Body: ${text.slice(0, 200)}`);
+  });
+}
+
+async function queryOffset(uploadUrl, fileSize) {
+  const res = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: { "Content-Range": `bytes */${fileSize}` },
+  });
+  if (res.status === 200 || res.status === 201) {
+    const j = await res.json();
+    return { complete: true, fileId: j.id, name: j.name };
+  }
+  if (res.status === 308) {
+    const range = res.headers.get("range");
+    const m = range?.match(/bytes=0-(\d+)/);
+    return { complete: false, offset: m ? parseInt(m[1]) + 1 : 0 };
+  }
+  const text = await res.text();
+  throw Object.assign(
+    new Error(`queryOffset ${res.status}: ${text.slice(0, 200)}`),
+    { status: res.status },
+  );
+}
+
+async function putChunk(uploadUrl, buf, offset, fileSize) {
+  const end = offset + buf.length - 1;
+  const res = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Length": String(buf.length),
+      "Content-Range": `bytes ${offset}-${end}/${fileSize}`,
+    },
+    body: buf,
+  });
+  if (res.status === 200 || res.status === 201) {
+    const j = await res.json();
+    return { done: true, fileId: j.id, name: j.name };
+  }
+  if (res.status === 308) {
+    const range = res.headers.get("range");
+    const m = range?.match(/bytes=0-(\d+)/);
+    return { done: false, nextOffset: m ? parseInt(m[1]) + 1 : offset + buf.length };
+  }
+  const text = await res.text();
+  throw Object.assign(
+    new Error(`putChunk ${res.status}: ${text.slice(0, 300)}`),
+    { status: res.status },
+  );
+}
+
+async function uploadFile(localPath, filename, fileSize, parentFolderId, manifestEntry, saveManifest) {
+  const mimeType = guessMime(filename);
+  let uploadUrl = manifestEntry.uploadUrl || null;
+  let offset = manifestEntry.offset || 0;
+
+  if (uploadUrl && offset > 0) {
+    try {
+      const q = await queryOffset(uploadUrl, fileSize);
+      if (q.complete) return { fileId: q.fileId, name: q.name };
+      offset = q.offset;
+    } catch (err) {
+      if (err.status === 404 || err.status === 410) {
+        console.log(`  Session expired, re-initiating for "${filename}"`);
+        uploadUrl = null;
+        offset = 0;
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  if (!uploadUrl) {
+    uploadUrl = await initiateResumable(filename, fileSize, mimeType, parentFolderId);
+    offset = 0;
+    manifestEntry.uploadUrl = uploadUrl;
+    manifestEntry.offset = 0;
+    saveManifest();
+  }
+
+  const fd = fs.openSync(localPath, "r");
+  try {
+    while (offset < fileSize) {
+      const chunkLen = Math.min(RESUMABLE_CHUNK_SIZE, fileSize - offset);
+      const buf = Buffer.alloc(chunkLen);
+      fs.readSync(fd, buf, 0, chunkLen, offset);
+
+      let result;
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+          result = await putChunk(uploadUrl, buf, offset, fileSize);
+          break;
+        } catch (err) {
+          if (err.status === 404 || err.status === 410) {
+            console.log(`  Session expired mid-upload, re-initiating for "${filename}"`);
+            uploadUrl = await initiateResumable(filename, fileSize, mimeType, parentFolderId);
+            offset = 0;
+            manifestEntry.uploadUrl = uploadUrl;
+            manifestEntry.offset = 0;
+            saveManifest();
+            result = null;
+            break;
+          }
+          const retryable = !err.status || err.status === 429 || err.status >= 500;
+          if (!retryable || attempt >= MAX_RETRIES) throw err;
+          const delay = Math.min(2000 * Math.pow(2, attempt - 1), 60000);
+          console.error(`  [retry ${attempt}/${MAX_RETRIES}] chunk@${offset} "${filename}": ${err.message.slice(0, 80)} — ${delay}ms`);
+          await sleep(delay);
+        }
+      }
+
+      if (!result) continue;
+      if (result.done) return { fileId: result.fileId, name: result.name };
+
+      offset = result.nextOffset;
+      manifestEntry.offset = offset;
+      saveManifest();
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  throw new Error(`Upload loop ended without completion for "${filename}"`);
+}
+
+// ─── Manifest ───────────────────────────────────────────────────────────────
+
+function loadManifest() {
+  if (fs.existsSync(MANIFEST_PATH)) {
+    try { return JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8")); } catch (_) { /* corrupt; start fresh */ }
+  }
+  return {};
+}
+
+function saveManifest(manifest) {
+  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
+}
+
+// ─── Drive file count (for reconciliation) ──────────────────────────────────
+
+async function countDriveFolder(folderId) {
+  let fileCount = 0;
+  let byteCount = 0;
+  const queue = [folderId];
+  while (queue.length > 0) {
+    const id = queue.shift();
+    let pageToken = null;
+    do {
+      const q = encodeURIComponent(`'${id}' in parents and trashed=false`);
+      let url = `/drive/v3/files?q=${q}&fields=files(id,mimeType,size),nextPageToken&pageSize=1000`;
+      if (pageToken) url += `&pageToken=${encodeURIComponent(pageToken)}`;
+      let list;
+      try {
+        list = await withRetry("list drive files", () => proxyJson(url));
+      } catch (err) {
+        console.error(`  [WARN] Cannot list Drive folder ${id}: ${err.message}`);
+        break;
+      }
+      for (const f of list.files || []) {
+        if (f.mimeType === "application/vnd.google-apps.folder") {
+          queue.push(f.id);
+        } else {
+          fileCount++;
+          byteCount += parseInt(f.size || "0", 10);
+        }
+      }
+      pageToken = list.nextPageToken;
+    } while (pageToken);
+  }
+  return { fileCount, byteCount };
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== Slackdump archive → Google Drive uploader ===");
+  console.log(`Archive     : ${ARCHIVE_DIR}`);
+  console.log(`Drive parent: ${DRIVE_PARENT_ID}`);
+  console.log(`Manifest    : ${MANIFEST_PATH}`);
+  console.log(`Chunk size  : ${RESUMABLE_CHUNK_SIZE / 1024 / 1024} MB`);
+  console.log();
+
+  console.log("Scanning local archive...");
+  const allFiles = [];
+  function walk(dir, relBase) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      const rel = relBase ? `${relBase}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(full, rel);
+      else if (entry.isFile()) {
+        const st = fs.statSync(full);
+        allFiles.push({ fullPath: full, relPath: rel, size: st.size, mtimeMs: st.mtimeMs });
+      }
+    }
+  }
+  walk(ARCHIVE_DIR, "");
+  const totalFiles = allFiles.length;
+  const totalBytes = allFiles.reduce((s, f) => s + f.size, 0);
+  console.log(`Found ${totalFiles} files, ${(totalBytes / 1024 / 1024 / 1024).toFixed(2)} GB`);
+  console.log();
+
+  console.log("Ensuring 'archive' folder in Drive...");
+  const archiveFolderId = await ensureFolder("archive", DRIVE_PARENT_ID);
+  console.log(`archive folder id: ${archiveFolderId}`);
+  console.log();
+
+  const manifest = loadManifest();
+  const saveNow = () => saveManifest(manifest);
+
+  let doneCount = 0;
+  let doneBytes = 0;
+  for (const f of allFiles) {
+    const e = manifest[f.relPath];
+    if (e?.status === "done") {
+      const sizeMatch = e.size == null || e.size === f.size;
+      const mtimeMatch = e.mtimeMs == null || e.mtimeMs === f.mtimeMs;
+      if (!sizeMatch || !mtimeMatch) {
+        console.log(`  [STALE] ${f.relPath}: manifest size/mtime mismatch — will re-upload`);
+        manifest[f.relPath] = { status: "pending" };
+        continue;
+      }
+      doneCount++;
+      doneBytes += f.size;
+    }
+  }
+  console.log(`Resuming: ${doneCount}/${totalFiles} files already done (${(doneBytes / 1024 / 1024).toFixed(0)} MB)`);
+  console.log();
+
+  let processedCount = doneCount;
+  let processedBytes = doneBytes;
+  let failedCount = 0;
+  const failed = [];
+  let lastProgress = Date.now();
+  const sessionStartTime = Date.now();
+  const sessionStartBytes = doneBytes;
+
+  function printProgress() {
+    const pct = totalFiles > 0 ? (processedCount / totalFiles * 100).toFixed(1) : "0.0";
+    const gbDone = (processedBytes / 1024 / 1024 / 1024).toFixed(2);
+    const gbTotal = (totalBytes / 1024 / 1024 / 1024).toFixed(2);
+    const elapsedSec = (Date.now() - sessionStartTime) / 1000;
+    const sessionBytes = processedBytes - sessionStartBytes;
+    const throughputMBps = elapsedSec > 0 ? (sessionBytes / 1024 / 1024 / elapsedSec) : 0;
+    const remainingBytes = totalBytes - processedBytes;
+    const etaSec = throughputMBps > 0 ? remainingBytes / 1024 / 1024 / throughputMBps : Infinity;
+    const etaStr = !isFinite(etaSec) ? "-" : etaSec < 60
+      ? `${Math.round(etaSec)}s`
+      : etaSec < 3600
+        ? `${Math.round(etaSec / 60)}m`
+        : `${(etaSec / 3600).toFixed(1)}h`;
+    console.log(
+      `Progress: ${processedCount}/${totalFiles} (${pct}%) | ${gbDone}/${gbTotal} GB`
+      + ` | ${throughputMBps.toFixed(2)} MB/s | ETA: ${etaStr} | failed: ${failedCount}`,
+    );
+  }
+
+  for (const { fullPath, relPath, size, mtimeMs } of allFiles) {
+    if (manifest[relPath]?.status === "done") continue;
+
+    const now = Date.now();
+    if (now - lastProgress >= PROGRESS_INTERVAL_MS) {
+      printProgress();
+      lastProgress = now;
+    }
+
+    const relDir = path.dirname(relPath);
+    const filename = path.basename(relPath);
+    let parentFolderId;
+    try {
+      parentFolderId = await ensureFolderPath(relDir === "." ? "" : relDir, archiveFolderId);
+    } catch (err) {
+      console.error(`  [ERROR] folder for "${relPath}": ${err.message}`);
+      manifest[relPath] = { status: "failed", error: err.message };
+      saveNow();
+      failedCount++;
+      failed.push({ relPath, error: err.message });
+      processedCount++;
+      processedBytes += size;
+      continue;
+    }
+
+    if (!manifest[relPath]) manifest[relPath] = { status: "pending" };
+    manifest[relPath].status = "uploading";
+
+    try {
+      const { fileId, name } = await uploadFile(
+        fullPath, filename, size, parentFolderId,
+        manifest[relPath], saveNow,
+      );
+      manifest[relPath] = { status: "done", fileId, name, size, mtimeMs };
+      saveNow();
+      processedCount++;
+      processedBytes += size;
+    } catch (err) {
+      const msg = String(err.message).slice(0, 300);
+      console.error(`  [FAILED] ${relPath}: ${msg}`);
+      manifest[relPath] = {
+        status: "failed",
+        error: msg,
+        ...(manifest[relPath].uploadUrl ? { uploadUrl: manifest[relPath].uploadUrl } : {}),
+      };
+      saveNow();
+      failedCount++;
+      failed.push({ relPath, error: msg });
+      processedCount++;
+      processedBytes += size;
+    }
+  }
+
+  printProgress();
+
+  console.log();
+  console.log("Counting files on Drive...");
+  const { fileCount: driveFileCount, byteCount: driveBytes } = await countDriveFolder(archiveFolderId);
+
+  const doneInManifest = Object.values(manifest).filter(e => e.status === "done").length;
+  const report = [
+    "=== archive Upload Reconciliation Report ===",
+    `Date: ${new Date().toISOString()}`,
+    "",
+    `Local files scanned  : ${totalFiles}`,
+    `Local total bytes    : ${totalBytes} (${(totalBytes / 1024 / 1024 / 1024).toFixed(2)} GB)`,
+    "",
+    `Manifest done        : ${doneInManifest}`,
+    `Drive files counted  : ${driveFileCount}`,
+    `Drive total bytes    : ${driveBytes} (${(driveBytes / 1024 / 1024 / 1024).toFixed(2)} GB)`,
+    "",
+    `Failed uploads       : ${failed.length}`,
+    ...(failed.length > 0 ? ["", "Failed files:"] : []),
+    ...failed.map(f => `  ${f.relPath}: ${f.error}`),
+    "",
+    `Byte match  : ${totalBytes === driveBytes ? "YES" : `NO - local ${totalBytes} vs drive ${driveBytes}`}`,
+    `Count match : ${totalFiles === driveFileCount ? "YES" : `NO - local ${totalFiles} vs drive ${driveFileCount}`}`,
+  ].join("\n");
+
+  fs.writeFileSync(REPORT_PATH, report);
+  console.log("\n" + report);
+  console.log(`\nReport: ${REPORT_PATH}`);
+
+  if (failed.length > 0) {
+    console.log(`\n${failed.length} file(s) failed. Re-run to retry.`);
+    process.exit(1);
+  }
+  console.log("\nAll files uploaded successfully.");
+}
+
+main().catch(err => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/contrib/replit_drive_backup/package.json
+++ b/contrib/replit_drive_backup/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "slackdump-replit-drive-backup",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Resumable uploader for a slackdump archive into Google Drive, designed for Replit workspaces.",
+  "license": "AGPL-3.0-or-later",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "node drive-upload-folder.mjs"
+  },
+  "dependencies": {
+    "@replit/connectors-sdk": "^1.0.0"
+  }
+}


### PR DESCRIPTION
### What

  Adds `contrib/replit_drive_backup`, a self-contained Node.js recipe that mirrors a slackdump `archive/` directory into Google Drive from inside a [Replit](https://replit.com) workspace.

  ### Why

  Replit makes a convenient unattended runner for slackdump (always-on, generous bandwidth, the workspace already has Node), but archives for medium-sized Slack workspaces quickly outgrow what fits comfortably on a laptop. Streaming `archive/` directly to Drive from the Replit workspace lets the run finish unattended and leaves the result on cheap cold storage that is easy to share.

  ### How

  The recipe is three files inside `contrib/replit_drive_backup/`:

  - `drive-upload-folder.mjs` — the actual uploader.
  - `README.md` — prerequisites, usage, configuration, internals.
  - `package.json` — declares the single runtime dep, `@replit/connectors-sdk`.

  It also adds one entry to `contrib/catalogue.yaml`. `BASE_DIR=contrib go run ./contrib/_gen -v` passes locally.

  The uploader uses Drive's resumable upload protocol for **every** file, even small ones — Replit's connector proxy rejects request bodies larger than ~1 MB, so plain multipart upload is not viable for real archive files. With resumable upload the small JSON metadata body goes through the proxy (returning a Google-signed session URL), and the actual file bytes are PUT directly to that URL, bypassing the proxy entirely. The script saves per-file offsets to a manifest after every chunk, asks Drive for the canonical server offset before resuming, and transparently re-initiates expired sessions (404/410). It ends with a byte-exact reconciliation report comparing local vs Drive file count and total bytes.

  ### Notes

  - Auth is via the Replit Google Drive integration (`@replit/connectors-sdk`), so contributors do not need to manage OAuth client credentials by hand.
  - All tunables (chunk size, paths, progress interval) are env vars with sensible defaults.
  - The script is additive only — it does not delete files on Drive that are missing locally.
  