### PR TITLE
Do not return error when processing "tombstone", "hidden_by_limit" and "external" files

### DIFF
--- a/cmd/slackdump/internal/diag/merge_test.go
+++ b/cmd/slackdump/internal/diag/merge_test.go
@@ -339,6 +339,31 @@ func TestMergeSource(t *testing.T) {
 		assertFileContents(t, filepath.Join(targetDir, testReplyFilePath()), "thread attachment")
 	})
 
+	t.Run("skipped file modes do not fail merge", func(t *testing.T) {
+		ctx := context.Background()
+		targetDir := newArchiveDir(t)
+		target, err := resolveMergeTarget(targetDir)
+		require.NoError(t, err)
+
+		conn, err := ensureDb(ctx, targetDir)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+
+		sourceDir := newArchiveDir(t)
+		writeMergeArchive(t, sourceDir, mergeSkippedFileChunks(), nil)
+
+		src, err := source.Load(ctx, sourceDir)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, src.Close())
+		})
+
+		err = mergeSource(ctx, target, conn, src, true, false)
+		require.NoError(t, err)
+	})
+
 	t.Run("does not copy files when files disabled", func(t *testing.T) {
 		ctx := context.Background()
 		targetDir := newArchiveDir(t)
@@ -393,6 +418,33 @@ func TestMergeSource(t *testing.T) {
 		require.NoError(t, err)
 
 		assertFileContents(t, filepath.Join(targetDir, testAvatarPath()), "avatar bytes")
+	})
+
+	t.Run("real file copy failures stay warning only during merge", func(t *testing.T) {
+		ctx := context.Background()
+		targetDir := newArchiveDir(t)
+		target, err := resolveMergeTarget(targetDir)
+		require.NoError(t, err)
+
+		conn, err := ensureDb(ctx, targetDir)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+
+		sourceDir := newArchiveDir(t)
+		writeMergeArchive(t, sourceDir, mergeSourceChunks(), nil)
+
+		src, err := source.Load(ctx, sourceDir)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, src.Close())
+		})
+
+		err = mergeSource(ctx, target, conn, src, true, false)
+		require.NoError(t, err)
+		_, err = os.Stat(filepath.Join(targetDir, testTopFilePath()))
+		require.ErrorIs(t, err, os.ErrNotExist)
 	})
 }
 
@@ -566,6 +618,26 @@ func mergeAvatarChunks() []*chunk.Chunk {
 		testWorkspaceChunk(testTeamID),
 		testUsersChunk(testAvatarUser()),
 		testChannelsChunk(testChannel(testChannelID, "general", testTeamID)),
+	}
+}
+
+func mergeSkippedFileChunks() []*chunk.Chunk {
+	root := testRootMessage()
+	skipped := slack.Message{
+		Msg: slack.Msg{
+			Timestamp: "1710000002.000001",
+			Text:      "skipped file",
+			Files: []slack.File{{
+				ID:   "F-skip",
+				Name: "gone.txt",
+				Mode: "tombstone",
+			}},
+		},
+	}
+	return []*chunk.Chunk{
+		testWorkspaceChunk(testTeamID),
+		testChannelsChunk(testChannel(testChannelID, "general", testTeamID)),
+		testMessagesChunk(testChannelID, root, skipped),
 	}
 }
 

