### PR TITLE
resume: add -skip-stale-threads and -skip-stale-channels flags

### DIFF
--- a/cmd/slackdump/internal/resume/assets/resume.md
+++ b/cmd/slackdump/internal/resume/assets/resume.md
@@ -48,5 +48,36 @@ slackdump resume -dedupe slackdump_20241231_150405
 Deduplication runs only after resume finishes successfully. To preview or run
 the same cleanup manually later, use `slackdump tools dedupe`.
 
+### Skipping stale entities.
+
+Long-lived archives accumulate channels and threads that have not received any
+new activity for weeks or months. Resuming such archives spends most of its
+wall-clock time fetching the first page of `conversations.replies` for
+thread parents that will never get another reply, which also burns
+rate-limit budget on `conversations.replies` and is the most common cause of
+Slack 429 retries during resume.
+
+`-skip-stale-threads` and `-skip-stale-channels` filter dormant entities out
+of the entity list **before** any API call fires. Both flags accept an ISO
+8601 duration (e.g. `p21d`, `p7d`, `p2w`) and default to disabled when not
+set:
+
+```plaintext
+# Skip threads whose latest reply is older than 21 days; channels untouched.
+slackdump resume -threads -skip-stale-threads p21d <archive>
+
+# Skip dormant channels in addition. Pair with a periodic full-sweep run
+# (e.g. a daily cron without the skip-stale flags) so dormant channels
+# are still revisited and resurrections are surfaced.
+slackdump resume -threads -skip-stale-threads p21d -skip-stale-channels p21d <archive>
+```
+
+The two flags are independent. Skipping stale **channels** is the more
+aggressive trade because brand-new top-level messages in a skipped channel
+will not be picked up until that channel is included again — pair with a
+periodic full sweep. Skipping stale **threads** is conservative: dormant
+thread parents are very unlikely to receive new replies, and a full sweep
+will still catch them.
+
 __NOTE__: Resume is in beta and may not work as expected. Please report any
 issues on GitHub.

--- a/cmd/slackdump/internal/resume/resume.go
+++ b/cmd/slackdump/internal/resume/resume.go
@@ -75,12 +75,25 @@ type ResumeParams struct {
 	// replies (DB count == API reply_count + 1).  Faster, but won't detect
 	// edited or deleted messages.  Use only when threads are append-only.
 	SkipCompleteThreads bool
+	// SkipStaleThreads, if set to a non-zero duration, drops thread entities
+	// whose latest known reply is older than the duration before they are
+	// dispatched.  This is a pre-API filter that avoids fetching the first
+	// page of replies for dormant threads.  Default (zero/unset) = disabled.
+	SkipStaleThreads *extDuration
+	// SkipStaleChannels, if set to a non-zero duration, drops channel
+	// entities whose latest known message is older than the duration before
+	// they are dispatched.  Pair with a periodic full-sweep run so dormant
+	// channels are still revisited for resurrection coverage.  Default
+	// (zero/unset) = disabled.
+	SkipStaleChannels *extDuration
 	// Dedupe runs duplicate entity cleanup after a successful resume.
 	Dedupe bool
 }
 
 var resumeFlags = ResumeParams{
-	Lookback: (*extDuration)(duration.FromTimeDuration(7 * 24 * time.Hour)),
+	Lookback:          (*extDuration)(duration.FromTimeDuration(7 * 24 * time.Hour)),
+	SkipStaleThreads:  new(extDuration),
+	SkipStaleChannels: new(extDuration),
 }
 
 func init() {
@@ -90,6 +103,8 @@ func init() {
 	CmdResume.Flag.BoolVar(&resumeFlags.RecordOnlyNewUsers, "only-new-users", true, "record only new or updated users")
 	CmdResume.Flag.Var(resumeFlags.Lookback, "lookback", "lookback window `duration`")
 	CmdResume.Flag.BoolVar(&resumeFlags.SkipCompleteThreads, "skip-complete-threads", false, "skip threads where DB already has all replies (faster, but won't detect edits/deletes)")
+	CmdResume.Flag.Var(resumeFlags.SkipStaleThreads, "skip-stale-threads", "skip thread entities whose latest reply is older than this `duration` (default: disabled)")
+	CmdResume.Flag.Var(resumeFlags.SkipStaleChannels, "skip-stale-channels", "skip channel entities whose latest message is older than this `duration` (default: disabled; pair with a periodic full-sweep run)")
 	CmdResume.Flag.BoolVar(&resumeFlags.Dedupe, "dedupe", false, "run dedupe cleanup after successful resume finish")
 }
 
@@ -133,7 +148,9 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 		return fmt.Errorf("source type %q does not support resume, use 'slackdump convert -f database' to convert it", src.Type())
 	}
 
