### PR TITLE
Fix conversation pipeline shutdown deadlock

### DIFF
--- a/internal/chunk/control/runner.go
+++ b/internal/chunk/control/runner.go
@@ -159,16 +159,36 @@ func runWorkers(ctx context.Context, s Streamer, list *structures.EntityList, p 
 	{ // conversations goroutine
 		wg.Go(func() {
 			defer lg.DebugContext(ctx, "conversations done")
-
-			defer func() {
-				tryClose(errC, p.Conversations)
-			}()
 			gen := newGenerator(s, p, flags, list)
-			listC, wait := gen.Generate(ctx, errC, list)
-			defer wait() // sync with the generator
-			if err := conversationWorker(ctx, s, p.Conversations, listC); err != nil {
-				errC <- Error{"conversations", StgWorker, err}
-				return
+			genErrC := make(chan error)
+			var genErrs []error
+			genErrDone := make(chan struct{})
+			go func() {
+				defer close(genErrDone)
+				for err := range genErrC {
+					genErrs = append(genErrs, err)
+				}
+			}()
+
+			convCtx, cancel := context.WithCancel(ctx)
+			listC, wait := gen.Generate(convCtx, genErrC, list)
+			convErr := conversationWorker(convCtx, s, p.Conversations, listC)
+			cancel()
+
+			wait()
+			close(genErrC)
+			<-genErrDone
+
+			tryClose(errC, p.Conversations)
+
+			if convErr != nil {
+				errC <- Error{"conversations", StgWorker, convErr}
+			}
+			for _, genErr := range genErrs {
+				if convErr != nil && errors.Is(genErr, context.Canceled) {
+					continue
+				}
+				errC <- genErr
 			}
 		})
 	}

--- a/internal/chunk/control/runner_test.go
+++ b/internal/chunk/control/runner_test.go
@@ -17,8 +17,10 @@ package control
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -708,6 +710,50 @@ func Test_runWorkers(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("conversation failure cancels blocked API generator", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s := mock_control.NewMockStreamer(ctrl)
+		conversations := mock_processor.NewMockConversations(ctrl)
+		users := mock_processor.NewMockUsers(ctrl)
+		channels := mock_processor.NewMockChannels(ctrl)
+		workspace := mock_processor.NewMockWorkspaceInfo(ctrl)
+		conversationErr := errors.New("conversation failed")
+
+		s.EXPECT().WorkspaceInfo(gomock.Any(), workspace).Return(nil)
+		s.EXPECT().Users(gomock.Any(), users, gomock.Any()).Return(nil)
+		s.EXPECT().ListChannelsEx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, proc processor.Channels, _ *slack.GetConversationsParameters, _ bool) error {
+				return proc.Channels(ctx, []slack.Channel{
+					{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C1"}}},
+					{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C2"}}},
+				})
+			})
+		s.EXPECT().Conversations(gomock.Any(), conversations, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ processor.Conversations, links <-chan structures.EntityItem) error {
+				<-links
+				return conversationErr
+			})
+		conversations.EXPECT().Close().Return(nil).Times(1)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- runWorkers(t.Context(), s, structures.NewEntityListFromItems(), superprocessor{
+				Conversations: conversations,
+				Users:         users,
+				Channels:      channels,
+				WorkspaceInfo: workspace,
+			}, Flags{})
+		}()
+
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, conversationErr)
+			assert.NotContains(t, strings.ToLower(err.Error()), "api channel generator")
+		case <-time.After(time.Second):
+			t.Fatal("runWorkers remained blocked waiting for the API generator")
+		}
+	})
 }
 
 func Test_runSearch(t *testing.T) {

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -175,8 +175,7 @@ func (cs *Stream) startConversationPipeline(ctx context.Context, proc processor.
 	)
 	// Both the input loop (direct thread links) and channel worker (discovered
 	// threads) send to threadsC. Close it only after they both stop sending.
-	threadSenders.Add(resultSz)
-
+	threadSenders.Add(2)
 	workers.Go(func() {
 		defer threadSenders.Done()
 		cs.channelWorker(ctx, proc, resultsC, threadsC, chansC)
@@ -590,9 +589,8 @@ func (cs *Stream) procChannelUsers(ctx context.Context, proc processor.ChannelIn
 	return users, nil
 }
 
-// uniqueStrings returns a new slice with unique strings from the input slice.
-// it may modify the input slice, so it should not be used after calling this
-// function.
+// uniqueStrings sorts the slice and removes duplicates in-place, returning the compacted view.
+// The returned slice may share the input's backing array; the original order is not preserved.
 func uniqueStrings(input []string) []string {
 	slices.Sort(input)
 	return slices.Compact(input)

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -40,7 +40,8 @@ const (
 	// thread channel buffer size.  Threads are much slower than channels,
 	// because each message might have a thread, and that means, that we'll
 	// have to send a thread request for each message.  So, we need a larger
-	// buffer for it not to block the channel messages scraping.  Value is chosed
+	// buffer for it not to block the channel messages scraping.  Value is
+	// chosen to be large enough.
 	threadChanSz = 4000
 	// result channel buffer size.  We are running 2 goroutines, 1 for channel
 	// messages, and 1 for threads.

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -103,68 +103,10 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// create channels
-	chansC := make(chan request, msgChanSz)
-	threadsC := make(chan request, threadChanSz)
-
-	resultsC := make(chan Result, resultSz)
-
-	var (
-		wg              sync.WaitGroup
-		threadProducers sync.WaitGroup
-	)
-	threadProducers.Add(2)
-
-	// channel worker
-	wg.Go(func() {
-		defer threadProducers.Done()
-		cs.channelWorker(ctx, proc, resultsC, threadsC, chansC)
-		trace.Log(ctx, "async", "channel worker done")
-	})
-	// thread worker
-	wg.Go(func() {
-		cs.threadWorker(ctx, proc, resultsC, threadsC)
-		trace.Log(ctx, "async", "thread worker done")
-	})
-	// main loop
-	wg.Go(func() {
-		defer threadProducers.Done()
-		defer trace.Log(ctx, "async", "main loop done")
-		defer close(chansC)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case item, more := <-items:
-				if !more {
-					return
-				}
-				if err := processLink(ctx, chansC, threadsC, item); err != nil {
-					if !sendResult(ctx, resultsC, Result{Type: RTMain, Err: fmt.Errorf("item error: %q: %w", item.String(), err)}) {
-						return
-					}
-					return
-				}
-			}
-		}
-	})
-	wg.Go(func() {
-		threadProducers.Wait()
-		close(threadsC)
-	})
-
-	go func() {
-		// sentinel waits for all the workers to finish, then closes the error
-		// channel.
-		wg.Wait()
-		close(resultsC)
-		trace.Log(ctx, "async", "sentinel done")
-	}()
-
 	// Retain the first fatal error, cancel all producers immediately, and keep
 	// draining results until every producer and worker has stopped.
 	var fatalErr error
-	for res := range resultsC {
+	for res := range cs.startConversationPipeline(ctx, proc, items) {
 		if fatalErr != nil {
 			continue
 		}
@@ -174,7 +116,6 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 				slog.WarnContext(ctx, "channel not found or user not in channel, skipping", "channel_id", res.ChannelID)
 				continue
 			}
-			trace.Logf(ctx, "error", "type: %s, chan_id: %s, thread_ts: %s, error: %s", res.Type, res.ChannelID, res.ThreadTS, err.Error())
 			slog.ErrorContext(ctx, "streaming error", "error", res.Err, "type", res.Type, "channel_id", res.ChannelID, "thread_ts", res.ThreadTS)
 			if cause := context.Cause(ctx); cause != nil && errors.Is(err, ctx.Err()) {
 				fatalErr = cause
@@ -202,6 +143,68 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 	}
 	trace.Log(ctx, "info", "complete")
 	return nil
+}
+
+// startConversationPipeline starts the three pipeline stages and returns the
+// results channel. The input loop and channel worker both send thread requests,
+// so their completion owns closing threadsC.
+func (cs *Stream) startConversationPipeline(ctx context.Context, proc processor.Conversations, items <-chan structures.EntityItem) <-chan Result {
+	chansC := make(chan request, msgChanSz)
+	threadsC := make(chan request, threadChanSz)
+	resultsC := make(chan Result, resultSz)
+
+	var (
+		workers       sync.WaitGroup
+		threadSenders sync.WaitGroup
+	)
+	// Both the input loop (direct thread links) and channel worker (discovered
+	// threads) send to threadsC. Close it only after they both stop sending.
+	threadSenders.Add(2)
+
+	workers.Go(func() {
+		defer threadSenders.Done()
+		cs.channelWorker(ctx, proc, resultsC, threadsC, chansC)
+		trace.Log(ctx, "async", "channel worker done")
+	})
+	workers.Go(func() {
+		cs.threadWorker(ctx, proc, resultsC, threadsC)
+		trace.Log(ctx, "async", "thread worker done")
+	})
+	workers.Go(func() {
+		defer threadSenders.Done()
+		cs.feedConversationRequests(ctx, items, chansC, threadsC, resultsC)
+		trace.Log(ctx, "async", "input loop done")
+	})
+	workers.Go(func() {
+		threadSenders.Wait()
+		close(threadsC)
+	})
+
+	go func() {
+		workers.Wait()
+		close(resultsC)
+		trace.Log(ctx, "async", "pipeline done")
+	}()
+
+	return resultsC
+}
+
+func (cs *Stream) feedConversationRequests(ctx context.Context, items <-chan structures.EntityItem, chansC chan<- request, threadsC chan<- request, resultsC chan<- Result) {
+	defer close(chansC)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case item, more := <-items:
+			if !more {
+				return
+			}
+			if err := processLink(ctx, chansC, threadsC, item); err != nil {
+				sendResult(ctx, resultsC, Result{Type: RTMain, Err: fmt.Errorf("item error: %q: %w", item.String(), err)})
+				return
+			}
+		}
+	}
 }
 
 // processLink parses the link and sends it to the appropriate output channel.

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/trace"
+	"slices"
 	"sync"
 	"time"
 
@@ -574,6 +575,8 @@ func (cs *Stream) procChannelUsers(ctx context.Context, proc processor.ChannelIn
 		cursor = next
 	}
 
+	users = uniqueStrings(users)
+
 	// Cache the users for this channel.
 	cs.userCache.set(channelID, users)
 
@@ -583,6 +586,14 @@ func (cs *Stream) procChannelUsers(ctx context.Context, proc processor.ChannelIn
 	}
 
 	return users, nil
+}
+
+// uniqueStrings returns a new slice with unique strings from the input slice.
+// it may modify the input slice, so it should not be used after calling this
+// function.
+func uniqueStrings(input []string) []string {
+	slices.Sort(input)
+	return slices.Compact(input)
 }
 
 // procChannelInfoWithUsers returns the slack channel with members populated from

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -140,6 +140,7 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 				continue
 			}
 			trace.Logf(ctx, "error", "type: %s, chan_id: %s, thread_ts: %s, error: %s", res.Type, res.ChannelID, res.ThreadTS, err.Error())
