### PR TITLE
[codex] harden concurrency coordination

### DIFF
--- a/cmd/slackdump/internal/emoji/emojidl/emoedge.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoedge.go
@@ -57,6 +57,9 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 	if opt == nil {
 		opt = &Options{}
 	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	lg := cfg.Log
 	lg.DebugContext(ctx, "startup params", "dir", emojiDir, "numWorkers", numWorkers, "failFast", opt.FailFast)
 	if cb == nil {
@@ -65,8 +68,8 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 
 	var (
 		emojiC  = make(chan edge.Emoji)
-		totalC  = make(chan int)
-		genErrC = make(chan error)
+		totalC  = make(chan int, 1)
+		genErrC = make(chan error, 1)
 		resultC = make(chan result)
 	)
 
@@ -81,14 +84,23 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 		var once sync.Once
 		defer close(totalC)
 		defer close(emojiC)
+		defer close(genErrC)
 
 		for chunk, err := range sess.AdminEmojiList(ctx) {
 			if err != nil {
-				genErrC <- err
+				select {
+				case genErrC <- err:
+				default:
+				}
 				return
 			}
 			lg.DebugContext(ctx, "got emojis", "count", len(chunk.Emoji), "disabled", len(chunk.DisabledEmoji), "total", chunk.Total)
-			once.Do(func() { totalC <- chunk.Total }) // send total count once.
+			once.Do(func() {
+				select {
+				case totalC <- chunk.Total:
+				case <-ctx.Done():
+				}
+			}) // send total count once.
 			for _, emoji := range chunk.Emoji {
 				select {
 				case <-ctx.Done():
@@ -113,25 +125,37 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 		wg.Wait()
 		close(resultC)
 	}()
+	defer func(resultC <-chan result) {
+		cancel()
+		for range resultC {
+		}
+	}(resultC)
 
 	// 4. Result processor, receives download results and logs any errors that
 	//    may have occurred.
 	var (
 		count = 0
-		total = <-totalC // if there's a generator error, this will receive 0.
+		total = 0
 	)
+	if n, ok := <-totalC; ok {
+		total = n
+	}
 	emojis := make(map[string]edge.Emoji, total)
-LOOP:
-	for {
+	for resultC != nil || genErrC != nil {
 		select {
-		case genErr := <-genErrC:
+		case genErr, more := <-genErrC:
+			if !more {
+				genErrC = nil
+				continue
+			}
 			// generator error.
 			if genErr != nil {
 				return fmt.Errorf("failed to get emoji list: %w", genErr)
 			}
 		case res, more := <-resultC:
 			if !more {
-				break LOOP
+				resultC = nil
+				continue
 			}
 			lg := lg.With("name", res.emoji.Name)
 			if res.err != nil {
@@ -180,17 +204,40 @@ func worker(ctx context.Context, fsa fsadapter.FS, emojiC <-chan edge.Emoji, res
 				return
 			}
 			if em.IsAlias != 0 {
-				resultC <- result{emoji: em, skipped: true}
+				if !sendResult(ctx, resultC, result{emoji: em, skipped: true}) {
+					return
+				}
 				break
 			}
 			err := fetchFn(ctx, fsa, emojiDir, em.Name, em.URL)
-			resultC <- result{emoji: em, err: err}
+			if !sendResult(ctx, resultC, result{emoji: em, err: err}) {
+				return
+			}
 		}
 	}
 }
 
 func nofetchworker(ctx context.Context, _ fsadapter.FS, emojiC <-chan edge.Emoji, resultC chan<- result) {
-	for em := range emojiC {
-		resultC <- result{emoji: em}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case em, more := <-emojiC:
+			if !more {
+				return
+			}
+			if !sendResult(ctx, resultC, result{emoji: em}) {
+				return
+			}
+		}
+	}
+}
+
+func sendResult(ctx context.Context, resultC chan<- result, res result) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case resultC <- res:
+		return true
 	}
 }

--- a/cmd/slackdump/internal/emoji/emojidl/emoedge.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoedge.go
@@ -69,7 +69,7 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 	var (
 		emojiC  = make(chan edge.Emoji)
 		totalC  = make(chan int, 1)
-		genErrC = make(chan error, 1)
+		genErrC = make(chan error, 1) // generator errors chan
 		resultC = make(chan result)
 	)
 
@@ -84,7 +84,7 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 		var once sync.Once
 		defer close(totalC)
 		defer close(emojiC)
-		defer close(genErrC) // generator error channel
+		defer close(genErrC)
 
 		for chunk, err := range sess.AdminEmojiList(ctx) {
 			if err != nil {

--- a/cmd/slackdump/internal/emoji/emojidl/emoedge.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoedge.go
@@ -84,7 +84,7 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 		var once sync.Once
 		defer close(totalC)
 		defer close(emojiC)
-		defer close(genErrC)
+		defer close(genErrC) // generator error channel
 
 		for chunk, err := range sess.AdminEmojiList(ctx) {
 			if err != nil {
@@ -113,12 +113,10 @@ func DlEdgeFS(ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *
 
 	// 2. Download workers, download the emojis.
 	var wg sync.WaitGroup
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go func() {
+	for range numWorkers {
+		wg.Go(func() {
 			workerFn(ctx, fsa, emojiC, resultC)
-			wg.Done()
-		}()
+		})
 	}
 	// 3. Sentinel, closes the result channel once all workers are finished.
 	go func() {

--- a/cmd/slackdump/internal/emoji/emojidl/emoedge_test.go
+++ b/cmd/slackdump/internal/emoji/emojidl/emoedge_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2021-2026 Rustam Gilyazov and Contributors.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package emojidl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"iter"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rusq/fsadapter"
+
+	"github.com/rusq/slackdump/v4/internal/edge"
+)
+
+type edgeEmojiListerFunc func(context.Context) iter.Seq2[edge.EmojiResult, error]
+
+func (f edgeEmojiListerFunc) AdminEmojiList(ctx context.Context) iter.Seq2[edge.EmojiResult, error] {
+	return f(ctx)
+}
+
+func runDlEdgeFS(t *testing.T, ctx context.Context, sess EdgeEmojiLister, fsa fsadapter.FS, opt *Options) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- DlEdgeFS(ctx, sess, fsa, opt, nil)
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("DlEdgeFS timed out")
+		return nil
+	}
+}
+
+func TestDlEdgeFS(t *testing.T) {
+	t.Run("generator error returns promptly", func(t *testing.T) {
+		wantErr := errors.New("list failed")
+		sess := edgeEmojiListerFunc(func(context.Context) iter.Seq2[edge.EmojiResult, error] {
+			return func(yield func(edge.EmojiResult, error) bool) {
+				yield(edge.EmojiResult{}, wantErr)
+			}
+		})
+		fsa, err := fsadapter.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsa.Close()
+
+		if err := runDlEdgeFS(t, t.Context(), sess, fsa, nil); !errors.Is(err, wantErr) {
+			t.Fatalf("DlEdgeFS() error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("fail fast worker error returns promptly", func(t *testing.T) {
+		wantErr := errors.New("fetch failed")
+		setGlobalFetchFn(func(context.Context, fsadapter.FS, string, string, string) error {
+			return wantErr
+		})
+		defer setGlobalFetchFn(emptyFetchFn)
+
+		sess := edgeEmojiListerFunc(func(context.Context) iter.Seq2[edge.EmojiResult, error] {
+			return func(yield func(edge.EmojiResult, error) bool) {
+				yield(edge.EmojiResult{
+					Total: 2,
+					Emoji: []edge.Emoji{
+						{Name: "one", URL: "https://example.com/one.png"},
+						{Name: "two", URL: "https://example.com/two.png"},
+					},
+				}, nil)
+			}
+		})
+		fsa, err := fsadapter.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsa.Close()
+
+		err = runDlEdgeFS(t, t.Context(), sess, fsa, &Options{FailFast: true, WithFiles: true})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("DlEdgeFS() error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("canceled context returns promptly", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		sess := edgeEmojiListerFunc(func(context.Context) iter.Seq2[edge.EmojiResult, error] {
+			return func(yield func(edge.EmojiResult, error) bool) {
+				yield(edge.EmojiResult{}, context.Canceled)
+			}
+		})
+		fsa, err := fsadapter.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsa.Close()
+
+		if err := runDlEdgeFS(t, ctx, sess, fsa, nil); !errors.Is(err, context.Canceled) {
+			t.Fatalf("DlEdgeFS() error = %v, want %v", err, context.Canceled)
+		}
+	})
+
+	t.Run("success writes index", func(t *testing.T) {
+		dir := t.TempDir()
+		sess := edgeEmojiListerFunc(func(context.Context) iter.Seq2[edge.EmojiResult, error] {
+			return func(yield func(edge.EmojiResult, error) bool) {
+				yield(edge.EmojiResult{
+					Total: 1,
+					Emoji: []edge.Emoji{{Name: "party", URL: "https://example.com/party.png"}},
+				}, nil)
+			}
+		})
+		fsa, err := fsadapter.New(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsa.Close()
+
+		if err := runDlEdgeFS(t, t.Context(), sess, fsa, &Options{WithFiles: false}); err != nil {
+			t.Fatalf("DlEdgeFS() error = %v", err)
+		}
+		b, err := os.ReadFile(filepath.Join(dir, "index.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got map[string]edge.Emoji
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := got["party"]; !ok {
+			t.Fatalf("index missing emoji: %v", got)
+		}
+	})
+
+	t.Run("alias only completes without fetch", func(t *testing.T) {
+		setGlobalFetchFn(func(context.Context, fsadapter.FS, string, string, string) error {
+			t.Fatal("fetchFn called for alias")
+			return nil
+		})
+		defer setGlobalFetchFn(emptyFetchFn)
+
+		sess := edgeEmojiListerFunc(func(context.Context) iter.Seq2[edge.EmojiResult, error] {
+			return func(yield func(edge.EmojiResult, error) bool) {
+				yield(edge.EmojiResult{
+					Total: 1,
+					Emoji: []edge.Emoji{{Name: "shipit", IsAlias: 1, AliasFor: "squirrel"}},
+				}, nil)
+			}
+		})
+		fsa, err := fsadapter.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsa.Close()
+
+		if err := runDlEdgeFS(t, t.Context(), sess, fsa, &Options{WithFiles: true}); err != nil {
+			t.Fatalf("DlEdgeFS() error = %v", err)
+		}
+	})
+}

--- a/internal/convert/transform/export_coordinator.go
+++ b/internal/convert/transform/export_coordinator.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 
 	"github.com/rusq/slack"
@@ -57,9 +58,12 @@ type ExportCoordinator struct {
 	lg     *slog.Logger
 	closed atomic.Bool
 
-	start    chan struct{}
-	err      chan error   // error channel used to propagate errors to the main thread.
-	requestC chan request // channel used to pass channel IDs to the worker.
+	startOnce sync.Once
+	started   chan struct{}
+	done      chan struct{}
+	mu        sync.Mutex
+	err       error
+	requestC  chan request // channel used to pass channel IDs to the worker.
 }
 
 // bufferSz is the default size of the channel IDs buffer.  This is the number
@@ -94,9 +98,9 @@ func NewExportCoordinator(ctx context.Context, cvt UserConverter, tfopt ...ExpOp
 	t := &ExportCoordinator{
 		cvt:      cvt,
 		lg:       slog.Default(),
-		start:    make(chan struct{}),
+		started:  make(chan struct{}),
+		done:     make(chan struct{}),
 		requestC: make(chan request, bufferSz),
-		err:      make(chan error, 1),
 	}
 	for _, opt := range tfopt {
 		opt(t)
@@ -130,13 +134,17 @@ func (t *ExportCoordinator) Start(ctx context.Context) error {
 	if t.closed.Load() {
 		return errors.New("transform is closed")
 	}
+	if err := t.getErr(); err != nil {
+		return fmt.Errorf("transform: pending error: %w", err)
+	}
 	select {
 	case <-ctx.Done():
 		return context.Cause(ctx)
-	case err := <-t.err:
-		return fmt.Errorf("transform: pending error: %w", err)
 	default:
-		t.start <- struct{}{}
+	}
+	t.startOnce.Do(func() { close(t.started) })
+	if t.closed.Load() {
+		return errors.New("transform is closed")
 	}
 
 	return nil
@@ -149,10 +157,8 @@ func (t *ExportCoordinator) Start(ctx context.Context) error {
 // be queued for processing once the processor is started.  If the export
 // worker is closed, it will return ErrClosed.
 func (t *ExportCoordinator) Transform(ctx context.Context, channelID, threadTS string) error {
-	select {
-	case err := <-t.err:
+	if err := t.getErr(); err != nil {
 		return err
-	default:
 	}
 	if t.closed.Load() {
 		return ErrClosed
@@ -163,21 +169,38 @@ func (t *ExportCoordinator) Transform(ctx context.Context, channelID, threadTS s
 }
 
 func (t *ExportCoordinator) worker(ctx context.Context) {
-	defer close(t.err)
+	defer close(t.done)
 
 	lg := t.lg.With("in", "ExportCoordinator.worker")
 
 	lg.Debug("worker waiting", "buffer_size", cap(t.requestC))
-	<-t.start
+	<-t.started
 	lg.Debug("worker started", "queue_size", len(t.requestC))
 	for req := range t.requestC {
 		lg.Debug("transforming channel", "channel_id", req)
 		if err := t.cvt.Convert(ctx, req.channelID, req.threadTS); err != nil {
 			lg.Debug("transforming channel failure", "channel_id", req, "error", err)
-			t.err <- err
+			t.setErr(err)
 			continue
 		}
 	}
+}
+
+func (t *ExportCoordinator) setErr(err error) {
+	if err == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.err == nil {
+		t.err = err
+	}
+}
+
+func (t *ExportCoordinator) getErr() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.err
 }
 
 // Close closes the coordinator.  It must be called once it is guaranteed that
@@ -190,8 +213,9 @@ func (t *ExportCoordinator) Close() (err error) {
 	}
 	t.lg.Debug("transform: closing transform")
 	close(t.requestC)
-	close(t.start)
+	t.startOnce.Do(func() { close(t.started) })
 	t.lg.Debug("transform: waiting for workers to finish")
+	<-t.done
 
-	return <-t.err
+	return t.getErr()
 }

--- a/internal/convert/transform/export_coordinator_test.go
+++ b/internal/convert/transform/export_coordinator_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2021-2026 Rustam Gilyazov and Contributors.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package transform
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rusq/slack"
+)
+
+type exportCoordinatorTestConverter struct {
+	mu      sync.Mutex
+	users   []slack.User
+	convert func(context.Context, string, string) error
+}
+
+func (c *exportCoordinatorTestConverter) Convert(ctx context.Context, channelID, threadID string) error {
+	if c.convert == nil {
+		return nil
+	}
+	return c.convert(ctx, channelID, threadID)
+}
+
+func (c *exportCoordinatorTestConverter) SetUsers(users []slack.User) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.users = users
+}
+
+func (c *exportCoordinatorTestConverter) HasUsers() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.users) > 0
+}
+
+func testUsers() []slack.User {
+	return []slack.User{{ID: "U123", Name: "test"}}
+}
+
+func TestExportCoordinator_Start(t *testing.T) {
+	t.Run("after close returns error", func(t *testing.T) {
+		cvt := &exportCoordinatorTestConverter{}
+		ec := NewExportCoordinator(t.Context(), cvt, WithUsers(testUsers()))
+
+		if err := ec.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+		if err := ec.Start(t.Context()); err == nil {
+			t.Fatal("Start() error = nil, want error")
+		}
+	})
+
+	t.Run("concurrent close does not panic", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			cvt := &exportCoordinatorTestConverter{}
+			ec := NewExportCoordinator(t.Context(), cvt, WithUsers(testUsers()))
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					_ = ec.Start(t.Context())
+				}()
+				go func() {
+					defer wg.Done()
+					_ = ec.Close()
+				}()
+				wg.Wait()
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("concurrent Start and Close timed out")
+			}
+		}
+	})
+
+	t.Run("repeated start does not block", func(t *testing.T) {
+		cvt := &exportCoordinatorTestConverter{}
+		ec := NewExportCoordinator(t.Context(), cvt, WithUsers(testUsers()))
+		defer ec.Close()
+
+		for i := 0; i < 3; i++ {
+			done := make(chan error, 1)
+			go func() {
+				done <- ec.Start(t.Context())
+			}()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("Start() error = %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Start() timed out")
+			}
+		}
+	})
+}
+
+func TestExportCoordinator_Transform(t *testing.T) {
+	t.Run("after close returns ErrClosed", func(t *testing.T) {
+		cvt := &exportCoordinatorTestConverter{}
+		ec := NewExportCoordinator(t.Context(), cvt, WithUsers(testUsers()))
+
+		if err := ec.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+		if err := ec.Transform(t.Context(), "C123", ""); !errors.Is(err, ErrClosed) {
+			t.Fatalf("Transform() error = %v, want %v", err, ErrClosed)
+		}
+	})
+}
+
+func TestExportCoordinator_Close(t *testing.T) {
+	t.Run("returns convert error", func(t *testing.T) {
+		wantErr := errors.New("convert failed")
+		cvt := &exportCoordinatorTestConverter{
+			convert: func(context.Context, string, string) error {
+				return wantErr
+			},
+		}
+		ec := NewExportCoordinator(t.Context(), cvt, WithUsers(testUsers()))
+
+		if err := ec.Start(t.Context()); err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		if err := ec.Transform(t.Context(), "C123", ""); err != nil {
+			t.Fatalf("Transform() error = %v", err)
+		}
+		if err := ec.Close(); !errors.Is(err, wantErr) {
+			t.Fatalf("Close() error = %v, want %v", err, wantErr)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Hardened two internal concurrency paths without changing public CLI behavior:

- Reworked `ExportCoordinator` startup/shutdown coordination so `Start` cannot panic when racing with `Close`, and closed worker state is no longer interpreted as a nil success.
- Reworked `DlEdgeFS` generator/worker coordination so generator errors, fail-fast worker errors, cancellation, and early returns do not strand goroutines or silently succeed.
- Added regression tests covering the race/error paths, including the generator-error precedence case where `resultC` could close before the buffered generator error was consumed.

## Root Cause

`ExportCoordinator` used a send/close handshake on `t.start`, so concurrent `Start` and `Close` could panic. It also read from `t.err` with single-value receives, making a closed channel look like a nil error.

`DlEdgeFS` used unbuffered lifecycle/error channels and could return early while generator/workers were blocked. After the first fix, the generator error could still be lost when `resultC` closed at the same time as `genErrC` had a buffered error, because `select` could choose the closed result channel first.

## Validation

- `go test -run 'TestDlEdgeFS/generator_error_returns_promptly|TestDlEdgeFS/canceled_context_returns_promptly' -count=300 -race ./cmd/slackdump/internal/emoji/emojidl`
- `go test ./cmd/slackdump/internal/emoji/emojidl`
- `go test ./internal/convert/transform`
- `go test -race ./internal/convert/transform ./cmd/slackdump/internal/emoji/emojidl`