-	latest, err := latest(ctx, src, resumeFlags.IncludeThreads, resumeFlags.SkipCompleteThreads, time.Duration((*duration.Duration)(resumeFlags.Lookback).ToTimeDuration()), list)
+	threadCutoff := computeCutoff(resumeFlags.SkipStaleThreads)
+	channelCutoff := computeCutoff(resumeFlags.SkipStaleChannels)
+	latest, err := latest(ctx, src, resumeFlags.IncludeThreads, resumeFlags.SkipCompleteThreads, time.Duration((*duration.Duration)(resumeFlags.Lookback).ToTimeDuration()), threadCutoff, channelCutoff, list)
 	if err != nil {
 		base.SetExitStatus(base.SApplicationError)
 		return fmt.Errorf("error loading latest timestamps: %w", err)
@@ -243,7 +260,7 @@ func runDedupeAfterFinish(ctx context.Context, conn *sqlx.DB, dir string, enable
 	return err
 }
 
-func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCompleteThreads bool, lookBack time.Duration, other *structures.EntityList) (*structures.EntityList, error) {
+func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCompleteThreads bool, lookBack time.Duration, threadCutoff, channelCutoff *time.Time, other *structures.EntityList) (*structures.EntityList, error) {
 	if lookBack > 0 {
 		lookBack = -lookBack
 	}
@@ -262,6 +279,12 @@ func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCo
 	ei := make([]structures.EntityItem, 0, len(latest))
 	for sl, ts := range latest {
 		if sl.IsThread() && !includeThreads {
+			continue
+		}
+		if sl.IsThread() && threadCutoff != nil && ts.Before(*threadCutoff) {
+			continue
+		}
+		if !sl.IsThread() && channelCutoff != nil && ts.Before(*channelCutoff) {
 			continue
 		}
 		item := structures.EntityItem{
@@ -389,6 +412,22 @@ func channelsTeam(ctx context.Context, src source.Sourcer) (string, error) {
 		}
 	}
 	return "", source.ErrNotFound
+}
+
+// computeCutoff returns the absolute time before which entities are
+// considered stale.  Returns nil when d is nil or represents a zero/
+// negative duration, in which case callers should treat the filter as
+// disabled.
+func computeCutoff(d *extDuration) *time.Time {
+	if d == nil {
+		return nil
+	}
+	dur := time.Duration((*duration.Duration)(d).ToTimeDuration())
+	if dur <= 0 {
+		return nil
+	}
+	t := time.Now().Add(-dur)
+	return &t
 }
 
 type extDuration duration.Duration

--- a/cmd/slackdump/internal/resume/resume_test.go
+++ b/cmd/slackdump/internal/resume/resume_test.go
@@ -347,8 +347,13 @@ func Test_latest(t *testing.T) {
 		includeThreads      bool
 		skipCompleteThreads bool
 		lookBack            time.Duration
+		threadCutoff        *time.Time
+		channelCutoff       *time.Time
 		other               *structures.EntityList
 	}
+	staleCutoff := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	dormantTS := time.Date(2021, 6, 1, 0, 0, 0, 0, time.UTC)
+	freshTS := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name     string
 		args     args
@@ -480,6 +485,92 @@ func Test_latest(t *testing.T) {
 			),
 			wantErr: false,
 		},