+			slog.ErrorContext(ctx, "streaming error", "error", res.Err, "type", res.Type, "channel_id", res.ChannelID, "thread_ts", res.ThreadTS)
 			return &res // res implements Error
 		}
 		for _, fn := range cs.resultFn {

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -32,6 +32,20 @@ import (
 	"github.com/rusq/slackdump/v4/processor"
 )
 
+const (
+	// message channel buffer size.  Messages are much faster than threads, so
+	// we can have a smaller buffer.
+	msgChanSz = 16
+	// thread channel buffer size.  Threads are much slower than channels,
+	// because each message might have a thread, and that means, that we'll
+	// have to send a thread request for each message.  So, we need a larger
+	// buffer for it not to block the channel messages scraping.  Value is chosed
+	threadChanSz = 4000
+	// result channel buffer size.  We are running 2 goroutines, 1 for channel
+	// messages, and 1 for threads.
+	resultSz = 2
+)
+
 // SyncConversations fetches the conversations from the link which can be a
 // channelID, channel URL, thread URL or a link in Slackdump format.
 func (cs *Stream) SyncConversations(ctx context.Context, proc processor.Conversations, items ...structures.EntityItem) error {
@@ -159,7 +173,7 @@ func (cs *Stream) startConversationPipeline(ctx context.Context, proc processor.
 	)
 	// Both the input loop (direct thread links) and channel worker (discovered
 	// threads) send to threadsC. Close it only after they both stop sending.
-	threadSenders.Add(2)
+	threadSenders.Add(resultSz)
 
 	workers.Go(func() {
 		defer threadSenders.Done()

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -48,24 +48,43 @@ func (cs *Stream) ConversationsCB(ctx context.Context, proc processor.Conversati
 
 	lg := slog.With("links", items)
 	cs.resultFn = append(cs.resultFn, cb)
+	return runConversationItems(ctx, items, produceItems, func(ctx context.Context, itemC <-chan structures.EntityItem) error {
+		err := cs.Conversations(ctx, proc, itemC)
+		lg.DebugContext(ctx, "stream: item consumer stopped", "len", len(items))
+		return err
+	})
+}
 
+func runConversationItems(
+	ctx context.Context,
+	items []structures.EntityItem,
+	produce func(context.Context, chan<- structures.EntityItem, []structures.EntityItem),
+	consume func(context.Context, <-chan structures.EntityItem) error,
+) error {
+	ctx, cancel := context.WithCancel(ctx)
 	itemC := make(chan structures.EntityItem, 1)
+	producerDone := make(chan struct{})
 	go func() {
-		defer close(itemC)
-		for _, l := range items {
-			select {
-			case itemC <- l:
-			case <-ctx.Done():
-				return
-			}
-		}
-		lg.DebugContext(ctx, "stream: sent link count", "len", len(items))
+		defer close(producerDone)
+		produce(ctx, itemC, items)
+	}()
+	defer func() {
+		cancel()
+		<-producerDone
 	}()
 
-	if err := cs.Conversations(ctx, proc, itemC); err != nil {
-		return err
+	return consume(ctx, itemC)
+}
+
+func produceItems(ctx context.Context, output chan<- structures.EntityItem, items []structures.EntityItem) {
+	defer close(output)
+	for _, item := range items {
+		select {
+		case output <- item:
+		case <-ctx.Done():
+			return
+		}
 	}
-	return nil
 }
 
 // Conversations fetches the conversations from the links channel.  The link
@@ -81,6 +100,8 @@ func (cs *Stream) ConversationsCB(ctx context.Context, proc processor.Conversati
 func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversations, items <-chan structures.EntityItem) error {
 	ctx, task := trace.NewTask(ctx, "AsyncConversations")
 	defer task.End()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// create channels
 	chansC := make(chan request, msgChanSz)
@@ -88,14 +109,16 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 
 	resultsC := make(chan Result, resultSz)
 
-	var wg sync.WaitGroup
+	var (
+		wg              sync.WaitGroup
+		threadProducers sync.WaitGroup
+	)
+	threadProducers.Add(2)
 
 	// channel worker
 	wg.Go(func() {
+		defer threadProducers.Done()
 		cs.channelWorker(ctx, proc, resultsC, threadsC, chansC)
-		// we close threads here, instead of the main loop, because we want to
-		// close it after all the threads are sent by channels.
-		close(threadsC)
 		trace.Log(ctx, "async", "channel worker done")
 	})
 	// thread worker
@@ -105,22 +128,29 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 	})
 	// main loop
 	wg.Go(func() {
+		defer threadProducers.Done()
 		defer trace.Log(ctx, "async", "main loop done")
 		defer close(chansC)
 		for {
 			select {
 			case <-ctx.Done():
-				resultsC <- Result{Type: RTMain, Err: context.Cause(ctx)}
 				return
 			case item, more := <-items:
 				if !more {
 					return
 				}
-				if err := processLink(chansC, threadsC, item); err != nil {
-					resultsC <- Result{Type: RTMain, Err: fmt.Errorf("item error: %q: %w", item.String(), err)}
+				if err := processLink(ctx, chansC, threadsC, item); err != nil {
+					if !sendResult(ctx, resultsC, Result{Type: RTMain, Err: fmt.Errorf("item error: %q: %w", item.String(), err)}) {
+						return
+					}
+					return
 				}
 			}
 		}
+	})
+	wg.Go(func() {
+		threadProducers.Wait()
+		close(threadsC)
 	})
 
 	go func() {
@@ -131,8 +161,13 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 		trace.Log(ctx, "async", "sentinel done")
 	}()
 
-	// result processing.
+	// Retain the first fatal error, cancel all producers immediately, and keep
+	// draining results until every producer and worker has stopped.
+	var fatalErr error
 	for res := range resultsC {
+		if fatalErr != nil {
+			continue
+		}
 		if err := res.Err; err != nil {
 			trace.Logf(ctx, "error", "type: %s, chan_id: %s, thread_ts: %s, error: %s", res.Type, res.ChannelID, res.ThreadTS, err.Error())
 			if (errors.Is(err, errChanNotFound) || errors.Is(err, errNotInChannel)) && !cs.failChnlNotFnd {
@@ -141,20 +176,36 @@ func (cs *Stream) Conversations(ctx context.Context, proc processor.Conversation
 			}
 			trace.Logf(ctx, "error", "type: %s, chan_id: %s, thread_ts: %s, error: %s", res.Type, res.ChannelID, res.ThreadTS, err.Error())
 			slog.ErrorContext(ctx, "streaming error", "error", res.Err, "type", res.Type, "channel_id", res.ChannelID, "thread_ts", res.ThreadTS)
-			return &res // res implements Error
+			if cause := context.Cause(ctx); cause != nil && errors.Is(err, ctx.Err()) {
+				fatalErr = cause
+			} else {
+				resultErr := res
+				fatalErr = &resultErr // Result implements error.
+			}
+			cancel()
+			continue
 		}
 		for _, fn := range cs.resultFn {
 			if err := fn(res); err != nil {
-				return fmt.Errorf("result %s, callback error: %w", res, err)
+				slog.ErrorContext(ctx, "result function call error", "res", res.String())
+				fatalErr = fmt.Errorf("result %s, callback error: %w", res, err)
+				cancel()
+				break
 			}
 		}
+	}
+	if fatalErr != nil {
+		return fatalErr
+	}
+	if err := context.Cause(ctx); err != nil {
+		return err
 	}
 	trace.Log(ctx, "info", "complete")
 	return nil
 }
 
 // processLink parses the link and sends it to the appropriate output channel.
-func processLink(channels chan<- request, threads chan<- request, link structures.EntityItem) error {
+func processLink(ctx context.Context, channels chan<- request, threads chan<- request, link structures.EntityItem) error {
 	sl, err := structures.ParseLink(link.Id)
 	if err != nil {
 		return err
@@ -163,9 +214,17 @@ func processLink(channels chan<- request, threads chan<- request, link structure
 		return fmt.Errorf("invalid slack link: %s", link.Id)
 	}
 	if sl.IsThread() {
-		threads <- request{sl: &sl, threadOnly: true, Oldest: link.Oldest, Latest: link.Latest}
+		select {
+		case threads <- request{sl: &sl, threadOnly: true, Oldest: link.Oldest, Latest: link.Latest}:
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		}
 	} else {
-		channels <- request{sl: &sl, Oldest: link.Oldest, Latest: link.Latest}
+		select {
+		case channels <- request{sl: &sl, Oldest: link.Oldest, Latest: link.Latest}:
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		}
 	}
 	return nil
 }
@@ -361,7 +420,11 @@ func (cs *Stream) procChanMsg(ctx context.Context, proc processor.Conversations,
 		return 0, fmt.Errorf("channel %s: failed to process message chunk starting with id=%s (size=%d): %w", channel.ID, mm[0].Timestamp, len(mm), err)
 	}
 	for _, tr := range trs {
-		threadC <- tr
+		select {
+		case threadC <- tr:
+		case <-ctx.Done():
+			return len(trs), context.Cause(ctx)
+		}
 	}
 	return len(trs), nil
 }

--- a/stream/conversation.go
+++ b/stream/conversation.go
@@ -575,6 +575,7 @@ func (cs *Stream) procChannelUsers(ctx context.Context, proc processor.ChannelIn
 		cursor = next
 	}
 
+	// ensure there are no duplicate entries.
 	users = uniqueStrings(users)
 
 	// Cache the users for this channel.

--- a/stream/conversation_test.go
+++ b/stream/conversation_test.go
@@ -18,6 +18,7 @@ package stream
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -703,6 +704,55 @@ func Test_isNonCriticalErr(t *testing.T) {
 			}
 			if ok != tt.wantOK {
 				t.Fatalf("isNonCriticalErr() ok = %t, wantOK = %t", ok, tt.wantOK)
+			}
+		})
+	}
+}
+
+func Test_uniqueStrings(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		input []string
+		want  []string
+	}{
+		{
+			name:  "empty slice",
+			input: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "single element",
+			input: []string{"a"},
+			want:  []string{"a"},
+		},
+		{
+			name:  "multiple unique elements",
+			input: []string{"b", "a", "c"},
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "multiple duplicate elements",
+			input: []string{"b", "a", "c", "a", "b"},
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "all duplicates",
+			input: []string{"a", "a", "a"},
+			want:  []string{"a"},
+		},
+		{
+			name:  "mixed case",
+			input: []string{"A", "a", "B", "b"},
+			want:  []string{"A", "B", "a", "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := uniqueStrings(tt.input)
+			// TODO: update the condition below to compare got with tt.want.
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("uniqueStrings() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/stream/conversation_test.go
+++ b/stream/conversation_test.go
@@ -19,12 +19,16 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/rusq/slack"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/rusq/slackdump/v4/internal/client/mock_client"
 	"github.com/rusq/slackdump/v4/internal/fixtures"
+	"github.com/rusq/slackdump/v4/internal/network"
+	"github.com/rusq/slackdump/v4/internal/structures"
 	"github.com/rusq/slackdump/v4/mocks/mock_processor"
 )
 
@@ -34,6 +38,191 @@ var TestChannel = &slack.Channel{
 			ID: "C12345678",
 		},
 	},
+}
+
+func Test_produceItems(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	output := make(chan structures.EntityItem)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		produceItems(ctx, output, []structures.EntityItem{{Id: "C1"}})
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("produceItems remained blocked after cancellation")
+	}
+}
+
+func Test_runConversationItems(t *testing.T) {
+	consumerErr := errors.New("consumer failed")
+	cancelObserved := make(chan struct{})
+	releaseProducer := make(chan struct{})
+	producerDone := make(chan struct{})
+	producer := func(ctx context.Context, output chan<- structures.EntityItem, _ []structures.EntityItem) {
+		defer close(output)
+		defer close(producerDone)
+		output <- structures.EntityItem{Id: "C1"}
+		<-ctx.Done()
+		close(cancelObserved)
+		<-releaseProducer
+	}
+	consumer := func(_ context.Context, input <-chan structures.EntityItem) error {
+		<-input
+		return consumerErr
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- runConversationItems(t.Context(), nil, producer, consumer)
+	}()
+
+	select {
+	case <-cancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("producer did not observe consumer cancellation")
+	}
+	select {
+	case err := <-result:
+		t.Fatalf("runConversationItems returned before its producer exited: %v", err)
+	default:
+	}
+	close(releaseProducer)
+	select {
+	case err := <-result:
+		assert.ErrorIs(t, err, consumerErr)
+	case <-time.After(time.Second):
+		t.Fatal("runConversationItems did not return after its producer exited")
+	}
+	select {
+	case <-producerDone:
+	default:
+		t.Fatal("producer was not joined before runConversationItems returned")
+	}
+}
+
+func TestStream_ConversationsCB(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cs := New(mock_client.NewMockSlack(ctrl), network.NoLimits)
+	proc := mock_processor.NewMockConversations(ctrl)
+	items := make([]structures.EntityItem, 100)
+	items[0] = structures.EntityItem{Id: "not-a-valid-slack-link"}
+	for i := 1; i < len(items); i++ {
+		items[i] = structures.EntityItem{Id: "C12345678"}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cs.ConversationsCB(t.Context(), proc, items, func(Result) error { return nil })
+	}()
+	select {
+	case err := <-done:
+		assert.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("ConversationsCB did not return after a fatal item")
+	}
+}
+
+func TestStream_Conversations(t *testing.T) {
+	threadItem := structures.EntityItem{Id: "CTM1:1610000000.000000"}
+	threadChannel := &slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "CTM1"}}}
+	threadMessages := []slack.Message{{Msg: slack.Msg{
+		Channel:         "CTM1",
+		Timestamp:       "1610000000.000000",
+		ThreadTimestamp: "1610000000.000000",
+	}}}
+
+	t.Run("fatal thread result cancels queued work", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cl := mock_client.NewMockSlack(ctrl)
+		proc := mock_processor.NewMockConversations(ctrl)
+		cs := New(cl, network.NoLimits)
+		cs.chanCache.set("CTM1", threadChannel)
+		cl.EXPECT().GetConversationRepliesContext(gomock.Any(), gomock.Any()).Return(threadMessages, false, "", nil).AnyTimes()
+		proc.EXPECT().ChannelInfo(gomock.Any(), gomock.Any(), "1610000000.000000").Return(nil).AnyTimes()
+		proc.EXPECT().ThreadMessages(gomock.Any(), "CTM1", gomock.Any(), true, true, threadMessages).Return(assert.AnError).AnyTimes()
+
+		items := make(chan structures.EntityItem, threadChanSz+1)
+		for range threadChanSz + 1 {
+			items <- threadItem
+		}
+		close(items)
+
+		done := make(chan error, 1)
+		go func() { done <- cs.Conversations(t.Context(), proc, items) }()
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, assert.AnError)
+		case <-time.After(time.Second):
+			t.Fatal("Conversations did not join cancelled workers")
+		}
+	})
+
+	t.Run("callback failure cancels and joins producers", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cl := mock_client.NewMockSlack(ctrl)
+		proc := mock_processor.NewMockConversations(ctrl)
+		callbackErr := errors.New("callback failed")
+		cs := New(cl, network.NoLimits, OptResultFn(func(Result) error { return callbackErr }))
+		cs.chanCache.set("CTM1", threadChannel)
+		cl.EXPECT().GetConversationRepliesContext(gomock.Any(), gomock.Any()).Return(threadMessages, false, "", nil).AnyTimes()
+		proc.EXPECT().ChannelInfo(gomock.Any(), gomock.Any(), "1610000000.000000").Return(nil).AnyTimes()
+		proc.EXPECT().ThreadMessages(gomock.Any(), "CTM1", gomock.Any(), true, true, threadMessages).Return(nil).AnyTimes()
+
+		items := make(chan structures.EntityItem, threadChanSz+1)
+		for range threadChanSz + 1 {
+			items <- threadItem
+		}
+		close(items)
+
+		done := make(chan error, 1)
+		go func() { done <- cs.Conversations(t.Context(), proc, items) }()
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, callbackErr)
+		case <-time.After(time.Second):
+			t.Fatal("Conversations did not join producers after callback failure")
+		}
+	})
+
+	t.Run("external cancellation returns cause", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cs := New(mock_client.NewMockSlack(ctrl), network.NoLimits)
+		proc := mock_processor.NewMockConversations(ctrl)
+		ctx, cancel := context.WithCancelCause(t.Context())
+		cause := errors.New("caller stopped")
+		cancel(cause)
+
+		err := cs.Conversations(ctx, proc, make(chan structures.EntityItem))
+		assert.ErrorIs(t, err, cause)
+	})
+
+	t.Run("nonfatal channel error continues processing", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cl := mock_client.NewMockSlack(ctrl)
+		proc := mock_processor.NewMockConversations(ctrl)
+		cs := New(cl, network.NoLimits)
+		cl.EXPECT().GetConversationInfoContext(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, in *slack.GetConversationInfoInput) (*slack.Channel, error) {
+				if in.ChannelID == "CMISSING" {
+					return nil, slack.SlackErrorResponse{Err: errChanNotFound.Error()}
+				}
+				return threadChannel, nil
+			}).AnyTimes()
+		cl.EXPECT().GetConversationRepliesContext(gomock.Any(), gomock.Any()).Return(threadMessages, false, "", nil)
+		proc.EXPECT().ChannelInfo(gomock.Any(), threadChannel, "1610000000.000000").Return(nil)
+		proc.EXPECT().ThreadMessages(gomock.Any(), "CTM1", gomock.Any(), true, true, threadMessages).Return(nil)
+
+		items := make(chan structures.EntityItem, 2)
+		items <- structures.EntityItem{Id: "CMISSING:1610000000.000000"}
+		items <- threadItem
+		close(items)
+
+		assert.NoError(t, cs.Conversations(t.Context(), proc, items))
+	})
 }
 
 func Test_procChanMsg(t *testing.T) {
@@ -215,6 +404,19 @@ func Test_procChanMsg(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("cancellation unblocks thread output", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mp := mock_processor.NewMockConversations(ctrl)
+		mp.EXPECT().Messages(gomock.Any(), TestChannel.ID, 1, true, threadedMsg).Return(nil)
+		ctx, cancel := context.WithCancelCause(t.Context())
+		cause := errors.New("stop thread routing")
+		cancel(cause)
+
+		got, err := (&Stream{}).procChanMsg(ctx, mp, make(chan request), TestChannel, true, threadedMsg)
+		assert.Equal(t, 1, got)
+		assert.ErrorIs(t, err, cause)
+	})
 }
 
 func stuffProcWithFiles(mp *mock_processor.MockConversations, ch *slack.Channel, mm []slack.Message) {

--- a/stream/conversation_test.go
+++ b/stream/conversation_test.go
@@ -18,7 +18,6 @@ package stream
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
 	"time"
 
@@ -709,6 +708,41 @@ func Test_isNonCriticalErr(t *testing.T) {
 	}
 }
 
