### PR TITLE
auth: prefer system browser for interactive login (fixes #675)

### DIFF
--- a/auth/option.go
+++ b/auth/option.go
@@ -16,73 +16,90 @@
 package auth
 
 import (
-	"strings"
-	"time"
+        "strings"
+        "time"
 
-	"github.com/rusq/slackdump/v4/auth/browser"
+        "github.com/rusq/slackdump/v4/auth/browser"
 )
 
 type options struct {
-	playwrightOptions
-	rodOpts
-	workspace string
+        playwrightOptions
+        rodOpts
+        workspace string
 }
 
 type Option func(*options)
 
 func BrowserWithAuthFlow(flow BrowserAuthUI) Option {
-	return func(o *options) {
-		if flow == nil {
-			return
-		}
-		o.playwrightOptions.flow = flow
-	}
+        return func(o *options) {
+                if flow == nil {
+                        return
+                }
+                o.playwrightOptions.flow = flow
+        }
 }
 
 func BrowserWithWorkspace(name string) Option {
-	return func(o *options) {
-		o.workspace = strings.ToLower(name)
-	}
+        return func(o *options) {
+                o.workspace = strings.ToLower(name)
+        }
 }
 
 func BrowserWithBrowser(b browser.Browser) Option {
-	return func(o *options) {
-		o.playwrightOptions.browser = b
-	}
+        return func(o *options) {
+                o.playwrightOptions.browser = b
+        }
 }
 
 func BrowserWithTimeout(d time.Duration) Option {
-	return func(o *options) {
-		if d < 0 {
-			return
-		}
-		o.playwrightOptions.loginTimeout = d
-	}
+        return func(o *options) {
+                if d < 0 {
+                        return
+                }
+                o.playwrightOptions.loginTimeout = d
+        }
 }
 
 func BrowserWithVerbose(b bool) Option {
-	return func(o *options) {
-		o.playwrightOptions.verbose = b
-	}
+        return func(o *options) {
+                o.playwrightOptions.verbose = b
+        }
 }
 
 // RODWithRODHeadlessTimeout sets the timeout for the headless browser
 // interaction.  It is a net time of headless browser interaction, without the
 // browser starting time.
 func RODWithRODHeadlessTimeout(d time.Duration) Option {
-	return func(o *options) {
-		if d <= 0 {
-			return
-		}
-		o.rodOpts.autoTimeout = d
-	}
+        return func(o *options) {
+                if d <= 0 {
+                        return
+                }
+                o.rodOpts.autoTimeout = d
+        }
 }
 
 // RODWithUserAgent sets the user agent string for the headless browser.
 func RODWithUserAgent(ua string) Option {
-	return func(o *options) {
-		if ua != "" {
-			o.rodOpts.userAgent = ua
-		}
-	}
+        return func(o *options) {
+                if ua != "" {
+                        o.rodOpts.userAgent = ua
+                }
+        }
+}
+
+// RODWithInteractiveBrowserAuto controls whether the [auth_ui.LInteractive]
+// "Login in Browser" flow opportunistically uses a locally installed
+// system browser (Chrome/Edge/Brave/Chromium) instead of the bundled
+// Chromium that go-rod's launcher downloads.
+//
+// When true (the default), if a system browser is discovered via
+// [slackauth.ListBrowsers] it is used in place of the bundled browser.
+// This is the recommended setting because the launcher's bundled
+// Chromium is currently pinned to revision ~v128, which Slack now
+// rejects on its login page (issue #675).  When false, the bundled
+// browser is always used, preserving the historical behaviour.
+func RODWithInteractiveBrowserAuto(b bool) Option {
+        return func(o *options) {
+                o.rodOpts.interactiveBrowserAuto = b
+        }
 }

--- a/auth/option.go
+++ b/auth/option.go
@@ -16,75 +16,75 @@
 package auth
 
 import (
-        "strings"
-        "time"
+	"strings"
+	"time"
 
-        "github.com/rusq/slackdump/v4/auth/browser"
+	"github.com/rusq/slackdump/v4/auth/browser"
 )
 
 type options struct {
-        playwrightOptions
-        rodOpts
-        workspace string
+	playwrightOptions
+	rodOpts
+	workspace string
 }
 
 type Option func(*options)
 
 func BrowserWithAuthFlow(flow BrowserAuthUI) Option {
-        return func(o *options) {
-                if flow == nil {
-                        return
-                }
-                o.playwrightOptions.flow = flow
-        }
+	return func(o *options) {
+		if flow == nil {
+			return
+		}
+		o.playwrightOptions.flow = flow
+	}
 }
 
 func BrowserWithWorkspace(name string) Option {
-        return func(o *options) {
-                o.workspace = strings.ToLower(name)
-        }
+	return func(o *options) {
+		o.workspace = strings.ToLower(name)
+	}
 }
 
 func BrowserWithBrowser(b browser.Browser) Option {
-        return func(o *options) {
-                o.playwrightOptions.browser = b
-        }
+	return func(o *options) {
+		o.playwrightOptions.browser = b
+	}
 }
 
 func BrowserWithTimeout(d time.Duration) Option {
-        return func(o *options) {
-                if d < 0 {
-                        return
-                }
-                o.playwrightOptions.loginTimeout = d
-        }
+	return func(o *options) {
+		if d < 0 {
+			return
+		}
+		o.playwrightOptions.loginTimeout = d
+	}
 }
 
 func BrowserWithVerbose(b bool) Option {
-        return func(o *options) {
-                o.playwrightOptions.verbose = b
-        }
+	return func(o *options) {
+		o.playwrightOptions.verbose = b
+	}
 }
 
 // RODWithRODHeadlessTimeout sets the timeout for the headless browser
 // interaction.  It is a net time of headless browser interaction, without the
 // browser starting time.
 func RODWithRODHeadlessTimeout(d time.Duration) Option {
-        return func(o *options) {
-                if d <= 0 {
-                        return
-                }
-                o.rodOpts.autoTimeout = d
-        }
+	return func(o *options) {
+		if d <= 0 {
+			return
+		}
+		o.rodOpts.autoTimeout = d
+	}
 }
 
 // RODWithUserAgent sets the user agent string for the headless browser.
 func RODWithUserAgent(ua string) Option {
-        return func(o *options) {
-                if ua != "" {
-                        o.rodOpts.userAgent = ua
-                }
-        }
+	return func(o *options) {
+		if ua != "" {
+			o.rodOpts.userAgent = ua
+		}
+	}
 }
 
 // RODWithInteractiveBrowserAuto controls whether the [auth_ui.LInteractive]
@@ -99,7 +99,7 @@ func RODWithUserAgent(ua string) Option {
 // rejects on its login page (issue #675).  When false, the bundled
 // browser is always used, preserving the historical behaviour.
 func RODWithInteractiveBrowserAuto(b bool) Option {
-        return func(o *options) {
-                o.rodOpts.interactiveBrowserAuto = b
-        }
+	return func(o *options) {
+		o.rodOpts.interactiveBrowserAuto = b
+	}
 }

--- a/auth/option.go
+++ b/auth/option.go
@@ -87,6 +87,17 @@ func RODWithUserAgent(ua string) Option {
 	}
 }
 
+// RODWithBundledBrowser forces the launcher-managed bundled Chromium to be
+// used for all browser-based login flows, overriding system browser
+// auto-detection.  Callers that set this to true should also call
+// [RODWithInteractiveBrowserAuto](false) to suppress the system-browser
+// detection added in issue #675.
+func RODWithBundledBrowser(b bool) Option {
+	return func(o *options) {
+		o.rodOpts.bundledBrowser = b
+	}
+}
+
 // RODWithInteractiveBrowserAuto controls whether the [auth_ui.LInteractive]
 // "Login in Browser" flow opportunistically uses a locally installed
 // system browser (Chrome/Edge/Brave/Chromium) instead of the bundled

--- a/auth/rod.go
+++ b/auth/rod.go
@@ -16,18 +16,18 @@
 package auth
 
 import (
-	"context"
-	"fmt"
-	"io"
-	"log/slog"
-	"os"
-	"time"
+        "context"
+        "fmt"
+        "io"
+        "log/slog"
+        "os"
+        "time"
 
-	"github.com/rusq/slackauth"
+        "github.com/rusq/slackauth"
 
-	"github.com/rusq/slackdump/v4/auth/auth_ui"
-	"github.com/rusq/slackdump/v4/internal/osext"
-	"github.com/rusq/slackdump/v4/internal/structures"
+        "github.com/rusq/slackdump/v4/auth/auth_ui"
+        "github.com/rusq/slackdump/v4/internal/osext"
+        "github.com/rusq/slackdump/v4/internal/structures"
 )
 
 // RODHeadlessTimeout is the default timeout for the headless login flow.
@@ -47,155 +47,196 @@ const RODHeadlessTimeout = 40 * time.Second
 // Headless login is a bit fragile.  If it fails, user should be advised to
 // login interactively by choosing SSO auth type.
 type RodAuth struct {
-	simpleProvider
-	opts options
+        simpleProvider
+        opts options
 }
 
 type rodOpts struct {
-	ui             browserAuthUIExt
-	autoTimeout    time.Duration
-	userAgent      string
-	usermode       bool
-	bundledBrowser bool
+        ui             browserAuthUIExt
+        autoTimeout    time.Duration
+        userAgent      string
+        usermode       bool
+        bundledBrowser bool
+        // interactiveBrowserAuto, when true, lets the [LInteractive] login
+        // flow opportunistically use a locally installed system browser
+        // (Chrome/Edge/Brave/Chromium) instead of the launcher-managed
+        // bundled Chromium.  See [findInteractiveBrowser] and issue #675.
+        interactiveBrowserAuto bool
 }
 
 func (ro rodOpts) slackauthOpts() []slackauth.Option {
-	sopts := []slackauth.Option{
-		slackauth.WithChallengeFunc(ro.ui.ConfirmationCode),
-		slackauth.WithAutologinTimeout(ro.autoTimeout),
-	}
-	if ro.userAgent != "" {
-		sopts = append(sopts, slackauth.WithUserAgent(ro.userAgent))
-	}
-	if ro.usermode {
-		sopts = append(sopts, slackauth.WithForceUser())
-	}
-	if ro.bundledBrowser {
-		sopts = append(sopts, slackauth.WithBundledBrowser())
-	}
-	return sopts
+        sopts := []slackauth.Option{
+                slackauth.WithChallengeFunc(ro.ui.ConfirmationCode),
+                slackauth.WithAutologinTimeout(ro.autoTimeout),
+        }
+        if ro.userAgent != "" {
+                sopts = append(sopts, slackauth.WithUserAgent(ro.userAgent))
+        }
+        if ro.usermode {
+                sopts = append(sopts, slackauth.WithForceUser())
+        }
+        if ro.bundledBrowser {
+                sopts = append(sopts, slackauth.WithBundledBrowser())
+        }
+        return sopts
 }
 
 type browserAuthUIExt interface {
-	// RequestLoginType should request the login type from the user and return
-	// one of the [auth_ui.LoginType] constants.  The implementation should
-	// provide a way to cancel the login flow, returning [auth_ui.LoginCancel].
-	RequestLoginType(ctx context.Context, w io.Writer, workspace string) (auth_ui.LoginOpts, error)
-	// RequestCreds should request the user's email and password and return
-	// them.
-	RequestCreds(ctx context.Context, w io.Writer, workspace string) (email string, passwd string, err error)
-	// ConfirmationCode should request the confirmation code from the user and
-	// return it.  Callback function is called to indicate that the code is
-	// requested.
-	ConfirmationCode(email string) (code int, err error)
-	// RequestQR should request the URL-encoded png image and return it.
-	RequestQR(ctx context.Context, w io.Writer) (encImage string, err error)
+        // RequestLoginType should request the login type from the user and return
+        // one of the [auth_ui.LoginType] constants.  The implementation should
+        // provide a way to cancel the login flow, returning [auth_ui.LoginCancel].
+        RequestLoginType(ctx context.Context, w io.Writer, workspace string) (auth_ui.LoginOpts, error)
+        // RequestCreds should request the user's email and password and return
+        // them.
+        RequestCreds(ctx context.Context, w io.Writer, workspace string) (email string, passwd string, err error)
+        // ConfirmationCode should request the confirmation code from the user and
+        // return it.  Callback function is called to indicate that the code is
+        // requested.
+        ConfirmationCode(email string) (code int, err error)
+        // RequestQR should request the URL-encoded png image and return it.
+        RequestQR(ctx context.Context, w io.Writer) (encImage string, err error)
 }
 
 // NewRODAuth constructs new RodAuth provider.
 func NewRODAuth(ctx context.Context, opts ...Option) (RodAuth, error) {
-	if osext.IsDocker() || !osext.IsInteractive() {
-		return RodAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in dumb terminals, use token/cookie auth instead"}
-	}
-	r := RodAuth{
-		opts: options{
-			rodOpts: rodOpts{
-				ui:             &auth_ui.Huh{},
-				autoTimeout:    RODHeadlessTimeout,
-				userAgent:      "", // slackauth default user agent.
-				usermode:       false,
-				bundledBrowser: false,
-			},
-		},
-	}
-	for _, opt := range opts {
-		opt(&r.opts)
-	}
-	if wsp, err := structures.ExtractWorkspace(r.opts.workspace); err != nil {
-		return r, err
-	} else {
-		r.opts.workspace = wsp
-	}
+        if osext.IsDocker() || !osext.IsInteractive() {
+                return RodAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in dumb terminals, use token/cookie auth instead"}
+        }
+        r := RodAuth{
+                opts: options{
+                        rodOpts: rodOpts{
+                                ui:                     &auth_ui.Huh{},
+                                autoTimeout:            RODHeadlessTimeout,
+                                userAgent:              "", // slackauth default user agent.
+                                usermode:               false,
+                                bundledBrowser:         false,
+                                interactiveBrowserAuto: true,
+                        },
+                },
+        }
+        for _, opt := range opts {
+                opt(&r.opts)
+        }
+        if wsp, err := structures.ExtractWorkspace(r.opts.workspace); err != nil {
+                return r, err
+        } else {
+                r.opts.workspace = wsp
+        }
 
-	resp, err := r.opts.ui.RequestLoginType(ctx, os.Stdout, r.opts.workspace)
-	if err != nil {
-		return r, err
-	}
-	sopts := r.opts.slackauthOpts()
-	if resp.Type == auth_ui.LUserBrowser {
-		// it doesn't need to know that this browser is just a puppet in the
-		// masterful hands.
-		sopts = append(sopts, slackauth.WithForceUser(), slackauth.WithLocalBrowser(resp.BrowserPath))
-	}
+        resp, err := r.opts.ui.RequestLoginType(ctx, os.Stdout, r.opts.workspace)
+        if err != nil {
+                return r, err
+        }
+        sopts := r.opts.slackauthOpts()
+        if resp.Type == auth_ui.LUserBrowser {
+                // it doesn't need to know that this browser is just a puppet in the
+                // masterful hands.
+                sopts = append(sopts, slackauth.WithForceUser(), slackauth.WithLocalBrowser(resp.BrowserPath))
+        } else if resp.Type == auth_ui.LInteractive && !r.opts.bundledBrowser && r.opts.interactiveBrowserAuto {
+                // Workaround for #675: the launcher-managed bundled Chromium is
+                // currently pinned to revision ~v128, which Slack now rejects on
+                // the login page.  Users almost always have a newer system
+                // browser already installed; prefer it transparently for the
+                // "Login in Browser" flow.  Falls back to the bundled browser
+                // if no system browser is detected, preserving prior behaviour.
+                if path := findInteractiveBrowser(slackauth.ListBrowsers); path != "" {
+                        slog.Default().InfoContext(ctx,
+                                "using system browser for interactive login (workaround for slackdump#675)",
+                                "path", path)
+                        sopts = append(sopts, slackauth.WithLocalBrowser(path))
+                }
+        }
 
-	cl, err := slackauth.New(
-		resp.Workspace,
-		sopts...,
-	)
-	if err != nil {
-		return r, err
-	}
-	defer cl.Close()
+        cl, err := slackauth.New(
+                resp.Workspace,
+                sopts...,
+        )
+        if err != nil {
+                return r, err
+        }
+        defer cl.Close()
 
-	lg := slog.Default()
-	t := time.Now()
-	var sp simpleProvider
+        lg := slog.Default()
+        t := time.Now()
+        var sp simpleProvider
 
-	switch resp.Type {
-	case auth_ui.LInteractive, auth_ui.LUserBrowser:
-		lg.InfoContext(ctx, "ℹ️ Initialising browser, once the browser appears, login as usual")
-		sp.Token, sp.Cookie, err = cl.Manual(ctx)
-	case auth_ui.LHeadless:
-		sp, err = headlessFlow(ctx, cl, resp.Workspace, r.opts.ui)
-	case auth_ui.LMobileSignin:
-		sp, err = qrFlow(ctx, cl, r.opts.ui)
-	case auth_ui.LCancel:
-		return r, ErrCancelled
-	}
-	if err != nil {
-		return r, err
-	}
+        switch resp.Type {
+        case auth_ui.LInteractive, auth_ui.LUserBrowser:
+                lg.InfoContext(ctx, "ℹ️ Initialising browser, once the browser appears, login as usual")
+                sp.Token, sp.Cookie, err = cl.Manual(ctx)
+        case auth_ui.LHeadless:
+                sp, err = headlessFlow(ctx, cl, resp.Workspace, r.opts.ui)
+        case auth_ui.LMobileSignin:
+                sp, err = qrFlow(ctx, cl, r.opts.ui)
+        case auth_ui.LCancel:
+                return r, ErrCancelled
+        }
+        if err != nil {
+                return r, err
+        }
 
-	lg.InfoContext(ctx, "✅ authenticated", "time_taken", time.Since(t).String())
+        lg.InfoContext(ctx, "✅ authenticated", "time_taken", time.Since(t).String())
 
-	return RodAuth{
-		simpleProvider: sp,
-	}, nil
+        return RodAuth{
+                simpleProvider: sp,
+        }, nil
 }
 
 func headlessFlow(ctx context.Context, cl *slackauth.Client, workspace string, ui browserAuthUIExt) (sp simpleProvider, err error) {
-	username, password, err := ui.RequestCreds(ctx, os.Stdout, workspace)
-	if err != nil {
-		return sp, err
-	}
-	if username == "" {
-		return sp, fmt.Errorf("email cannot be empty")
-	}
-	if password == "" {
-		return sp, fmt.Errorf("password cannot be empty")
-	}
+        username, password, err := ui.RequestCreds(ctx, os.Stdout, workspace)
+        if err != nil {
+                return sp, err
+        }
+        if username == "" {
+                return sp, fmt.Errorf("email cannot be empty")
+        }
+        if password == "" {
+                return sp, fmt.Errorf("password cannot be empty")
+        }
 
-	stopSpinnerFn := pleaseWait(ctx, "Logging in to Slack, it will take 25-40 seconds")
-	defer stopSpinnerFn()
-	var loginErr error
-	sp.Token, sp.Cookie, loginErr = cl.Headless(ctx, username, password, stopSpinnerFn)
-	if loginErr != nil {
-		return sp, loginErr
-	}
-	return
+        stopSpinnerFn := pleaseWait(ctx, "Logging in to Slack, it will take 25-40 seconds")
+        defer stopSpinnerFn()
+        var loginErr error
+        sp.Token, sp.Cookie, loginErr = cl.Headless(ctx, username, password, stopSpinnerFn)
+        if loginErr != nil {
+                return sp, loginErr
+        }
+        return
+}
+
+// findInteractiveBrowser returns the path to a locally installed system
+// browser (Chrome/Edge/Brave/Chromium) suitable for use in place of the
+// launcher-managed bundled Chromium during the interactive login flow.
+//
+// It exists to work around https://github.com/rusq/slackdump/issues/675:
+// go-rod's launcher pins a Chromium revision (~v128) that Slack now
+// rejects on the login page, while users almost always have a newer
+// browser already installed on their machines.
+//
+// The lister is injected to keep the function unit-testable; in
+// production it is [slackauth.ListBrowsers].  Returns the path to the
+// first detected browser, or "" if none was detected (in which case the
+// caller should fall back to the bundled browser, preserving prior
+// behaviour).
+func findInteractiveBrowser(lister func() ([]slackauth.LocalBrowser, error)) string {
+        browsers, err := lister()
+        if err != nil || len(browsers) == 0 {
+                return ""
+        }
+        return browsers[0].Path
 }
 
 func qrFlow(ctx context.Context, cl *slackauth.Client, ui browserAuthUIExt) (sp simpleProvider, err error) {
-	imageData, err := ui.RequestQR(ctx, os.Stdout)
-	if err != nil {
-		return sp, err
-	}
-	tok, cook, err := cl.QRAuth(ctx, imageData)
-	if err != nil {
-		return sp, err
-	}
-	return simpleProvider{
-		Token:  tok,
-		Cookie: cook,
-	}, nil
+        imageData, err := ui.RequestQR(ctx, os.Stdout)
+        if err != nil {
+                return sp, err
+        }
+        tok, cook, err := cl.QRAuth(ctx, imageData)
+        if err != nil {
+                return sp, err
+        }
+        return simpleProvider{
+                Token:  tok,
+                Cookie: cook,
+        }, nil
 }

--- a/auth/rod.go
+++ b/auth/rod.go
@@ -16,18 +16,18 @@
 package auth
 
 import (
-        "context"
-        "fmt"
-        "io"
-        "log/slog"
-        "os"
-        "time"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
 
-        "github.com/rusq/slackauth"
+	"github.com/rusq/slackauth"
 
-        "github.com/rusq/slackdump/v4/auth/auth_ui"
-        "github.com/rusq/slackdump/v4/internal/osext"
-        "github.com/rusq/slackdump/v4/internal/structures"
+	"github.com/rusq/slackdump/v4/auth/auth_ui"
+	"github.com/rusq/slackdump/v4/internal/osext"
+	"github.com/rusq/slackdump/v4/internal/structures"
 )
 
 // RODHeadlessTimeout is the default timeout for the headless login flow.
@@ -47,161 +47,161 @@ const RODHeadlessTimeout = 40 * time.Second
 // Headless login is a bit fragile.  If it fails, user should be advised to
 // login interactively by choosing SSO auth type.
 type RodAuth struct {
-        simpleProvider
-        opts options
+	simpleProvider
+	opts options
 }
 
 type rodOpts struct {
-        ui             browserAuthUIExt
-        autoTimeout    time.Duration
-        userAgent      string
-        usermode       bool
-        bundledBrowser bool
-        // interactiveBrowserAuto, when true, lets the [LInteractive] login
-        // flow opportunistically use a locally installed system browser
-        // (Chrome/Edge/Brave/Chromium) instead of the launcher-managed
-        // bundled Chromium.  See [findInteractiveBrowser] and issue #675.
-        interactiveBrowserAuto bool
+	ui             browserAuthUIExt
+	autoTimeout    time.Duration
+	userAgent      string
+	usermode       bool
+	bundledBrowser bool
+	// interactiveBrowserAuto, when true, lets the [LInteractive] login
+	// flow opportunistically use a locally installed system browser
+	// (Chrome/Edge/Brave/Chromium) instead of the launcher-managed
+	// bundled Chromium.  See [findInteractiveBrowser] and issue #675.
+	interactiveBrowserAuto bool
 }
 
 func (ro rodOpts) slackauthOpts() []slackauth.Option {
-        sopts := []slackauth.Option{
-                slackauth.WithChallengeFunc(ro.ui.ConfirmationCode),
-                slackauth.WithAutologinTimeout(ro.autoTimeout),
-        }
-        if ro.userAgent != "" {
-                sopts = append(sopts, slackauth.WithUserAgent(ro.userAgent))
-        }
-        if ro.usermode {
-                sopts = append(sopts, slackauth.WithForceUser())
-        }
-        if ro.bundledBrowser {
-                sopts = append(sopts, slackauth.WithBundledBrowser())
-        }
-        return sopts
+	sopts := []slackauth.Option{
+		slackauth.WithChallengeFunc(ro.ui.ConfirmationCode),
+		slackauth.WithAutologinTimeout(ro.autoTimeout),
+	}
+	if ro.userAgent != "" {
+		sopts = append(sopts, slackauth.WithUserAgent(ro.userAgent))
+	}
+	if ro.usermode {
+		sopts = append(sopts, slackauth.WithForceUser())
+	}
+	if ro.bundledBrowser {
+		sopts = append(sopts, slackauth.WithBundledBrowser())
+	}
+	return sopts
 }
 
 type browserAuthUIExt interface {
-        // RequestLoginType should request the login type from the user and return
-        // one of the [auth_ui.LoginType] constants.  The implementation should
-        // provide a way to cancel the login flow, returning [auth_ui.LoginCancel].
-        RequestLoginType(ctx context.Context, w io.Writer, workspace string) (auth_ui.LoginOpts, error)
-        // RequestCreds should request the user's email and password and return
-        // them.
-        RequestCreds(ctx context.Context, w io.Writer, workspace string) (email string, passwd string, err error)
-        // ConfirmationCode should request the confirmation code from the user and
-        // return it.  Callback function is called to indicate that the code is
-        // requested.
-        ConfirmationCode(email string) (code int, err error)
-        // RequestQR should request the URL-encoded png image and return it.
-        RequestQR(ctx context.Context, w io.Writer) (encImage string, err error)
+	// RequestLoginType should request the login type from the user and return
+	// one of the [auth_ui.LoginType] constants.  The implementation should
+	// provide a way to cancel the login flow, returning [auth_ui.LoginCancel].
+	RequestLoginType(ctx context.Context, w io.Writer, workspace string) (auth_ui.LoginOpts, error)
+	// RequestCreds should request the user's email and password and return
+	// them.
+	RequestCreds(ctx context.Context, w io.Writer, workspace string) (email string, passwd string, err error)
+	// ConfirmationCode should request the confirmation code from the user and
+	// return it.  Callback function is called to indicate that the code is
+	// requested.
+	ConfirmationCode(email string) (code int, err error)
+	// RequestQR should request the URL-encoded png image and return it.
+	RequestQR(ctx context.Context, w io.Writer) (encImage string, err error)
 }
 
 // NewRODAuth constructs new RodAuth provider.
 func NewRODAuth(ctx context.Context, opts ...Option) (RodAuth, error) {
-        if osext.IsDocker() || !osext.IsInteractive() {
-                return RodAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in dumb terminals, use token/cookie auth instead"}
-        }
-        r := RodAuth{
-                opts: options{
-                        rodOpts: rodOpts{
-                                ui:                     &auth_ui.Huh{},
-                                autoTimeout:            RODHeadlessTimeout,
-                                userAgent:              "", // slackauth default user agent.
-                                usermode:               false,
-                                bundledBrowser:         false,
-                                interactiveBrowserAuto: true,
-                        },
-                },
-        }
-        for _, opt := range opts {
-                opt(&r.opts)
-        }
-        if wsp, err := structures.ExtractWorkspace(r.opts.workspace); err != nil {
-                return r, err
-        } else {
-                r.opts.workspace = wsp
-        }
+	if osext.IsDocker() || !osext.IsInteractive() {
+		return RodAuth{}, &Error{Err: ErrNotSupported, Msg: "browser auth is not supported in dumb terminals, use token/cookie auth instead"}
+	}
+	r := RodAuth{
+		opts: options{
+			rodOpts: rodOpts{
+				ui:                     &auth_ui.Huh{},
+				autoTimeout:            RODHeadlessTimeout,
+				userAgent:              "", // slackauth default user agent.
+				usermode:               false,
+				bundledBrowser:         false,
+				interactiveBrowserAuto: true,
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(&r.opts)
+	}
+	if wsp, err := structures.ExtractWorkspace(r.opts.workspace); err != nil {
+		return r, err
+	} else {
+		r.opts.workspace = wsp
+	}
 
-        resp, err := r.opts.ui.RequestLoginType(ctx, os.Stdout, r.opts.workspace)
-        if err != nil {
-                return r, err
-        }
-        sopts := r.opts.slackauthOpts()
-        if resp.Type == auth_ui.LUserBrowser {
-                // it doesn't need to know that this browser is just a puppet in the
-                // masterful hands.
-                sopts = append(sopts, slackauth.WithForceUser(), slackauth.WithLocalBrowser(resp.BrowserPath))
-        } else if resp.Type == auth_ui.LInteractive && !r.opts.bundledBrowser && r.opts.interactiveBrowserAuto {
-                // Workaround for #675: the launcher-managed bundled Chromium is
-                // currently pinned to revision ~v128, which Slack now rejects on
-                // the login page.  Users almost always have a newer system
-                // browser already installed; prefer it transparently for the
-                // "Login in Browser" flow.  Falls back to the bundled browser
-                // if no system browser is detected, preserving prior behaviour.
-                if path := findInteractiveBrowser(slackauth.ListBrowsers); path != "" {
-                        slog.Default().InfoContext(ctx,
-                                "using system browser for interactive login (workaround for slackdump#675)",
-                                "path", path)
-                        sopts = append(sopts, slackauth.WithLocalBrowser(path))
-                }
-        }
+	resp, err := r.opts.ui.RequestLoginType(ctx, os.Stdout, r.opts.workspace)
+	if err != nil {
+		return r, err
+	}
+	sopts := r.opts.slackauthOpts()
+	if resp.Type == auth_ui.LUserBrowser {
+		// it doesn't need to know that this browser is just a puppet in the
+		// masterful hands.
+		sopts = append(sopts, slackauth.WithForceUser(), slackauth.WithLocalBrowser(resp.BrowserPath))
+	} else if resp.Type == auth_ui.LInteractive && !r.opts.bundledBrowser && r.opts.interactiveBrowserAuto {
+		// Workaround for #675: the launcher-managed bundled Chromium is
+		// currently pinned to revision ~v128, which Slack now rejects on
+		// the login page.  Users almost always have a newer system
+		// browser already installed; prefer it transparently for the
+		// "Login in Browser" flow.  Falls back to the bundled browser
+		// if no system browser is detected, preserving prior behaviour.
+		if path := findInteractiveBrowser(slackauth.ListBrowsers); path != "" {
+			slog.Default().InfoContext(ctx,
+				"using system browser for interactive login (workaround for slackdump#675)",
+				"path", path)
+			sopts = append(sopts, slackauth.WithLocalBrowser(path))
+		}
+	}
 
-        cl, err := slackauth.New(
-                resp.Workspace,
-                sopts...,
-        )
-        if err != nil {
-                return r, err
-        }
-        defer cl.Close()
+	cl, err := slackauth.New(
+		resp.Workspace,
+		sopts...,
+	)
+	if err != nil {
+		return r, err
+	}
+	defer cl.Close()
 
-        lg := slog.Default()
-        t := time.Now()
-        var sp simpleProvider
+	lg := slog.Default()
+	t := time.Now()
+	var sp simpleProvider
 
-        switch resp.Type {
-        case auth_ui.LInteractive, auth_ui.LUserBrowser:
-                lg.InfoContext(ctx, "ℹ️ Initialising browser, once the browser appears, login as usual")
-                sp.Token, sp.Cookie, err = cl.Manual(ctx)
-        case auth_ui.LHeadless:
-                sp, err = headlessFlow(ctx, cl, resp.Workspace, r.opts.ui)
-        case auth_ui.LMobileSignin:
-                sp, err = qrFlow(ctx, cl, r.opts.ui)
-        case auth_ui.LCancel:
-                return r, ErrCancelled
-        }
-        if err != nil {
-                return r, err
-        }
+	switch resp.Type {
+	case auth_ui.LInteractive, auth_ui.LUserBrowser:
+		lg.InfoContext(ctx, "ℹ️ Initialising browser, once the browser appears, login as usual")
+		sp.Token, sp.Cookie, err = cl.Manual(ctx)
+	case auth_ui.LHeadless:
+		sp, err = headlessFlow(ctx, cl, resp.Workspace, r.opts.ui)
+	case auth_ui.LMobileSignin:
+		sp, err = qrFlow(ctx, cl, r.opts.ui)
+	case auth_ui.LCancel:
+		return r, ErrCancelled
+	}
+	if err != nil {
+		return r, err
+	}
 
-        lg.InfoContext(ctx, "✅ authenticated", "time_taken", time.Since(t).String())
+	lg.InfoContext(ctx, "✅ authenticated", "time_taken", time.Since(t).String())
 
-        return RodAuth{
-                simpleProvider: sp,
-        }, nil
+	return RodAuth{
+		simpleProvider: sp,
+	}, nil
 }
 
 func headlessFlow(ctx context.Context, cl *slackauth.Client, workspace string, ui browserAuthUIExt) (sp simpleProvider, err error) {
-        username, password, err := ui.RequestCreds(ctx, os.Stdout, workspace)
-        if err != nil {
-                return sp, err
-        }
-        if username == "" {
-                return sp, fmt.Errorf("email cannot be empty")
-        }
-        if password == "" {
-                return sp, fmt.Errorf("password cannot be empty")
-        }
+	username, password, err := ui.RequestCreds(ctx, os.Stdout, workspace)
+	if err != nil {
+		return sp, err
+	}
+	if username == "" {
+		return sp, fmt.Errorf("email cannot be empty")
+	}
+	if password == "" {
+		return sp, fmt.Errorf("password cannot be empty")
+	}
 
-        stopSpinnerFn := pleaseWait(ctx, "Logging in to Slack, it will take 25-40 seconds")
-        defer stopSpinnerFn()
-        var loginErr error
-        sp.Token, sp.Cookie, loginErr = cl.Headless(ctx, username, password, stopSpinnerFn)
-        if loginErr != nil {
-                return sp, loginErr
-        }
-        return
+	stopSpinnerFn := pleaseWait(ctx, "Logging in to Slack, it will take 25-40 seconds")
+	defer stopSpinnerFn()
+	var loginErr error
+	sp.Token, sp.Cookie, loginErr = cl.Headless(ctx, username, password, stopSpinnerFn)
+	if loginErr != nil {
+		return sp, loginErr
+	}
+	return
 }
 
 // findInteractiveBrowser returns the path to a locally installed system
@@ -219,24 +219,24 @@ func headlessFlow(ctx context.Context, cl *slackauth.Client, workspace string, u
 // caller should fall back to the bundled browser, preserving prior
 // behaviour).
 func findInteractiveBrowser(lister func() ([]slackauth.LocalBrowser, error)) string {
-        browsers, err := lister()
-        if err != nil || len(browsers) == 0 {
-                return ""
-        }
-        return browsers[0].Path
+	browsers, err := lister()
+	if err != nil || len(browsers) == 0 {
+		return ""
+	}
+	return browsers[0].Path
 }
 
 func qrFlow(ctx context.Context, cl *slackauth.Client, ui browserAuthUIExt) (sp simpleProvider, err error) {
-        imageData, err := ui.RequestQR(ctx, os.Stdout)
-        if err != nil {
-                return sp, err
-        }
-        tok, cook, err := cl.QRAuth(ctx, imageData)
-        if err != nil {
-                return sp, err
-        }
-        return simpleProvider{
-                Token:  tok,
-                Cookie: cook,
-        }, nil
+	imageData, err := ui.RequestQR(ctx, os.Stdout)
+	if err != nil {
+		return sp, err
+	}
+	tok, cook, err := cl.QRAuth(ctx, imageData)
+	if err != nil {
+		return sp, err
+	}
+	return simpleProvider{
+		Token:  tok,
+		Cookie: cook,
+	}, nil
 }

--- a/auth/rod_test.go
+++ b/auth/rod_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2021-2026 Rustam Gilyazov and Contributors.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rusq/slackauth"
+)
+
+func TestFindInteractiveBrowser(t *testing.T) {
+	tests := []struct {
+		name   string
+		lister func() ([]slackauth.LocalBrowser, error)
+		want   string
+	}{
+		{
+			name:   "no browsers found returns empty",
+			lister: func() ([]slackauth.LocalBrowser, error) { return nil, slackauth.ErrNoBrowsers },
+			want:   "",
+		},
+		{
+			name:   "arbitrary lister error returns empty",
+			lister: func() ([]slackauth.LocalBrowser, error) { return nil, errors.New("disk on fire") },
+			want:   "",
+		},
+		{
+			name:   "empty slice returns empty",
+			lister: func() ([]slackauth.LocalBrowser, error) { return []slackauth.LocalBrowser{}, nil },
+			want:   "",
+		},
+		{
+			name: "single chromium returns its path",
+			lister: func() ([]slackauth.LocalBrowser, error) {
+				return []slackauth.LocalBrowser{{Name: "Chromium", Path: "/usr/bin/chromium"}}, nil
+			},
+			want: "/usr/bin/chromium",
+		},
+		{
+			name: "multiple browsers picks the first (slackauth-prioritised) one",
+			lister: func() ([]slackauth.LocalBrowser, error) {
+				return []slackauth.LocalBrowser{
+					{Name: "Microsoft Edge", Path: "/usr/bin/microsoft-edge"},
+					{Name: "Chromium", Path: "/usr/bin/chromium"},
+				}, nil
+			},
+			want: "/usr/bin/microsoft-edge",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findInteractiveBrowser(tt.lister); got != tt.want {
+				t.Errorf("findInteractiveBrowser() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/auth/rod_test.go
+++ b/auth/rod_test.go
@@ -22,6 +22,25 @@ import (
 	"github.com/rusq/slackauth"
 )
 
+func TestRODWithBundledBrowser(t *testing.T) {
+	tests := []struct {
+		name string
+		b    bool
+	}{
+		{name: "sets true", b: true},
+		{name: "sets false", b: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var o options
+			RODWithBundledBrowser(tt.b)(&o)
+			if o.rodOpts.bundledBrowser != tt.b {
+				t.Errorf("RODWithBundledBrowser(%v): bundledBrowser = %v, want %v", tt.b, o.rodOpts.bundledBrowser, tt.b)
+			}
+		})
+	}
+}
+
 func TestFindInteractiveBrowser(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/cmd/slackdump/internal/resume/resume_test.go
+++ b/cmd/slackdump/internal/resume/resume_test.go
@@ -339,11 +339,11 @@ func Test_usersTeam(t *testing.T) {
 
 func Test_latest(t *testing.T) {
 	type args struct {
-		ctx                context.Context
-		includeThreads     bool
+		ctx                 context.Context
+		includeThreads      bool
 		skipCompleteThreads bool
-		lookBack           time.Duration
-		other              *structures.EntityList
+		lookBack            time.Duration
+		other               *structures.EntityList
 	}
 	tests := []struct {
 		name     string
@@ -355,10 +355,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "resumer error",
 			args: args{
-				ctx:                  t.Context(),
-				includeThreads:       false,
+				ctx:                 t.Context(),
+				includeThreads:      false,
 				skipCompleteThreads: false,
-				lookBack:             0,
+				lookBack:            0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(nil, assert.AnError)
@@ -369,10 +369,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "no entities",
 			args: args{
-				ctx:                  t.Context(),
-				includeThreads:       false,
+				ctx:                 t.Context(),
+				includeThreads:      false,
 				skipCompleteThreads: false,
-				lookBack:             0,
+				lookBack:            0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{}, nil)
@@ -383,10 +383,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "returns latest status",
 			args: args{
-				ctx:                  t.Context(),
-				includeThreads:       false,
+				ctx:                 t.Context(),
+				includeThreads:      false,
 				skipCompleteThreads: false,
-				lookBack:             0,
+				lookBack:            0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
@@ -401,10 +401,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "returns latest status with thread",
 			args: args{
-				ctx:                  t.Context(),
-				includeThreads:       true,
+				ctx:                 t.Context(),
+				includeThreads:      true,
 				skipCompleteThreads: false,
-				lookBack:             0,
+				lookBack:            0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
@@ -421,10 +421,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "returns latest status with thread, but includeThreads is false",
 			args: args{
-				ctx:                  t.Context(),
-				includeThreads:       false,
+				ctx:                 t.Context(),
+				includeThreads:      false,
 				skipCompleteThreads: false,
-				lookBack:             0,
+				lookBack:            0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
@@ -459,10 +459,10 @@ func Test_latest(t *testing.T) {
 		{
 			name: "returns latest status with thread and skipCompleteThreads true",
 			args: args{
-				ctx:                  t.Context(),
-				includeThreads:       true,
+				ctx:                 t.Context(),
+				includeThreads:      true,
 				skipCompleteThreads: true,
-				lookBack:             0,
+				lookBack:            0,
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{

--- a/cmd/slackdump/internal/workspace/assets/new.md
+++ b/cmd/slackdump/internal/workspace/assets/new.md
@@ -13,6 +13,20 @@ workspace by default. You can either continue using it as your default
 workspace or create a new one. Later, you can switch between workspaces using
 the `workspace select` command.
 
+## Browser selection
+
+By default, `workspace new` will detect a locally installed browser (Chrome,
+Edge, Brave, or Chromium) and use it for the interactive "Login in Browser"
+flow.  This is the recommended behaviour because the launcher-managed bundled
+Chromium is pinned to an older revision that Slack now rejects.
+
+If a system browser causes problems (or none is installed), use
+`-bundled-browser` to fall back to the launcher-managed bundled Chromium:
+
+```shell
+slackdump workspace new -bundled-browser <workspace name or url>
+```
+
 ## Usage
 ### Free and Standard Workspaces
 

--- a/cmd/slackdump/internal/workspace/new.go
+++ b/cmd/slackdump/internal/workspace/new.go
@@ -51,13 +51,13 @@ func init() {
 
 // runWspNew authenticates in the new workspace.
 func runWspNew(ctx context.Context, cmd *base.Command, args []string) error {
+	authOpts := append([]auth.Option{
+		auth.BrowserWithBrowser(wspcfg.Browser),
+		auth.BrowserWithTimeout(wspcfg.LoginTimeout),
+	}, wspcfg.RodAuthOptions()...)
+
 	m, err := CacheMgr(
-		cache.WithAuthOpts(
-			auth.BrowserWithBrowser(wspcfg.Browser),
-			auth.BrowserWithTimeout(wspcfg.LoginTimeout),
-			auth.RODWithRODHeadlessTimeout(wspcfg.HeadlessTimeout),
-			auth.RODWithUserAgent(wspcfg.RODUserAgent),
-		))
+		cache.WithAuthOpts(authOpts...))
 	if err != nil {
 		base.SetExitStatus(base.SCacheError)
 		return fmt.Errorf("error initialising workspace manager: %s", err)

--- a/cmd/slackdump/internal/workspace/workspaceui/ezlogin3000.go
+++ b/cmd/slackdump/internal/workspace/workspaceui/ezlogin3000.go
@@ -77,7 +77,10 @@ func playwrightLogin(ctx context.Context, mgr manager) error {
 }
 
 func rodLogin(ctx context.Context, mgr manager) error {
-	prov, err := auth.NewRODAuth(ctx, auth.BrowserWithTimeout(wspcfg.LoginTimeout), auth.RODWithRODHeadlessTimeout(wspcfg.HeadlessTimeout), auth.RODWithUserAgent(wspcfg.RODUserAgent))
+	authOpts := append([]auth.Option{
+		auth.BrowserWithTimeout(wspcfg.LoginTimeout),
+	}, wspcfg.RodAuthOptions()...)
+	prov, err := auth.NewRODAuth(ctx, authOpts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/slackdump/internal/workspace/workspaceui/workspaceui.go
+++ b/cmd/slackdump/internal/workspace/workspaceui/workspaceui.go
@@ -232,6 +232,12 @@ func configuration() cfgui.Configuration {
 					Value:       wspcfg.RODUserAgent,
 					Updater:     updaters.NewString(&wspcfg.RODUserAgent, "", false, nil),
 				},
+				{
+					Name:        "Force Bundled Browser",
+					Description: "Use the launcher-managed bundled Chromium instead of a system browser for interactive login.",
+					Value:       cfgui.Checkbox(wspcfg.BundledBrowser),
+					Updater:     updaters.NewBool(&wspcfg.BundledBrowser),
+				},
 			},
 		},
 	}

--- a/cmd/slackdump/internal/workspace/wspcfg/wspcfg.go
+++ b/cmd/slackdump/internal/workspace/wspcfg/wspcfg.go
@@ -32,9 +32,17 @@ var (
 	LoginTimeout    time.Duration = browser.DefLoginTimeout // overall login time.
 	HeadlessTimeout time.Duration = auth.RODHeadlessTimeout // net interaction time.
 	RODUserAgent    string                                  // when empty, slackauth uses the default user agent.
+	BundledBrowser  bool                                    // when true, forces the launcher-managed bundled Chromium for interactive login.
 	// playwright stuff
 	Browser       browser.Browser
 	LegacyBrowser bool
+)
+
+var (
+	rodWithHeadlessTimeout = auth.RODWithRODHeadlessTimeout
+	rodWithUserAgent       = auth.RODWithUserAgent
+	rodWithBundledBrowser  = auth.RODWithBundledBrowser
+	rodWithInteractiveAuto = auth.RODWithInteractiveBrowserAuto
 )
 
 func SetWspFlags(fs *flag.FlagSet) {
@@ -45,4 +53,16 @@ func SetWspFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&HeadlessTimeout, "autologin-timeout", HeadlessTimeout, "headless autologin `timeout`, without the browser starting time, just the interaction time")
 	fs.BoolVar(&LegacyBrowser, "legacy-browser", false, "use legacy browser automation (playwright) for EZ-Login 3000")
 	fs.StringVar(&RODUserAgent, "user-agent", "", "override the user agent string for EZ-Login 3000")
+	fs.BoolVar(&BundledBrowser, "bundled-browser", false, "force the launcher-managed bundled Chromium for interactive login (disables system browser auto-detection)")
+}
+
+// RodAuthOptions returns auth options shared by all ROD-based workspace login
+// entry points, keeping CLI and TUI behaviour aligned.
+func RodAuthOptions() []auth.Option {
+	return []auth.Option{
+		rodWithHeadlessTimeout(HeadlessTimeout),
+		rodWithUserAgent(RODUserAgent),
+		rodWithBundledBrowser(BundledBrowser),
+		rodWithInteractiveAuto(!BundledBrowser),
+	}
 }

--- a/cmd/slackdump/internal/workspace/wspcfg/wspcfg_test.go
+++ b/cmd/slackdump/internal/workspace/wspcfg/wspcfg_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2021-2026 Rustam Gilyazov and Contributors.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package wspcfg
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/rusq/slackdump/v4/auth"
+)
+
+func TestSetWspFlags_bundledBrowser(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "default is false", args: []string{}, want: false},
+		{name: "-bundled-browser sets true", args: []string{"-bundled-browser"}, want: true},
+		{name: "-bundled-browser=true", args: []string{"-bundled-browser=true"}, want: true},
+		{name: "-bundled-browser=false", args: []string{"-bundled-browser=false"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			BundledBrowser = false
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			SetWspFlags(fs)
+			if err := fs.Parse(tt.args); err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if BundledBrowser != tt.want {
+				t.Errorf("BundledBrowser = %v, want %v", BundledBrowser, tt.want)
+			}
+		})
+	}
+}
+
+func TestRodAuthOptions_WiresBundledBrowserPolarity(t *testing.T) {
+	origHeadless := rodWithHeadlessTimeout
+	origUA := rodWithUserAgent
+	origBundled := rodWithBundledBrowser
+	origAuto := rodWithInteractiveAuto
+	defer func() {
+		rodWithHeadlessTimeout = origHeadless
+		rodWithUserAgent = origUA
+		rodWithBundledBrowser = origBundled
+		rodWithInteractiveAuto = origAuto
+	}()
+
+	var (
+		gotHeadless time.Duration
+		gotUA       string
+		gotBundled  bool
+		gotAuto     bool
+	)
+	rodWithHeadlessTimeout = func(d time.Duration) auth.Option {
+		gotHeadless = d
+		return nil
+	}
+	rodWithUserAgent = func(s string) auth.Option {
+		gotUA = s
+		return nil
+	}
+	rodWithBundledBrowser = func(b bool) auth.Option {
+		gotBundled = b
+		return nil
+	}
+	rodWithInteractiveAuto = func(b bool) auth.Option {
+		gotAuto = b
+		return nil
+	}
+
+	HeadlessTimeout = 77 * time.Second
+	RODUserAgent = "ua-test"
+	BundledBrowser = true
+	opts := RodAuthOptions()
+
+	if len(opts) != 4 {
+		t.Fatalf("RodAuthOptions() len = %d, want 4", len(opts))
+	}
+	if gotHeadless != 77*time.Second {
+		t.Errorf("headless timeout = %v, want %v", gotHeadless, 77*time.Second)
+	}
+	if gotUA != "ua-test" {
+		t.Errorf("user agent = %q, want %q", gotUA, "ua-test")
+	}
+	if !gotBundled {
+		t.Errorf("bundled browser = %v, want true", gotBundled)
+	}
+	if gotAuto {
+		t.Errorf("interactive auto = %v, want false", gotAuto)
+	}
+}


### PR DESCRIPTION
### What

  Adds an opportunistic system-browser-detection step to slackdump's
  `auth.NewRODAuth` so the default "Login in Browser" flow Just Works
  again.  When the user picks `LInteractive` and has not explicitly
  opted into the bundled browser, slackdump now calls
  `slackauth.ListBrowsers()` and, if any system browser
  (Chrome/Edge/Brave/Chromium) is detected, threads its path through
  `slackauth.WithLocalBrowser()`.  Existing flows
  (`LUserBrowser`, `LHeadless`, `LMobileSignin`) are untouched, and
  when no system browser is detected we fall back to the bundled
  browser as before.

  ### Why this and not a Chromium pin bump

  Slack's login page started rejecting browsers older than v137 a few
  weeks ago, which is what users in the issue thread are hitting:

  > Sorry, your browser is too old to use Slack.

  The natural reflex is "bump the bundled Chromium" — but go-rod's
  launcher pins the revision (~v128) inside go-rod itself, and go-rod
  has not cut a release since 2024-07-12.  Even if it had, every user
  on a fresh install would still pay the multi-hundred-MB download.
  Meanwhile, the same users almost always have a perfectly modern
  Chrome/Edge/Brave/Chromium installed already and slackauth already
  knows how to discover them via `ListBrowsers()` — it just was not
  being used for the default path.  This is the smallest change that
  restores working behaviour for the affected users today, without
  waiting on go-rod's release cycle and without adding a download.

  ### How

  `auth/rod.go` (`NewRODAuth`):

    - Add a new `interactiveBrowserAuto` field on `rodOpts` (defaults
      to `true`).
    - When `resp.Type == LInteractive`, the bundled browser was not
      explicitly requested, and the auto path is enabled, call
      `findInteractiveBrowser(slackauth.ListBrowsers)` and append
      `slackauth.WithLocalBrowser(path)` if a system browser is found.
    - Log the chosen path at `INFO` so users can see what happened.

  `auth/rod.go` (new helper `findInteractiveBrowser`):

    - Takes the lister as a function value to keep the function
      unit-testable without touching `PATH` or the filesystem.
    - Returns `""` on lister error / empty result, so callers can
      simply skip the option append and fall back to the bundled
      browser.

  `auth/option.go`:

    - New `RODWithInteractiveBrowserAuto(b bool) Option` lets callers
      opt out (e.g. for test fixtures or for users that explicitly
      want the bundled browser back).

  `auth/rod_test.go`:

    - Covers the four interesting cases for `findInteractiveBrowser`:
      no browsers, lister error, single browser, multi-browser
      (first-wins).

  ### Verification

  ```
  $ go build ./...                   # passes
  $ go test -count=1 ./auth/         # ok  github.com/rusq/slackdump/v4/auth  0.063s
  ```

  Manual interactive verification was not possible from the
  contributor's environment (no display server, no Slack workspace to
  auth against), but the logic is exercised by the new unit tests and
  the production code path is the same one already used by
  `LUserBrowser`, which works today.

  ### Notes

    - `bundledBrowser` was already a field on `rodOpts` but had no
      public `Option` setter.  This PR keeps it gated by the new
      `interactiveBrowserAuto` flag so neither field changes meaning
      for existing callers.
    - This does not change behaviour for the `LHeadless` flow.  That
      flow uses a real headless browser and should keep using the
      bundled Chromium so behaviour is reproducible across machines.
      If users hit the same v128 issue there, that is a separate
      discussion (probably waiting on a go-rod launcher release).

  Fixes #675.