+		{
+			name: "skip-stale-threads drops dormant thread, keeps fresh thread and channels",
+			args: args{
+				ctx:            t.Context(),
+				includeThreads: true,
+				lookBack:       0,
+				threadCutoff:   &staleCutoff,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C-fresh-ch"}:                          freshTS,
+					{Channel: "C-dormant-ch"}:                        dormantTS,
+					{Channel: "C-fresh-th", ThreadTS: "111.111"}:     freshTS,
+					{Channel: "C-dormant-th", ThreadTS: "222.222"}:   dormantTS,
+				}, nil)
+			},
+			want: structures.NewEntityListFromItems(
+				structures.EntityItem{Id: "C-fresh-ch", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
+				structures.EntityItem{Id: "C-dormant-ch", Oldest: dormantTS, Latest: time.Time(cfg.Latest), Include: true},
+				structures.EntityItem{Id: "C-fresh-th:111.111", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
+			),
+			wantErr: false,
+		},
+		{
+			name: "skip-stale-channels drops dormant channel, keeps fresh channel; threads excluded by default",
+			args: args{
+				ctx:            t.Context(),
+				includeThreads: false,
+				lookBack:       0,
+				channelCutoff:  &staleCutoff,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C-fresh-ch"}:                        freshTS,
+					{Channel: "C-dormant-ch"}:                      dormantTS,
+					{Channel: "C-fresh-th", ThreadTS: "111.111"}:   freshTS,
+				}, nil)
+			},
+			want: structures.NewEntityListFromItems(
+				structures.EntityItem{Id: "C-fresh-ch", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
+			),
+			wantErr: false,
+		},
+		{
+			name: "both cutoffs drop dormant entities of both types, keep fresh",
+			args: args{
+				ctx:            t.Context(),
+				includeThreads: true,
+				lookBack:       0,
+				threadCutoff:   &staleCutoff,
+				channelCutoff:  &staleCutoff,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C-fresh-ch"}:                          freshTS,
+					{Channel: "C-dormant-ch"}:                        dormantTS,
+					{Channel: "C-fresh-th", ThreadTS: "111.111"}:     freshTS,
+					{Channel: "C-dormant-th", ThreadTS: "222.222"}:   dormantTS,
+				}, nil)
+			},
+			want: structures.NewEntityListFromItems(
+				structures.EntityItem{Id: "C-fresh-ch", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
+				structures.EntityItem{Id: "C-fresh-th:111.111", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
+			),
+			wantErr: false,
+		},
+		{
+			name: "skip-stale-threads cutoff does not affect channel entities",
+			args: args{
+				ctx:            t.Context(),
+				includeThreads: false,
+				lookBack:       0,
+				threadCutoff:   &staleCutoff,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C-fresh-ch"}:   freshTS,
+					{Channel: "C-dormant-ch"}: dormantTS,
+				}, nil)
+			},
+			want: structures.NewEntityListFromItems(
+				structures.EntityItem{Id: "C-fresh-ch", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
+				structures.EntityItem{Id: "C-dormant-ch", Oldest: dormantTS, Latest: time.Time(cfg.Latest), Include: true},
+			),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -488,7 +579,7 @@ func Test_latest(t *testing.T) {
 			if tt.expectFn != nil {
 				tt.expectFn(mr)
 			}
-			got, err := latest(tt.args.ctx, mr, tt.args.includeThreads, tt.args.skipCompleteThreads, tt.args.lookBack, tt.args.other)
+			got, err := latest(tt.args.ctx, mr, tt.args.includeThreads, tt.args.skipCompleteThreads, tt.args.lookBack, tt.args.threadCutoff, tt.args.channelCutoff, tt.args.other)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("latest() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Summary

Two opt-in flags on `slackdump resume`:

- `-skip-stale-threads <duration>` — drop threads whose latest
  reply is older than the duration.
- `-skip-stale-channels <duration>` — drop channels whose latest
  message is older.

Filtering happens in `latest()` *before* any API call fires.
Durations use the existing `extDuration` parser. Both default to
disabled.

## Motivation

The dominant cost in a thread-heavy resume cycle is the first-page
`conversations.replies` fetch fired per thread-only `EntityItem`,
regardless of whether the thread has new replies. The existing
resume toolset (`-skip-complete-threads`, `-lookback`, `tools
dedupe`) covers adjacent completeness-for-speed tradeoffs but lacks
an entity-list-level filter.

## Measured impact

One long-running archive (51 channels, 691 thread parents),
back-to-back cycles with `-skip-stale-threads p21d
-skip-stale-channels p21d` vs. the unset baseline; otherwise-
identical flag set:

| Metric | Baseline | With both at `p21d` | Δ |
|---|---|---|---|
| **Wall clock** | **7:24** (444s) | **0:28** (28s) | **−93.7%, 15.9×** |
| 429 retries on `conversations.replies` | 23 | **0** | storm gone |
| `conversations.replies` first-page calls | 693 | 81 | −88.3% |
| `conversations.history` calls | 51 | 26 | −49% |
| Cumulative API calls / cycle | ~890 | ~140 | −84% |

The 429 storm goes away as a side-effect of the call-count drop.

## Design

Two cutoff checks in `latest()` after the existing `IncludeThreads`
guard, dropping dormant SlackLinks before `EntityItem` construction.
No changes to the stream layer, controllers, chunk types, schema, or
dedupe path. `Test_latest` extended with subtests for the four flag
combinations; `make vet && make test -race` green.

## Scope note

These flags support a periodic-incremental resume pattern (frequent
lean cycle + a less-frequent full sweep without the flags for
resurrection coverage) that isn't named in Slackdump's docs today.
My read is that the existing resume toolset already accommodates
this kind of tradeoff and these flags fill a missing piece; if
you'd rather not bring it in-tree, happy to maintain on the fork.

Branch: `chawlz7/slackdump:skip-stale-resume` at commit `67616c15`,
off `rusq/slackdump:master` at `0d7e1c69`.