+func TestStream_procChannelUsers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cl := mock_client.NewMockSlack(ctrl)
+	proc := mock_processor.NewMockConversations(ctrl)
+	cs := New(cl, network.NoLimits)
+
+	gomock.InOrder(
+		cl.EXPECT().
+			GetUsersInConversationContext(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+				assert.Empty(t, params.Cursor)
+				return []string{"U2", "U1"}, "next", nil
+			}),
+		cl.EXPECT().
+			GetUsersInConversationContext(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+				assert.Equal(t, "next", params.Cursor)
+				return []string{"U3", "U2"}, "", nil
+			}),
+	)
+	proc.EXPECT().
+		ChannelUsers(gomock.Any(), "C1", "", []string{"U1", "U2", "U3"}).
+		Return(nil)
+
+	got, err := cs.procChannelUsers(t.Context(), proc, "C1", "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"U1", "U2", "U3"}, got)
+
+	// A second request should use the deduplicated cached value without calling
+	// either the Slack API or the processor again.
+	got, err = cs.procChannelUsers(t.Context(), proc, "C1", "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"U1", "U2", "U3"}, got)
+}
+
 func Test_uniqueStrings(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case
@@ -750,10 +784,7 @@ func Test_uniqueStrings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := uniqueStrings(tt.input)
-			// TODO: update the condition below to compare got with tt.want.
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("uniqueStrings() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -33,20 +33,6 @@ import (
 	"github.com/rusq/slackdump/v4/processor"
 )
 
-const (
-	// message channel buffer size.  Messages are much faster than threads, so
-	// we can have a smaller buffer.
-	msgChanSz = 16
-	// thread channel buffer size.  Threads are much slower than channels,
-	// because each message might have a thread, and that means, that we'll
-	// have to send a thread request for each message.  So, we need a larger
-	// buffer for it not to block the channel messages scraping.
-	threadChanSz = 4000
-	// result channel buffer size.  We are running 2 goroutines, 1 for channel
-	// messages, and 1 for threads.
-	resultSz = 2
-)
-
 // Stream is used to fetch conversations from Slack.  It is safe for concurrent
 // use.
 type Stream struct {

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -405,7 +405,7 @@ func Test_processLink(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			chans := make(chan request, 1)
 			threads := make(chan request, 1)
-			if err := processLink(chans, threads, tt.args.item); (err != nil) != tt.wantErr {
+			if err := processLink(t.Context(), chans, threads, tt.args.item); (err != nil) != tt.wantErr {
 				t.Errorf("processLink() error = %v, wantErr %v", err, tt.wantErr)
 				return // otherwise will block
 			}
@@ -424,6 +424,24 @@ func Test_processLink(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("cancellation unblocks output", func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		channels := make(chan request)
+		done := make(chan error, 1)
+		go func() {
+			done <- processLink(ctx, channels, make(chan request), structures.EntityItem{Id: "CTM1"})
+		}()
+
+		cause := errors.New("stop routing")
+		cancel(cause)
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, cause)
+		case <-time.After(time.Second):
+			t.Fatal("processLink remained blocked after cancellation")
+		}
+	})
 }
 
 func TestStream_Users(t *testing.T) {

--- a/stream/stream_workers.go
+++ b/stream/stream_workers.go
@@ -34,7 +34,6 @@ func (cs *Stream) channelWorker(ctx context.Context, proc processor.Conversation
 	for {
 		select {
 		case <-ctx.Done():
-			results <- Result{Type: RTChannel, Err: ctx.Err()}
 			return
 		case req, more := <-reqs:
 			if !more {
@@ -42,7 +41,9 @@ func (cs *Stream) channelWorker(ctx context.Context, proc processor.Conversation
 			}
 			channel, err := cs.procChannelInfoWithUsers(ctx, proc, req.sl.Channel, req.sl.ThreadTS)
 			if err != nil {
-				results <- Result{Type: RTChannel, ChannelID: req.sl.Channel, Err: err}
+				if !sendResult(ctx, results, Result{Type: RTChannel, ChannelID: req.sl.Channel, Err: err}) {
+					return
+				}
 				continue
 			}
 
@@ -59,10 +60,14 @@ func (cs *Stream) channelWorker(ctx context.Context, proc processor.Conversation
 				if err != nil {
 					return err
 				}
-				results <- Result{Type: RTChannel, ChannelID: req.sl.Channel, ThreadCount: n, IsLast: isLast}
+				if !sendResult(ctx, results, Result{Type: RTChannel, ChannelID: req.sl.Channel, ThreadCount: n, IsLast: isLast}) {
+					return context.Cause(ctx)
+				}
 				return nil
 			}); err != nil {
-				results <- Result{Type: RTChannel, ChannelID: req.sl.Channel, Err: err}
+				if !sendResult(ctx, results, Result{Type: RTChannel, ChannelID: req.sl.Channel, Err: err}) {
+					return
+				}
 				continue
 			}
 		}
@@ -76,14 +81,15 @@ func (cs *Stream) threadWorker(ctx context.Context, proc processor.Conversations
 	for {
 		select {
 		case <-ctx.Done():
-			results <- Result{Type: RTThread, Err: ctx.Err()}
 			return
 		case req, more := <-threadReq:
 			if !more {
 				return // channel closed
 			}
 			if !req.sl.IsThread() {
-				results <- Result{Type: RTThread, Err: fmt.Errorf("invalid thread link: %s", req.sl)}
+				if !sendResult(ctx, results, Result{Type: RTThread, Err: fmt.Errorf("invalid thread link: %s", req.sl)}) {
+					return
+				}
 				continue
 			}
 
@@ -96,7 +102,9 @@ func (cs *Stream) threadWorker(ctx context.Context, proc processor.Conversations
 				// user IDs. Skipping procChannelUsers saves an API call per thread.
 				var err error
 				if channel, err = cs.procChannelInfo(ctx, proc, req.sl.Channel, req.sl.ThreadTS); err != nil {
-					results <- Result{Type: RTThread, ChannelID: req.sl.Channel, ThreadTS: req.sl.ThreadTS, Err: err}
+					if !sendResult(ctx, results, Result{Type: RTThread, ChannelID: req.sl.Channel, ThreadTS: req.sl.ThreadTS, Err: err}) {
+						return
+					}
 					continue
 				}
 			} else {
@@ -109,13 +117,26 @@ func (cs *Stream) threadWorker(ctx context.Context, proc processor.Conversations
 				if err := procThreadMsg(ctx, proc, channel, req.sl.ThreadTS, req.threadOnly, isLast, msgs); err != nil {
 					return err
 				}
-				results <- Result{Type: RTThread, ChannelID: req.sl.Channel, ThreadTS: req.sl.ThreadTS, IsLast: isLast}
+				if !sendResult(ctx, results, Result{Type: RTThread, ChannelID: req.sl.Channel, ThreadTS: req.sl.ThreadTS, IsLast: isLast}) {
+					return context.Cause(ctx)
+				}
 				return nil
 			}); err != nil {
-				results <- Result{Type: RTThread, ChannelID: req.sl.Channel, ThreadTS: req.sl.ThreadTS, Err: err}
+				if !sendResult(ctx, results, Result{Type: RTThread, ChannelID: req.sl.Channel, ThreadTS: req.sl.ThreadTS, Err: err}) {
+					return
+				}
 				continue
 			}
 		}
+	}
+}
+
+func sendResult(ctx context.Context, results chan<- Result, res Result) bool {
+	select {
+	case results <- res:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -147,7 +168,9 @@ func (cs *Stream) channelInfoWorker(ctx context.Context, proc processor.ChannelI
 
 			if _, err := infoFetcher(ctx, proc, id, ""); err != nil {
 				// if _, err := cs.procChannelInfo(ctx, proc, id, ""); err != nil {
-				srC <- Result{Type: RTChannelInfo, ChannelID: id, Err: fmt.Errorf("channelInfoWorker: %s: %w", id, err)}
+				if !sendResult(ctx, srC, Result{Type: RTChannelInfo, ChannelID: id, Err: fmt.Errorf("channelInfoWorker: %s: %w", id, err)}) {
+					return
+				}
 			}
 			seen[id] = struct{}{}
 		}


### PR DESCRIPTION
## Problem

When conversation processing returned on the first fatal result or callback error, its producers and workers could remain blocked:

- channel and thread workers could stay blocked sending results;
- the input loop could stay blocked routing channel or thread requests;
- the thread channel could race with its close;
- the API channel generator could remain blocked while `runWorkers` waited for it;
- the user collector and processor shutdown could remain pending behind that chain.

A SIGQUIT stack trace from a production hang showed this exact pattern: `runWorkers` waiting for the generator, the generator blocked emitting channels, and conversation workers blocked on result sends after the consumer had returned.

In addition, after the fix, the original error that led to Hang-up was discovered — 
```
18:19:16 ERROR 006 (Application Error): error in subroutine 
                     │   conversations on stage worker: error streaming 
                     │   conversations: Channel channel XXXXX: encode: 
                     │   insertchunk: insert: insertchunk: payload: insert all 
                     │   CHANNEL_USER (ID=XXXXX): constraint failed: UNIQUE 
                     │   constraint failed: CHANNEL_USER.CHANNEL_ID, 
                     │   CHANNEL_USER.USER_ID, CHANNEL_USER.CHUNK_ID (1555).
```
to address it a channel users slices deduplication was introduced during streaming.

## Solution

- Give `Conversations` an internal cancellable context and retain the first fatal result or callback error.
- Cancel immediately on failure, then drain results and join every internal worker before returning.
- Make result, channel-request, and thread-request sends cancellation-aware.
- Close `threadsC` only after both the input loop and channel worker have stopped.
- Preserve nonfatal `channel_not_found` and `not_in_channel` handling.
- Coordinate `runWorkers` with a shared generator/conversation context and concurrently drain generator errors, removing the fixed error-channel capacity.
- Cancel and join the `ConversationsCB` item producer deterministically.
- Add regression tests for queued fatal work, callback failures, external cancellation, nonfatal errors, blocked sends, producer joining, and generator shutdown.
- Deduplicate channel user IDs and keep related conversation constants local to their use.

## Validation

- `go test -race ./stream ./internal/chunk/control`
- Repeated focused race tests
- `go test ./... -run '^$'`
- `git diff --check`