--- a/internal/convert/export.go
+++ b/internal/convert/export.go
@@ -142,7 +142,10 @@ func (c *ToExport) Convert(ctx context.Context) error {
 	errC := make(chan error, c.workers)
 	{
 		// 2. workers
-		var filewg sync.WaitGroup
+		var (
+			filewg   sync.WaitGroup
+			resultwg sync.WaitGroup
+		)
 
 		if c.opts.includeFiles && c.src.Files().Type() != source.STnone {
 			tfopts = append(tfopts, transform.ExpWithMsgUpdateFunc(func(ch *slack.Channel, m *slack.Message) error {
@@ -200,31 +203,36 @@ func (c *ToExport) Convert(ctx context.Context) error {
 				errC <- err
 			}
 		}()
-		// 2.3. workers sentinels
+		// 2.3. file result processor
+		fileresults := merge(c.fileresult, c.avtrresult)
+		resultwg.Add(1)
+		go func() {
+			defer resultwg.Done()
+			for res := range fileresults {
+				if res.err != nil {
+					if res.fr.message != nil {
+						lg.Error("file converter: error processing message", "ts", res.fr.message.Timestamp, "err", res.err)
+					} else {
+						lg.Error("file converter", "err", res.err)
+					}
+					errC <- res.err
+				}
+			}
+		}()
+
+		// 2.4. workers sentinel
 		go func() {
 			msgwg.Wait()
 			lg.Debug("messages wait group done, closing file requests")
 			close(c.filerequest)
 			filewg.Wait()
+			resultwg.Wait()
 			lg.Debug("file workers done, finalising")
 			close(errC)
 		}()
 	}
-	// 3. result processor
-	fileresults := merge(c.fileresult, c.avtrresult)
-	go func() {
-		for res := range fileresults {
-			if res.err != nil {
-				if res.fr.message != nil {
-					lg.Error("file converter: error processing message", "ts", res.fr.message.Timestamp, "err", res.err)
-				} else {
-					lg.Error("file converter", "err", res.err)
-				}
-				errC <- res.err
-			}
-		}
-	}()
 
+	// 3. result processor
 	var failed bool
 LOOP:
 	for {

--- a/internal/convert/export_test.go
+++ b/internal/convert/export_test.go
@@ -16,17 +16,22 @@
 package convert
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
+	"time"
 
 	"github.com/rusq/fsadapter"
 	"github.com/rusq/slack"
+	"go.uber.org/mock/gomock"
 
 	"github.com/rusq/slackdump/v4/internal/chunk"
 	"github.com/rusq/slackdump/v4/internal/fixtures"
 	"github.com/rusq/slackdump/v4/source"
+	"github.com/rusq/slackdump/v4/source/mock_source"
 )
 
 const (
@@ -112,30 +117,113 @@ func TestChunkToExport_Validate(t *testing.T) {
 }
 
 func TestChunkToExport_Convert(t *testing.T) {
-	fixtures.SkipInCI(t)
-	fixtures.SkipIfNotExist(t, testSrcDir)
-	cd, err := chunk.OpenDir(testSrcDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cd.Close()
-	testTrgDir, err := os.MkdirTemp("", "slackdump")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Log(testTrgDir)
-	// var testTrgDir = t.TempDir()
-	fsa, err := fsadapter.NewZipFile(filepath.Join(testTrgDir, "slackdump.zip"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer fsa.Close()
-	src := source.OpenChunkDir(cd, true)
-	c := NewToExport(src, fsa, WithIncludeFiles(true))
+	setupMockSource := func(t *testing.T, msg slack.Message, st *mock_source.MockStorage) *mock_source.MockSourcer {
+		t.Helper()
 
-	ctx := t.Context()
-	c.opts.lg = testLogger
-	if err := c.Convert(ctx); err != nil {
-		t.Fatal(err)
+		ctrl := gomock.NewController(t)
+		src := mock_source.NewMockSourcer(ctrl)
+		channel := &slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{ID: "C123"},
+				Name:         "general",
+			},
+		}
+
+		src.EXPECT().Users(gomock.Any()).Return([]slack.User{{ID: "U1", Name: "tester"}}, nil).AnyTimes()
+		src.EXPECT().Channels(gomock.Any()).Return([]slack.Channel{*channel}, nil).AnyTimes()
+		src.EXPECT().WorkspaceInfo(gomock.Any()).Return(&slack.AuthTestResponse{
+			UserID: "U1",
+			TeamID: "T1",
+			URL:    "https://example.slack.com/",
+		}, nil).AnyTimes()
+		src.EXPECT().Files().Return(st).AnyTimes()
+		src.EXPECT().Name().Return("mock-source").AnyTimes()
+		src.EXPECT().ChannelInfo(gomock.Any(), "C123").Return(channel, nil)
+		src.EXPECT().Sorted(gomock.Any(), "C123", false, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ string, _ bool, cb func(time.Time, *slack.Message) error) error {
+				return cb(time.Unix(1710000000, 0), &msg)
+			},
+		)
+
+		return src
 	}
+
+	t.Run("skipped file modes do not fail conversion", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		st := mock_source.NewMockStorage(ctrl)
+		st.EXPECT().Type().Return(source.STmattermost).AnyTimes()
+		st.EXPECT().FS().Return(fstest.MapFS{}).Times(1)
+
+		msg := slack.Message{Msg: slack.Msg{
+			Timestamp: "1710000000.000001",
+			Text:      "message",
+			Files: []slack.File{{
+				ID:   "F1",
+				Name: "gone.txt",
+				Mode: "tombstone",
+			}},
+		}}
+		src := setupMockSource(t, msg, st)
+
+		c := NewToExport(src, fsadapter.NewDirectory(t.TempDir()), WithIncludeFiles(true))
+		c.workers = 1
+		c.opts.lg = testLogger
+		if err := c.Convert(t.Context()); err != nil {
+			t.Fatalf("Convert() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("real copy failures still fail conversion", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		st := mock_source.NewMockStorage(ctrl)
+		st.EXPECT().Type().Return(source.STmattermost).AnyTimes()
+		st.EXPECT().FS().Return(fstest.MapFS{}).Times(1)
+		st.EXPECT().File("F1", "missing.txt").Return("", os.ErrNotExist).Times(1)
+
+		msg := slack.Message{Msg: slack.Msg{
+			Timestamp: "1710000000.000001",
+			Text:      "message",
+			Files: []slack.File{{
+				ID:   "F1",
+				Name: "missing.txt",
+			}},
+		}}
+		src := setupMockSource(t, msg, st)
+
+		c := NewToExport(src, fsadapter.NewDirectory(t.TempDir()), WithIncludeFiles(true))
+		c.workers = 1
+		c.opts.lg = testLogger
+		err := c.Convert(t.Context())
+		if err == nil || err.Error() != "convert: there were errors" {
+			t.Fatalf("Convert() error = %v, want convert: there were errors", err)
+		}
+	})
+
+	t.Run("integration", func(t *testing.T) {
+		fixtures.SkipInCI(t)
+		fixtures.SkipIfNotExist(t, testSrcDir)
+		cd, err := chunk.OpenDir(testSrcDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cd.Close()
+		testTrgDir, err := os.MkdirTemp("", "slackdump")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(testTrgDir)
+		fsa, err := fsadapter.NewZipFile(filepath.Join(testTrgDir, "slackdump.zip"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsa.Close()
+		src := source.OpenChunkDir(cd, true)
+		c := NewToExport(src, fsa, WithIncludeFiles(true))
+
+		ctx := t.Context()
+		c.opts.lg = testLogger
+		if err := c.Convert(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/internal/convert/filecopy.go
+++ b/internal/convert/filecopy.go
@@ -67,9 +67,12 @@ func (c *FileCopier) Copy(ch *slack.Channel, msg *slack.Message) error {
 		lg   = slog.With("channel", ch.ID, "ts", msg.Timestamp)
 	)
 	for _, f := range msg.Files {
-		if err := fileproc.IsValidWithReason(&f); err != nil {
-			lg.Info("skipping file", "file", f.ID, "error", err)
+		if reason, ok := fileproc.SkipReason(&f); ok {
+			lg.Info("skipping file", "file", f.ID, "reason", reason)
 			continue
+		}
+		if err := fileproc.IsValidWithReason(&f); err != nil {
+			return &copyerror{f.ID, err}
 		}
 
 		srcpath, err := c.src.Files().File(f.ID, f.Name)

--- a/internal/convert/filecopy_test.go
+++ b/internal/convert/filecopy_test.go
@@ -16,8 +16,11 @@
 package convert
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -29,6 +32,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/rusq/slackdump/v4/internal/chunk"
+	"github.com/rusq/slackdump/v4/source"
 )
 
 func Test_copy2trg(t *testing.T) {
@@ -121,4 +125,102 @@ func Test_avatarcopywrapper_copyAvatar(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFileCopier_Copy(t *testing.T) {
+	channel := &slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "C123"},
+		},
+	}
+
+	t.Run("returns nil for skipped files", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		src := mock_source.NewMockSourcer(ctrl)
+		st := mock_source.NewMockStorage(ctrl)
+
+		src.EXPECT().Files().Return(st).Times(1)
+		st.EXPECT().FS().Return(fstest.MapFS{}).Times(1)
+
+		c := NewFileCopier(src, fsadapter.NewDirectory(t.TempDir()), source.MattermostFilepath, true)
+		msg := &slack.Message{Msg: slack.Msg{
+			Timestamp: "123.456",
+			Files: []slack.File{
+				{ID: "F1", Mode: "tombstone", Name: "gone.txt"},
+				{ID: "F2", Mode: "hidden_by_limit", Name: "hidden.txt"},
+				{ID: "F3", Mode: "external", Name: "external.txt", IsExternal: true},
+			},
+		}}
+
+		if err := c.Copy(channel, msg); err != nil {
+			t.Fatalf("Copy() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("returns error when source path cannot be resolved", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		src := mock_source.NewMockSourcer(ctrl)
+		st := mock_source.NewMockStorage(ctrl)
+
+		src.EXPECT().Files().Return(st).Times(2)
+		st.EXPECT().FS().Return(fstest.MapFS{}).Times(1)
+		st.EXPECT().File("F1", "missing.txt").Return("", fs.ErrNotExist).Times(1)
+
+		c := NewFileCopier(src, fsadapter.NewDirectory(t.TempDir()), source.MattermostFilepath, true)
+		msg := &slack.Message{Msg: slack.Msg{
+			Timestamp: "123.456",
+			Files:     []slack.File{{ID: "F1", Name: "missing.txt"}},
+		}}
+
+		err := c.Copy(channel, msg)
+		if err == nil || !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("Copy() error = %v, want fs.ErrNotExist", err)
+		}
+	})
+
+	t.Run("returns error when resolved source file cannot be statted", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		src := mock_source.NewMockSourcer(ctrl)
+		st := mock_source.NewMockStorage(ctrl)
+
+		src.EXPECT().Files().Return(st).Times(2)
+		st.EXPECT().FS().Return(fstest.MapFS{}).Times(1)
+		st.EXPECT().File("F1", "missing.txt").Return("uploads/F1/missing.txt", nil).Times(1)
+
+		c := NewFileCopier(src, fsadapter.NewDirectory(t.TempDir()), source.MattermostFilepath, true)
+		msg := &slack.Message{Msg: slack.Msg{
+			Timestamp: "123.456",
+			Files:     []slack.File{{ID: "F1", Name: "missing.txt"}},
+		}}
+
+		err := c.Copy(channel, msg)
+		if err == nil || !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("Copy() error = %v, want fs.ErrNotExist", err)
+		}
+	})
+
+	t.Run("returns error when target create fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		src := mock_source.NewMockSourcer(ctrl)
+		st := mock_source.NewMockStorage(ctrl)
+		trg := mock_fsadapter.NewMockFSCloser(ctrl)
+
+		src.EXPECT().Files().Return(st).Times(2)
+		st.EXPECT().FS().Return(fstest.MapFS{
+			"uploads/F1/ok.txt": {Data: []byte("content")},
+		}).Times(1)
+		st.EXPECT().File("F1", "ok.txt").Return("uploads/F1/ok.txt", nil).Times(1)
+		trg.EXPECT().Create(source.MattermostFilepath(channel, &slack.File{ID: "F1", Name: "ok.txt"})).Return(nil, errors.New("create failed")).Times(1)
+
+		c := NewFileCopier(src, trg, source.MattermostFilepath, true)
+		msg := &slack.Message{Msg: slack.Msg{
+			Timestamp: "123.456",
+			Files:     []slack.File{{ID: "F1", Name: "ok.txt"}},
+		}}
+
+		err := c.Copy(channel, msg)
+		if err == nil || !strings.Contains(err.Error(), "create failed") {
+			t.Fatalf("Copy() error = %v, want create failed", err)
+		}
+	})
 }

--- a/internal/convert/src2enc_test.go
+++ b/internal/convert/src2enc_test.go
@@ -20,8 +20,10 @@ import (
 	"iter"
 	"slices"
 	"testing"
+	"testing/fstest"
 	"time"
 
+	"github.com/rusq/fsadapter"
 	"github.com/rusq/slackdump/v4/source/mock_source"
 
 	"github.com/rusq/slack"
@@ -30,6 +32,8 @@ import (
 	"github.com/rusq/slackdump/v4/internal/fasttime"
 	"github.com/rusq/slackdump/v4/internal/structures"
 	"github.com/rusq/slackdump/v4/mocks/mock_processor"
+	"github.com/rusq/slackdump/v4/processor"
+	"github.com/rusq/slackdump/v4/source"
 )
 
 func Test_encodeMessages(t *testing.T) {
@@ -76,6 +80,41 @@ func Test_encodeMessages(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("skipped file modes do not fail source encoding file copy", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := mock_processor.NewMockConversations(ctrl)
+		ms := mock_source.NewMockSourcer(ctrl)
+		st := mock_source.NewMockStorage(ctrl)
+
+		msg := slack.Message{
+			Msg: slack.Msg{
+				Timestamp: "123.456",
+				Text:      "msg",
+				Files: []slack.File{{
+					ID:   "F1",
+					Name: "gone.txt",
+					Mode: "tombstone",
+				}},
+			},
+		}
+		it := func(yield func(slack.Message, error) bool) {
+			yield(msg, nil)
+		}
+
+		ms.EXPECT().AllMessages(gomock.Any(), "C123").Return(it, nil)
+		ms.EXPECT().Files().Return(st).Times(1)
+		st.EXPECT().FS().Return(fstest.MapFS{}).Times(1)
+		mc.EXPECT().Files(gomock.Any(), gomock.Any(), msg, msg.Files).Return(nil)
+		mc.EXPECT().Messages(gomock.Any(), "C123", 0, true, []slack.Message{msg}).Return(nil)
+
+		rec := processor.PrependFiler(mc, &filecopywrapper{
+			fc: NewFileCopier(ms, fsadapter.NewDirectory(t.TempDir()), source.MattermostFilepath, true),
+		})
+		if err := encodeMessages(t.Context(), rec, ms, structures.ChannelFromID("C123")); err != nil {
+			t.Fatalf("encodeMessages() error = %v, want nil", err)
+		}
+	})
 }
 
 func msgGenerator(t *testing.T, startTS int64, num int, chunkSz int) (iter.Seq2[slack.Message, error], [][]slack.Message) {

--- a/internal/convert/transform/fileproc/fileproc.go
+++ b/internal/convert/transform/fileproc/fileproc.go
@@ -108,6 +108,8 @@ func ExportTokenUpdateFn(token string) func(_ *slack.Channel, msg *slack.Message
 	}
 }
 
+// skippedModes lists all file modes that are always skipped and not treated as
+// an error.
 var skippedModes = map[string]struct{}{
 	"hidden_by_limit": {},
 	"external":        {},

--- a/internal/convert/transform/fileproc/fileproc.go
+++ b/internal/convert/transform/fileproc/fileproc.go
@@ -108,7 +108,7 @@ func ExportTokenUpdateFn(token string) func(_ *slack.Channel, msg *slack.Message
 	}
 }
 
-var invalidModes = map[string]struct{}{
+var skippedModes = map[string]struct{}{
 	"hidden_by_limit": {},
 	"external":        {},
 	"tombstone":       {},
@@ -116,15 +116,33 @@ var invalidModes = map[string]struct{}{
 
 // IsValid returns true if the file can be downloaded and is valid.
 func IsValid(f *slack.File) bool {
-	return IsValidWithReason(f) == nil
+	return !ShouldSkip(f) && IsValidWithReason(f) == nil
+}
+
+// ShouldSkip returns true for file modes that are expected in message payloads
+// but do not represent downloadable files.
+func ShouldSkip(f *slack.File) bool {
+	_, ok := SkipReason(f)
+	return ok
+}
+
+// SkipReason returns the reason why the file should be skipped.
+func SkipReason(f *slack.File) (string, bool) {
+	if f == nil {
+		return "", false
+	}
+	if _, ok := skippedModes[f.Mode]; ok {
+		return f.Mode, true
+	}
+	return "", false
 }
 
 func IsValidWithReason(f *slack.File) error {
 	if f == nil {
 		return errors.New("file is nil")
 	}
-	if _, ok := invalidModes[f.Mode]; ok {
-		return fmt.Errorf("invalid file mode %q", f.Mode)
+	if ShouldSkip(f) {
+		return nil
 	}
 	if !f.IsExternal && f.Name == "" {
 		return fmt.Errorf("invalid file: external=%v, name=%q", f.IsExternal, f.Name)

--- a/internal/convert/transform/fileproc/fileproc_test.go
+++ b/internal/convert/transform/fileproc/fileproc_test.go
@@ -89,3 +89,101 @@ func TestIsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestSkipReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		file       *slack.File
+		wantReason string
+		wantSkip   bool
+	}{
+		{
+			name:       "tombstone",
+			file:       &slack.File{Mode: "tombstone", Name: "foo"},
+			wantReason: "tombstone",
+			wantSkip:   true,
+		},
+		{
+			name:       "hidden by limit",
+			file:       &slack.File{Mode: "hidden_by_limit", Name: "foo"},
+			wantReason: "hidden_by_limit",
+			wantSkip:   true,
+		},
+		{
+			name:       "external",
+			file:       &slack.File{Mode: "external", Name: "foo", IsExternal: true},
+			wantReason: "external",
+			wantSkip:   true,
+		},
+		{
+			name:     "downloadable file",
+			file:     fixtures.LoadPtr[slack.File](fixtures.FileJPEG),
+			wantSkip: false,
+		},
+		{
+			name:     "nil file",
+			file:     nil,
+			wantSkip: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReason, gotSkip := SkipReason(tt.file)
+			if gotReason != tt.wantReason || gotSkip != tt.wantSkip {
+				t.Fatalf("SkipReason() = (%q, %v), want (%q, %v)", gotReason, gotSkip, tt.wantReason, tt.wantSkip)
+			}
+			if got := ShouldSkip(tt.file); got != tt.wantSkip {
+				t.Fatalf("ShouldSkip() = %v, want %v", got, tt.wantSkip)
+			}
+		})
+	}
+}
+
+func TestIsValidWithReason(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    *slack.File
+		wantErr bool
+	}{
+		{
+			name:    "tombstone is skipped not invalid",
+			file:    &slack.File{Mode: "tombstone", Name: "foo"},
+			wantErr: false,
+		},
+		{
+			name:    "hidden by limit is skipped not invalid",
+			file:    &slack.File{Mode: "hidden_by_limit", Name: "foo"},
+			wantErr: false,
+		},
+		{
+			name:    "external is skipped not invalid",
+			file:    &slack.File{Mode: "external", Name: "foo", IsExternal: true},
+			wantErr: false,
+		},
+		{
+			name:    "nil file is invalid",
+			file:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "downloadable file with empty name is invalid",
+			file:    &slack.File{ID: "F123", Name: "", IsExternal: false},
+			wantErr: true,
+		},
+		{
+			name:    "valid downloadable file",
+			file:    fixtures.LoadPtr[slack.File](fixtures.FileJPEG),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := IsValidWithReason(tt.file)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("IsValidWithReason() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- **treat tombstone, external and hidden-by-limit files as non-error**
- **doc comments**

Fixes #702 