### PR TITLE
[codex] decouple DBController from command names

### DIFF
--- a/cmd/slackdump/internal/archive/archive.go
+++ b/cmd/slackdump/internal/archive/archive.go
@@ -39,6 +39,7 @@ import (
 	"github.com/rusq/slackdump/v4/internal/client"
 	"github.com/rusq/slackdump/v4/internal/convert/transform/fileproc"
 	"github.com/rusq/slackdump/v4/internal/structures"
+	"github.com/rusq/slackdump/v4/processor"
 	"github.com/rusq/slackdump/v4/source"
 	"github.com/rusq/slackdump/v4/stream"
 )
@@ -212,12 +213,12 @@ func WithFileDeduplication() DBControllerOption {
 // Obscene, just obscene amount of arguments.
 func DBController(ctx context.Context, sessionName string, conn *sqlx.DB, client client.Slack, dirname string, flags control.Flags, streamOpts []stream.Option, opts ...DBControllerOption) (Controller, error) {
 	lg := cfg.Log
-	var copt dbControllerOptions
+	var options dbControllerOptions
 	for _, opt := range opts {
-		opt(&copt)
+		opt(&options)
 	}
 
-	dbp, err := dbase.New(ctx, conn, bootstrap.SessionInfo(sessionName), copt.dbaseOptions...)
+	dbp, err := dbase.New(ctx, conn, bootstrap.SessionInfo(sessionName), options.dbaseOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -245,10 +246,7 @@ func DBController(ctx context.Context, sessionName string, conn *sqlx.DB, client
 		lg,
 	)
 
-	filer := fileproc.New(dl)
-	if copt.fileDeduplicate {
-		filer = fileproc.NewDeduplicatingFileProcessor(filer, conn, lg)
-	}
+	filer := dbControllerFiler(dl, conn, lg, options)
 
 	ctrl, err := control.New(
 		ctx,
@@ -262,6 +260,14 @@ func DBController(ctx context.Context, sessionName string, conn *sqlx.DB, client
 		return nil, err
 	}
 	return ctrl, nil
+}
+
+func dbControllerFiler(dl fileproc.Downloader, conn *sqlx.DB, lg *slog.Logger, options dbControllerOptions) processor.Filer {
+	filer := fileproc.New(dl)
+	if options.fileDeduplicate {
+		return fileproc.NewDeduplicatingFileProcessor(filer, conn, lg)
+	}
+	return filer
 }
 
 type Controller interface {

--- a/cmd/slackdump/internal/archive/archive.go
+++ b/cmd/slackdump/internal/archive/archive.go
@@ -182,13 +182,42 @@ func NewDirectory(name string) (*chunk.Directory, error) {
 	return cd, nil
 }
 
+type dbControllerOptions struct {
+	dbaseOptions    []dbase.Option
+	fileDeduplicate bool
+}
+
+// DBControllerOption configures the database controller.
+type DBControllerOption func(*dbControllerOptions)
+
+// WithDatabaseOptions passes options to the database backend.
+func WithDatabaseOptions(opts ...dbase.Option) DBControllerOption {
+	return func(o *dbControllerOptions) {
+		o.dbaseOptions = append(o.dbaseOptions, opts...)
+	}
+}
+
+// WithFileDeduplication skips downloading files already present in the
+// database.
+func WithFileDeduplication() DBControllerOption {
+	return func(o *dbControllerOptions) {
+		o.fileDeduplicate = true
+	}
+}
+
 // DBController returns a new database controller initialised with the given
-// parameters.
+// parameters. sessionName is recorded in the database session only and must not
+// be used to select controller behaviour.
 //
 // Obscene, just obscene amount of arguments.
-func DBController(ctx context.Context, cmdName string, conn *sqlx.DB, client client.Slack, dirname string, flags control.Flags, streamOpts []stream.Option, opts ...dbase.Option) (Controller, error) {
+func DBController(ctx context.Context, sessionName string, conn *sqlx.DB, client client.Slack, dirname string, flags control.Flags, streamOpts []stream.Option, opts ...DBControllerOption) (Controller, error) {
 	lg := cfg.Log
-	dbp, err := dbase.New(ctx, conn, bootstrap.SessionInfo(cmdName), opts...)
+	var copt dbControllerOptions
+	for _, opt := range opts {
+		opt(&copt)
+	}
+
+	dbp, err := dbase.New(ctx, conn, bootstrap.SessionInfo(sessionName), copt.dbaseOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -216,9 +245,8 @@ func DBController(ctx context.Context, cmdName string, conn *sqlx.DB, client cli
 		lg,
 	)
 
-	// Wrap file processor with deduplication for resume operations
 	filer := fileproc.New(dl)
-	if cmdName == "resume" {
+	if copt.fileDeduplicate {
 		filer = fileproc.NewDeduplicatingFileProcessor(filer, conn, lg)
 	}
 

--- a/cmd/slackdump/internal/archive/archive_test.go
+++ b/cmd/slackdump/internal/archive/archive_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/rusq/slackdump/v4/internal/chunk/backend/dbase"
+	"github.com/rusq/slackdump/v4/internal/convert/transform/fileproc"
 )
 
 func TestNewDirectory(t *testing.T) {
@@ -35,4 +38,47 @@ func TestNewDirectory(t *testing.T) {
 		defer cd.Close()
 		assert.Equal(t, tmpdir, cd.Name())
 	})
+}
+
+func TestDBControllerOptions(t *testing.T) {
+	var opts dbControllerOptions
+
+	WithDatabaseOptions(dbase.WithVerbose(true))(&opts)
+	WithDatabaseOptions(dbase.WithOnlyNewOrChangedUsers(true))(&opts)
+	WithFileDeduplication()(&opts)
+	WithFileDeduplication()(&opts)
+
+	assert.Len(t, opts.dbaseOptions, 2)
+	assert.True(t, opts.fileDeduplicate)
+}
+
+func TestDBControllerFileDeduplicationOption(t *testing.T) {
+	tests := []struct {
+		name string
+		opts dbControllerOptions
+		want func(t *testing.T, got any)
+	}{
+		{
+			name: "default file processor",
+			want: func(t *testing.T, got any) {
+				_, ok := got.(fileproc.FileProcessor)
+				assert.True(t, ok)
+			},
+		},
+		{
+			name: "deduplicating file processor",
+			opts: dbControllerOptions{fileDeduplicate: true},
+			want: func(t *testing.T, got any) {
+				_, ok := got.(*fileproc.DeduplicatingFileProcessor)
+				assert.True(t, ok)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dbControllerFiler(fileproc.NoopDownloader{}, nil, nil, tt.opts)
+			tt.want(t, got)
+		})
+	}
 }

--- a/cmd/slackdump/internal/resume/resume.go
+++ b/cmd/slackdump/internal/resume/resume.go
@@ -174,7 +174,17 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 	if resumeFlags.SkipCompleteThreads {
 		streamOpts = append(streamOpts, stream.OptSkipThreadFunc(dbase.NewThreadSkipper(wconn)))
 	}
-	ctrl, err := archive.DBController(ctx, cmd.Name(), wconn, client, dir, cf, streamOpts, dbase.WithOnlyNewOrChangedUsers(resumeFlags.RecordOnlyNewUsers))
+	ctrl, err := archive.DBController(
+		ctx,
+		cmd.Name(),
+		wconn,
+		client,
+		dir,
+		cf,
+		streamOpts,
+		archive.WithFileDeduplication(),
+		archive.WithDatabaseOptions(dbase.WithOnlyNewOrChangedUsers(resumeFlags.RecordOnlyNewUsers)),
+	)
 	if err != nil {
 		base.SetExitStatus(base.SInitializationError)
 		return fmt.Errorf("error creating archive controller: %w", err)


### PR DESCRIPTION
## Summary

This PR decouples `archive.DBController` behavior from command names. The controller now treats the supplied string as a database session label only, and callers select behavior explicitly through controller options.

## What Changed

- Added `DBControllerOption` support in `cmd/slackdump/internal/archive/archive.go`.
- Added `WithFileDeduplication()` so resume can request duplicate file skipping directly.
- Added `WithDatabaseOptions(...)` to keep existing `dbase.Option` passthrough behavior without overloading the session string.
- Renamed the controller string parameter to `sessionName` and documented that it must not drive controller behavior.
- Updated the resume command to opt into file deduplication explicitly while still recording its session name as before.

## Why

`DBController` previously checked `cmdName == "resume"` to decide whether to wrap the file processor with deduplication. That made a database/archive controller depend on a command name, even though the value should only describe the recorded session. This made the controller API harder to reason about and easy to break by renaming or reusing commands.

## Impact

Runtime behavior is intended to remain the same:

- `slackdump archive` records a normal database archive without file deduplication.
- `slackdump resume` still uses file deduplication and `dbase.WithOnlyNewOrChangedUsers(...)`.
- Database session `Mode` still records the command/session string.

The internal API now makes resume-specific behavior explicit at the call site.

## Validation

Ran:

```sh
go test ./cmd/slackdump/internal/archive ./cmd/slackdump/internal/resume ./internal/convert/transform/fileproc
```

All targeted tests passed.