### PR TITLE
fix for when filtering leads to no results

### DIFF
--- a/cmd/slackdump/internal/resume/assets/resume.md
+++ b/cmd/slackdump/internal/resume/assets/resume.md
@@ -78,6 +78,8 @@ will not be picked up until that channel is included again — pair with a
 periodic full sweep. Skipping stale **threads** is conservative: dormant
 thread parents are very unlikely to receive new replies, and a full sweep
 will still catch them.
+If stale filters skip every resume candidate, resume exits successfully as a
+no-op before setting up a Slack API session.
 
 __NOTE__: Resume is in beta and may not work as expected. Please report any
 issues on GitHub.

--- a/cmd/slackdump/internal/resume/resume.go
+++ b/cmd/slackdump/internal/resume/resume.go
@@ -150,14 +150,18 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 
 	threadCutoff := computeCutoff(resumeFlags.SkipStaleThreads)
 	channelCutoff := computeCutoff(resumeFlags.SkipStaleChannels)
-	latest, err := latest(ctx, src, resumeFlags.IncludeThreads, resumeFlags.SkipCompleteThreads, time.Duration((*duration.Duration)(resumeFlags.Lookback).ToTimeDuration()), threadCutoff, channelCutoff, list)
+	latestResult, err := latest(ctx, src, resumeFlags.IncludeThreads, resumeFlags.SkipCompleteThreads, time.Duration((*duration.Duration)(resumeFlags.Lookback).ToTimeDuration()), threadCutoff, channelCutoff, list)
 	if err != nil {
 		base.SetExitStatus(base.SApplicationError)
 		return fmt.Errorf("error loading latest timestamps: %w", err)
 	}
-	if latest.IsEmpty() {
+	switch decideResume(latestResult) {
+	case resumeDecisionInvalidArchive:
 		base.SetExitStatus(base.SInvalidParameters)
 		return fmt.Errorf("the archive does not contain any data: %s", dir)
+	case resumeDecisionNoop:
+		cfg.Log.InfoContext(ctx, "all resume entities were skipped by stale filters", "database", dir, "skipped", latestResult.skippedStale)
+		return nil
 	}
 
 	client, err := bootstrap.Slack(ctx)
@@ -223,7 +227,7 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 	}
 	defer ctrl.Close()
 
