### PR TITLE
Add slack-to-discord to Discord migration docs

### DIFF
--- a/doc/usage-export.md
+++ b/doc/usage-export.md
@@ -142,8 +142,9 @@ for full details.
 
 ## Migrating to Discord
 
-Use [Slackord2](https://github.com/thomasloupe/Slackord2) — a GUI tool
-compatible with Slackdump export files.
+There are multiple Discord importers that are compatible with Slackdump export files:
+- [`slack-to-discord`](https://github.com/pR0Ps/slack-to-discord) (CLI tool)
+- [Slackord](https://github.com/thomasloupe/Slackord) (GUI tool)
 
 ## Archive vs Export vs Dump
 


### PR DESCRIPTION
Hi, I'm the maintainer of [slack-to-discord](https://github.com/pR0Ps/slack-to-discord), a project that imports Slack export files into a Discord server.

I discovered this project via [a PR that a slackdump user opened on my repo](https://github.com/pR0Ps/slack-to-discord/pull/38) and have since made changes to ensure that slackdump-generated archives should now work just as well as the official exports.

Would you mind adding a link to the project in your Discord migration section? 