-	if err := runArchiveAndCleanup(ctx, ctrl, latest, wconn, dir, resumeFlags.Dedupe); err != nil {
+	if err := runArchiveAndCleanup(ctx, ctrl, latestResult.list, wconn, dir, resumeFlags.Dedupe); err != nil {
 		if errors.Is(err, errRunArchiveController) {
 			base.SetExitStatus(base.SApplicationError)
 		}
@@ -234,6 +238,27 @@ func runResume(ctx context.Context, cmd *base.Command, args []string) error {
 	}
 
 	return nil
+}
+
+type resumeDecision int
+
+const (
+	resumeDecisionContinue resumeDecision = iota
+	resumeDecisionInvalidArchive
+	resumeDecisionNoop
+)
+
+func decideResume(r latestResult) resumeDecision {
+	if r.list != nil && !r.list.IsEmpty() {
+		return resumeDecisionContinue
+	}
+	if !r.hasSourceData {
+		return resumeDecisionInvalidArchive
+	}
+	if r.skippedStale > 0 {
+		return resumeDecisionNoop
+	}
+	return resumeDecisionInvalidArchive
 }
 
 func runArchiveAndCleanup(ctx context.Context, runner archiveRunner, latest *structures.EntityList, conn *sqlx.DB, dir string, dedupeEnabled bool) error {
@@ -260,16 +285,26 @@ func runDedupeAfterFinish(ctx context.Context, conn *sqlx.DB, dir string, enable
 	return err
 }
 
-func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCompleteThreads bool, lookBack time.Duration, threadCutoff, channelCutoff *time.Time, other *structures.EntityList) (*structures.EntityList, error) {
+type latestResult struct {
+	list          *structures.EntityList
+	hasSourceData bool
+	skippedStale  int
+}
+
+func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCompleteThreads bool, lookBack time.Duration, threadCutoff, channelCutoff *time.Time, other *structures.EntityList) (latestResult, error) {
 	if lookBack > 0 {
 		lookBack = -lookBack
 	}
 	latest, err := src.Latest(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error loading latest timestamps: %w", err)
+		return latestResult{}, fmt.Errorf("error loading latest timestamps: %w", err)
+	}
+	result := latestResult{
+		list:          &structures.EntityList{},
+		hasSourceData: len(latest) > 0,
 	}
 	if len(latest) == 0 && (other == nil || other.IsEmpty()) {
-		return &structures.EntityList{}, nil
+		return result, nil
 	}
 
 	if cfg.Verbose {
@@ -282,9 +317,11 @@ func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCo
 			continue
 		}
 		if sl.IsThread() && threadCutoff != nil && ts.Before(*threadCutoff) {
+			result.skippedStale++
 			continue
 		}
 		if !sl.IsThread() && channelCutoff != nil && ts.Before(*channelCutoff) {
+			result.skippedStale++
 			continue
 		}
 		item := structures.EntityItem{
@@ -298,8 +335,9 @@ func latest(ctx context.Context, src source.Resumer, includeThreads bool, skipCo
 	}
 	el := structures.NewEntityListFromItems(ei...)
 	el.Overlay(other)
+	result.list = el
 
-	return el, nil
+	return result, nil
 }
 
 func debugprint(a ...any) {

--- a/cmd/slackdump/internal/resume/resume_test.go
+++ b/cmd/slackdump/internal/resume/resume_test.go
@@ -355,11 +355,13 @@ func Test_latest(t *testing.T) {
 	dormantTS := time.Date(2021, 6, 1, 0, 0, 0, 0, time.UTC)
 	freshTS := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name     string
-		args     args
-		expectFn func(mr *mock_source.MockResumer)
-		want     *structures.EntityList
-		wantErr  bool
+		name              string
+		args              args
+		expectFn          func(mr *mock_source.MockResumer)
+		want              *structures.EntityList
+		wantHasSourceData bool
+		wantSkippedStale  int
+		wantErr           bool
 	}{
 		{
 			name: "resumer error",
@@ -376,7 +378,7 @@ func Test_latest(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "no entities",
+			name: "empty archive has no source data and is not stale-filtered",
 			args: args{
 				ctx:                 t.Context(),
 				includeThreads:      false,
@@ -386,8 +388,10 @@ func Test_latest(t *testing.T) {
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{}, nil)
 			},
-			want:    &structures.EntityList{},
-			wantErr: false,
+			want:              &structures.EntityList{},
+			wantHasSourceData: false,
+			wantSkippedStale:  0,
+			wantErr:           false,
 		},
 		{
 			name: "returns latest status",
@@ -405,7 +409,8 @@ func Test_latest(t *testing.T) {
 			want: structures.NewEntityListFromItems(
 				structures.EntityItem{Id: "C123", Oldest: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantErr:           false,
 		},
 		{
 			name: "returns latest status with thread",
@@ -425,7 +430,8 @@ func Test_latest(t *testing.T) {
 				structures.EntityItem{Id: "C123", Oldest: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
 				structures.EntityItem{Id: "C456:123.456", Oldest: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantErr:           false,
 		},
 		{
 			name: "returns latest status with thread, but includeThreads is false",
@@ -444,7 +450,8 @@ func Test_latest(t *testing.T) {
 			want: structures.NewEntityListFromItems(
 				structures.EntityItem{Id: "C123", Oldest: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantErr:           false,
 		},
 		{
 			name: "returns latest status with thread, includeThreads false and skipCompleteThreads true",
@@ -463,7 +470,8 @@ func Test_latest(t *testing.T) {
 			want: structures.NewEntityListFromItems(
 				structures.EntityItem{Id: "C123", Oldest: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantErr:           false,
 		},
 		{
 			name: "returns latest status with thread and skipCompleteThreads true",
@@ -483,7 +491,8 @@ func Test_latest(t *testing.T) {
 				structures.EntityItem{Id: "C123", Oldest: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
 				structures.EntityItem{Id: "C456:123.456", Oldest: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC), Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantErr:           false,
 		},
 		{
 			name: "skip-stale-threads drops dormant thread, keeps fresh thread and channels",
@@ -495,10 +504,10 @@ func Test_latest(t *testing.T) {
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
-					{Channel: "C-fresh-ch"}:                          freshTS,
-					{Channel: "C-dormant-ch"}:                        dormantTS,
-					{Channel: "C-fresh-th", ThreadTS: "111.111"}:     freshTS,
-					{Channel: "C-dormant-th", ThreadTS: "222.222"}:   dormantTS,
+					{Channel: "C-fresh-ch"}:                        freshTS,
+					{Channel: "C-dormant-ch"}:                      dormantTS,
+					{Channel: "C-fresh-th", ThreadTS: "111.111"}:   freshTS,
+					{Channel: "C-dormant-th", ThreadTS: "222.222"}: dormantTS,
 				}, nil)
 			},
 			want: structures.NewEntityListFromItems(
@@ -506,7 +515,9 @@ func Test_latest(t *testing.T) {
 				structures.EntityItem{Id: "C-dormant-ch", Oldest: dormantTS, Latest: time.Time(cfg.Latest), Include: true},
 				structures.EntityItem{Id: "C-fresh-th:111.111", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantSkippedStale:  1,
+			wantErr:           false,
 		},
 		{
 			name: "skip-stale-channels drops dormant channel, keeps fresh channel; threads excluded by default",
@@ -518,15 +529,17 @@ func Test_latest(t *testing.T) {
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
-					{Channel: "C-fresh-ch"}:                        freshTS,
-					{Channel: "C-dormant-ch"}:                      dormantTS,
-					{Channel: "C-fresh-th", ThreadTS: "111.111"}:   freshTS,
+					{Channel: "C-fresh-ch"}:                      freshTS,
+					{Channel: "C-dormant-ch"}:                    dormantTS,
+					{Channel: "C-fresh-th", ThreadTS: "111.111"}: freshTS,
 				}, nil)
 			},
 			want: structures.NewEntityListFromItems(
 				structures.EntityItem{Id: "C-fresh-ch", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantSkippedStale:  1,
+			wantErr:           false,
 		},
 		{
 			name: "both cutoffs drop dormant entities of both types, keep fresh",
@@ -539,17 +552,19 @@ func Test_latest(t *testing.T) {
 			},
 			expectFn: func(mr *mock_source.MockResumer) {
 				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
-					{Channel: "C-fresh-ch"}:                          freshTS,
-					{Channel: "C-dormant-ch"}:                        dormantTS,
-					{Channel: "C-fresh-th", ThreadTS: "111.111"}:     freshTS,
-					{Channel: "C-dormant-th", ThreadTS: "222.222"}:   dormantTS,
+					{Channel: "C-fresh-ch"}:                        freshTS,
+					{Channel: "C-dormant-ch"}:                      dormantTS,
+					{Channel: "C-fresh-th", ThreadTS: "111.111"}:   freshTS,
+					{Channel: "C-dormant-th", ThreadTS: "222.222"}: dormantTS,
 				}, nil)
 			},
 			want: structures.NewEntityListFromItems(
 				structures.EntityItem{Id: "C-fresh-ch", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
 				structures.EntityItem{Id: "C-fresh-th:111.111", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantSkippedStale:  2,
+			wantErr:           false,
 		},
 		{
 			name: "skip-stale-threads cutoff does not affect channel entities",
@@ -569,7 +584,87 @@ func Test_latest(t *testing.T) {
 				structures.EntityItem{Id: "C-fresh-ch", Oldest: freshTS, Latest: time.Time(cfg.Latest), Include: true},
 				structures.EntityItem{Id: "C-dormant-ch", Oldest: dormantTS, Latest: time.Time(cfg.Latest), Include: true},
 			),
-			wantErr: false,
+			wantHasSourceData: true,
+			wantErr:           false,
+		},
+		{
+			name: "skip-stale-channels filters every channel and is stale-filtered",
+			args: args{
+				ctx:            t.Context(),
+				includeThreads: false,
+				lookBack:       0,
+				channelCutoff:  &staleCutoff,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C-dormant-ch"}:  dormantTS,
+					{Channel: "C-dormant-ch2"}: dormantTS,
+				}, nil)
+			},
+			want:              structures.NewEntityListFromItems(),
+			wantHasSourceData: true,
+			wantSkippedStale:  2,
+			wantErr:           false,
+		},
+		{
+			name: "skip-stale-threads with threads filters every thread and is stale-filtered",
+			args: args{
+				ctx:            t.Context(),
+				includeThreads: true,
+				lookBack:       0,
+				threadCutoff:   &staleCutoff,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C-dormant-th", ThreadTS: "111.111"}:  dormantTS,
+					{Channel: "C-dormant-th2", ThreadTS: "222.222"}: dormantTS,
+				}, nil)
+			},
+			want:              structures.NewEntityListFromItems(),
+			wantHasSourceData: true,
+			wantSkippedStale:  2,
+			wantErr:           false,
+		},
+		{
+			name: "threads excluded only because threads flag is false are not stale-filtered",
+			args: args{
+				ctx:            t.Context(),
+				includeThreads: false,
+				lookBack:       0,
+				threadCutoff:   &staleCutoff,
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C-dormant-th", ThreadTS: "111.111"}: dormantTS,
+				}, nil)
+			},
+			want:              structures.NewEntityListFromItems(),
+			wantHasSourceData: true,
+			wantSkippedStale:  0,
+			wantErr:           false,
+		},
+		{
+			name: "explicit entity overlay after stale filtering prevents empty no-op",
+			args: args{
+				ctx:            t.Context(),
+				includeThreads: false,
+				lookBack:       0,
+				channelCutoff:  &staleCutoff,
+				other: structures.NewEntityListFromItems(
+					structures.EntityItem{Id: "C-explicit", Include: true},
+				),
+			},
+			expectFn: func(mr *mock_source.MockResumer) {
+				mr.EXPECT().Latest(gomock.Any()).Return(map[structures.SlackLink]time.Time{
+					{Channel: "C-dormant-ch"}: dormantTS,
+				}, nil)
+			},
+			want: structures.NewEntityListFromItems(
+				structures.EntityItem{Id: "C-explicit", Include: true},
+			),
+			wantHasSourceData: true,
+			wantSkippedStale:  1,
+			wantErr:           false,
 		},
 	}
 	for _, tt := range tests {
@@ -584,7 +679,58 @@ func Test_latest(t *testing.T) {
 				t.Errorf("latest() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, got.list)
+			assert.Equal(t, tt.wantHasSourceData, got.hasSourceData)
+			assert.Equal(t, tt.wantSkippedStale, got.skippedStale)
+		})
+	}
+}
+
+func Test_decideResume(t *testing.T) {
+	tests := []struct {
+		name string
+		in   latestResult
+		want resumeDecision
+	}{
+		{
+			name: "empty source is invalid archive",
+			in: latestResult{
+				list: &structures.EntityList{},
+			},
+			want: resumeDecisionInvalidArchive,
+		},
+		{
+			name: "fully stale-filtered source is no-op",
+			in: latestResult{
+				list:          &structures.EntityList{},
+				hasSourceData: true,
+				skippedStale:  1,
+			},
+			want: resumeDecisionNoop,
+		},
+		{
+			name: "non-empty selected entities continue",
+			in: latestResult{
+				list: structures.NewEntityListFromItems(
+					structures.EntityItem{Id: "C123", Include: true},
+				),
+				hasSourceData: true,
+				skippedStale:  1,
+			},
+			want: resumeDecisionContinue,
+		},
+		{
+			name: "source data excluded for non-stale reason is invalid archive",
+			in: latestResult{
+				list:          &structures.EntityList{},
+				hasSourceData: true,
+			},
+			want: resumeDecisionInvalidArchive,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, decideResume(tt.in))
 		})
 	}
 }


### PR DESCRIPTION
Followup for #695 

Fix `slackdump resume` when stale filters remove every resume candidate.

Previously, a valid database archive could be reported as empty if `-skip-stale-threads` or `-skip-stale-channels` filtered out all generated resume
entities. The command now treats that case as a successful no-op and returns before Slack API setup.

## Changes

- Changed `latest(...)` to return a small result struct with:
  - the generated entity list
  - whether the source had latest timestamp data
  - how many entities were skipped by stale cutoffs
- Added resume exit decision logic to distinguish:
  - truly empty archives
  - fully stale-filtered archives
  - non-empty resume selections
- Preserved explicit CLI entity overlays so user-provided entities still force work.
- Added an info log for fully stale-filtered no-op runs.
- Documented the no-op behavior in resume help.
- Expanded resume tests for stale-filtered empty results and decision behavior.

## Tests

- `go test ./cmd/slackdump/internal/resume`

