### PR TITLE
fix: show refreshed thread parents in channel timeline

### DIFF
--- a/internal/chunk/backend/dbase/repository/dbmessage.go
+++ b/internal/chunk/backend/dbase/repository/dbmessage.go
@@ -168,10 +168,9 @@ func NewMessageRepository() MessageRepository {
 }
 
 // channelTimelineCondition keeps thread replies out of a channel timeline while
-// retaining thread parents.  A resume that explicitly rechecks a thread stores
-// its result in a CThreadMessages chunk with ThreadOnly=false, so that parent
-// must be included as well as parents from thread-only chunks.
-const channelTimelineCondition = " AND ((CH.TYPE_ID=0 AND (CH.THREAD_ONLY=FALSE OR CH.THREAD_ONLY IS NULL)) OR (CH.TYPE_ID=1 AND T.IS_PARENT=TRUE))"
+// retaining parents from both thread-only and non-thread-only chunks. A
+// self-referencing PARENT_ID identifies a parent even after its replies are deleted.
+const channelTimelineCondition = " AND ((CH.TYPE_ID=0 AND (CH.THREAD_ONLY=FALSE OR CH.THREAD_ONLY IS NULL)) OR (CH.TYPE_ID=1 AND T.PARENT_ID=T.ID))"
 
 func (r messageRepository) Count(ctx context.Context, conn sqlx.QueryerContext, channelID string) (int64, error) {
 	return r.countTypeWhere(

--- a/internal/chunk/backend/dbase/repository/dbmessage.go
+++ b/internal/chunk/backend/dbase/repository/dbmessage.go
@@ -167,14 +167,18 @@ func NewMessageRepository() MessageRepository {
 	return messageRepository{newGenericRepository(DBMessage{})}
 }
 
-const threadOnlyCondition = " AND ((CH.TYPE_ID=0 AND (CH.THREAD_ONLY=FALSE OR CH.THREAD_ONLY IS NULL)) OR (CH.TYPE_ID=1 AND CH.THREAD_ONLY=TRUE AND T.IS_PARENT=TRUE))"
+// channelTimelineCondition keeps thread replies out of a channel timeline while
+// retaining thread parents.  A resume that explicitly rechecks a thread stores
+// its result in a CThreadMessages chunk with ThreadOnly=false, so that parent
+// must be included as well as parents from thread-only chunks.
+const channelTimelineCondition = " AND ((CH.TYPE_ID=0 AND (CH.THREAD_ONLY=FALSE OR CH.THREAD_ONLY IS NULL)) OR (CH.TYPE_ID=1 AND T.IS_PARENT=TRUE))"
 
 func (r messageRepository) Count(ctx context.Context, conn sqlx.QueryerContext, channelID string) (int64, error) {
 	return r.countTypeWhere(
 		ctx,
 		conn,
 		queryParams{
-			Where: "T.CHANNEL_ID = ?" + threadOnlyCondition,
+			Where: "T.CHANNEL_ID = ?" + channelTimelineCondition,
 			Binds: []any{channelID}},
 		chunk.CMessages, chunk.CThreadMessages,
 	)
@@ -185,7 +189,7 @@ func (r messageRepository) AllForID(ctx context.Context, conn sqlx.QueryerContex
 		ctx,
 		conn,
 		queryParams{
-			Where:        "T.CHANNEL_ID = ?" + threadOnlyCondition,
+			Where:        "T.CHANNEL_ID = ?" + channelTimelineCondition,
 			Binds:        []any{channelID},
 			UserKeyOrder: true,
 		},

--- a/internal/chunk/backend/dbase/repository/dbmessage_test.go
+++ b/internal/chunk/backend/dbase/repository/dbmessage_test.go
@@ -340,7 +340,7 @@ func Test_messageRepository_Count(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "counts the thread only too",
+			name: "counts parents from thread-only chunks too",
 			fields: fields{
 				genericRepository: genericRepository[DBMessage]{DBMessage{}},
 			},
@@ -350,6 +350,20 @@ func Test_messageRepository_Count(t *testing.T) {
 				channelID: testChannelID,
 			},
 			prepFn:  finishedThreadFn,
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "counts parents from resumed thread chunks too",
+			fields: fields{
+				genericRepository: genericRepository[DBMessage]{DBMessage{}},
+			},
+			args: args{
+				ctx:       t.Context(),
+				conn:      testConn(t),
+				channelID: testChannelID,
+			},
+			prepFn:  resumedThreadFn,
 			want:    1,
 			wantErr: false,
 		},
@@ -392,7 +406,7 @@ func Test_messageRepository_AllForID(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Get only channel messages for C123 (no thread, and only latest version of the message)",
+			name: "gets channel messages and the latest thread parent",
 			fields: fields{
 				genericRepository: genericRepository[DBMessage]{DBMessage{}},
 			},
@@ -405,7 +419,23 @@ func Test_messageRepository_AllForID(t *testing.T) {
 			want: []testutil.TestResult[DBMessage]{
 				{V: *dbmA},
 				{V: *dbmB_},
-				{V: *dbmC},
+				{V: *dbmCt0},
+			},
+			wantErr: false,
+		},
+		{
+			name: "on resumed threads, returns the parent in the channel timeline",
+			fields: fields{
+				genericRepository: genericRepository[DBMessage]{DBMessage{}},
+			},
+			args: args{
+				ctx:       t.Context(),
+				conn:      testConn(t),
+				channelID: testChannelID,
+			},
+			prepFn: resumedThreadFn,
+			want: []testutil.TestResult[DBMessage]{
+				{V: *must(NewDBMessage(3, 0, testChannelID, &slack.Message{Msg: slack.Msg{Timestamp: testThreadID, ThreadTimestamp: testThreadID, Text: "A"}}))},
 			},
 			wantErr: false,
 		},
@@ -1132,64 +1162,69 @@ func Test_messageRepository_Sorted(t *testing.T) {
 }
 
 var (
-	// Thread only setup functions
-	finishedThreadFn = func(t *testing.T, conn PrepareExtContext) {
-		// for thread only entity list items there are no CMessage chunks, only CThreadMessages
-		// and these chunks have threadOnly = true
-		//
-		// Sample setup:
-		//
-		// Thread: 123.456
-		// 1. There are three chunks, 2 non-final and last one is final.
-		// 2. Each chunk will have 2 messages, one is a thread message and the other is a thread lead,
-		//    because API always returns the thread lead with the thread messages.
-		ctx := t.Context()
-		var sr sessionRepository
-		sess, err := sr.Insert(ctx, conn, &Session{ID: 1, Finished: true})
-		if err != nil {
-			t.Fatalf("insert session: %v", err)
-		}
+	// Thread-only and direct-resume thread setup functions.
+	finishedThreadFn = threadChunkFn(true)
+	resumedThreadFn  = threadChunkFn(false)
 
-		var bTrue = true
-		// prepare and insert chunks
-		chunks := [...]DBChunk{
-			{ID: 1, TypeID: chunk.CThreadMessages, ChannelID: &testChannelID, SessionID: sess, Final: false, ThreadOnly: &bTrue},
-			{ID: 2, TypeID: chunk.CThreadMessages, ChannelID: &testChannelID, SessionID: sess, Final: false, ThreadOnly: &bTrue},
-			{ID: 3, TypeID: chunk.CThreadMessages, ChannelID: &testChannelID, SessionID: sess, Final: true, ThreadOnly: &bTrue},
-		}
-		var cr chunkRepository
-		for _, chunk := range chunks {
-			if _, err := cr.Insert(ctx, conn, &chunk); err != nil {
-				t.Fatalf("insert chunk: %v", err)
+	threadChunkFn = func(threadOnly bool) utilityFn {
+		return func(t *testing.T, conn PrepareExtContext) {
+			// for thread only entity list items there are no CMessage chunks, only CThreadMessages
+			// and these chunks have threadOnly = true
+			//
+			// Sample setup:
+			//
+			// Thread: 123.456
+			// 1. There are three chunks, 2 non-final and last one is final.
+			// 2. Each chunk will have 2 messages, one is a thread message and the other is a thread lead,
+			//    because API always returns the thread lead with the thread messages.
+			ctx := t.Context()
+			var sr sessionRepository
+			sess, err := sr.Insert(ctx, conn, &Session{ID: 1, Finished: true})
+			if err != nil {
+				t.Fatalf("insert session: %v", err)
 			}
-		}
-		var (
-			parentMsg = slack.Message{Msg: slack.Msg{Timestamp: testThreadID, ThreadTimestamp: testThreadID, Text: "A"}}
 
-			tm1 = slack.Message{Msg: slack.Msg{Timestamp: "124.000", ThreadTimestamp: testThreadID, Text: "B"}}
-			tm2 = slack.Message{Msg: slack.Msg{Timestamp: "125.000", ThreadTimestamp: testThreadID, Text: "C"}}
-			tm3 = slack.Message{Msg: slack.Msg{Timestamp: "126.000", ThreadTimestamp: testThreadID, Text: "D"}}
-
-			chunkMessages = [len(chunks)][2]*DBMessage{
-				{
-					must(NewDBMessage(1, 0, testChannelID, &parentMsg)),
-					must(NewDBMessage(1, 1, testChannelID, &tm1)),
-				},
-				{
-					must(NewDBMessage(2, 0, testChannelID, &parentMsg)),
-					must(NewDBMessage(2, 1, testChannelID, &tm2)),
-				},
-				{
-					must(NewDBMessage(3, 0, testChannelID, &parentMsg)),
-					must(NewDBMessage(3, 1, testChannelID, &tm3)),
-				},
+			threadOnlyValue := threadOnly
+			// prepare and insert chunks
+			chunks := [...]DBChunk{
+				{ID: 1, TypeID: chunk.CThreadMessages, ChannelID: &testChannelID, SessionID: sess, Final: false, ThreadOnly: &threadOnlyValue},
+				{ID: 2, TypeID: chunk.CThreadMessages, ChannelID: &testChannelID, SessionID: sess, Final: false, ThreadOnly: &threadOnlyValue},
+				{ID: 3, TypeID: chunk.CThreadMessages, ChannelID: &testChannelID, SessionID: sess, Final: true, ThreadOnly: &threadOnlyValue},
 			}
-		)
+			var cr chunkRepository
+			for _, chunk := range chunks {
+				if _, err := cr.Insert(ctx, conn, &chunk); err != nil {
+					t.Fatalf("insert chunk: %v", err)
+				}
+			}
+			var (
+				parentMsg = slack.Message{Msg: slack.Msg{Timestamp: testThreadID, ThreadTimestamp: testThreadID, Text: "A"}}
 
-		var mr messageRepository
-		for i := range chunks {
-			if err := mr.Insert(ctx, conn, chunkMessages[i][:]...); err != nil {
-				t.Fatalf("insert message: %v", err)
+				tm1 = slack.Message{Msg: slack.Msg{Timestamp: "124.000", ThreadTimestamp: testThreadID, Text: "B"}}
+				tm2 = slack.Message{Msg: slack.Msg{Timestamp: "125.000", ThreadTimestamp: testThreadID, Text: "C"}}
+				tm3 = slack.Message{Msg: slack.Msg{Timestamp: "126.000", ThreadTimestamp: testThreadID, Text: "D"}}
+
+				chunkMessages = [len(chunks)][2]*DBMessage{
+					{
+						must(NewDBMessage(1, 0, testChannelID, &parentMsg)),
+						must(NewDBMessage(1, 1, testChannelID, &tm1)),
+					},
+					{
+						must(NewDBMessage(2, 0, testChannelID, &parentMsg)),
+						must(NewDBMessage(2, 1, testChannelID, &tm2)),
+					},
+					{
+						must(NewDBMessage(3, 0, testChannelID, &parentMsg)),
+						must(NewDBMessage(3, 1, testChannelID, &tm3)),
+					},
+				}
+			)
+
+			var mr messageRepository
+			for i := range chunks {
+				if err := mr.Insert(ctx, conn, chunkMessages[i][:]...); err != nil {
+					t.Fatalf("insert message: %v", err)
+				}
 			}
 		}
 	}

--- a/internal/chunk/backend/dbase/repository/dbmessage_test.go
+++ b/internal/chunk/backend/dbase/repository/dbmessage_test.go
@@ -354,7 +354,7 @@ func Test_messageRepository_Count(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "counts parents from resumed thread chunks too",
+			name: "counts parents from non-thread-only chunks too",
 			fields: fields{
 				genericRepository: genericRepository[DBMessage]{DBMessage{}},
 			},
@@ -363,8 +363,22 @@ func Test_messageRepository_Count(t *testing.T) {
 				conn:      testConn(t),
 				channelID: testChannelID,
 			},
-			prepFn:  resumedThreadFn,
+			prepFn:  nonThreadOnlyThreadFn,
 			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "counts empty thread parents",
+			fields: fields{
+				genericRepository: genericRepository[DBMessage]{DBMessage{}},
+			},
+			args: args{
+				ctx:       t.Context(),
+				conn:      testConn(t),
+				channelID: testChannelID,
+			},
+			prepFn:  emptyThreadParentFn,
+			want:    2,
 			wantErr: false,
 		},
 	}
@@ -424,7 +438,7 @@ func Test_messageRepository_AllForID(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "on resumed threads, returns the parent in the channel timeline",
+			name: "on non-thread-only chunks, returns the parent in the channel timeline",
 			fields: fields{
 				genericRepository: genericRepository[DBMessage]{DBMessage{}},
 			},
@@ -433,9 +447,36 @@ func Test_messageRepository_AllForID(t *testing.T) {
 				conn:      testConn(t),
 				channelID: testChannelID,
 			},
-			prepFn: resumedThreadFn,
+			prepFn: nonThreadOnlyThreadFn,
 			want: []testutil.TestResult[DBMessage]{
 				{V: *must(NewDBMessage(3, 0, testChannelID, &slack.Message{Msg: slack.Msg{Timestamp: testThreadID, ThreadTimestamp: testThreadID, Text: "A"}}))},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns the newest parent after all replies are deleted",
+			fields: fields{
+				genericRepository: genericRepository[DBMessage]{DBMessage{}},
+			},
+			args: args{
+				ctx:       t.Context(),
+				conn:      testConn(t),
+				channelID: testChannelID,
+			},
+			prepFn: emptyThreadParentFn,
+			want: []testutil.TestResult[DBMessage]{
+				{V: *must(NewDBMessage(2, 0, testChannelID, &slack.Message{Msg: slack.Msg{
+					Timestamp:       testThreadID,
+					ThreadTimestamp: testThreadID,
+					LatestReply:     structures.LatestReplyNoReplies,
+					Text:            "new",
+				}}))},
+				{V: *must(NewDBMessage(2, 1, testChannelID, &slack.Message{Msg: slack.Msg{
+					Timestamp:       "124.456",
+					ThreadTimestamp: "124.456",
+					LatestReply:     structures.LatestReplyNoReplies,
+					Text:            "only",
+				}}))},
 			},
 			wantErr: false,
 		},
@@ -1162,15 +1203,12 @@ func Test_messageRepository_Sorted(t *testing.T) {
 }
 
 var (
-	// Thread-only and direct-resume thread setup functions.
-	finishedThreadFn = threadChunkFn(true)
-	resumedThreadFn  = threadChunkFn(false)
+	// Thread-only and non-thread-only setup functions.
+	finishedThreadFn      = threadChunkFn(true)
+	nonThreadOnlyThreadFn = threadChunkFn(false)
 
 	threadChunkFn = func(threadOnly bool) utilityFn {
 		return func(t *testing.T, conn PrepareExtContext) {
-			// for thread only entity list items there are no CMessage chunks, only CThreadMessages
-			// and these chunks have threadOnly = true
-			//
 			// Sample setup:
 			//
 			// Thread: 123.456
@@ -1226,6 +1264,55 @@ var (
 					t.Fatalf("insert message: %v", err)
 				}
 			}
+		}
+	}
+
+	emptyThreadParentFn = func(t *testing.T, conn PrepareExtContext) {
+		ctx := t.Context()
+		var sr sessionRepository
+		sess, err := sr.Insert(ctx, conn, &Session{ID: 1, Finished: true})
+		if err != nil {
+			t.Fatalf("insert session: %v", err)
+		}
+
+		threadOnly := false
+		chunks := [...]DBChunk{
+			{TypeID: chunk.CMessages, ChannelID: &testChannelID, SessionID: sess, Final: true},
+			{TypeID: chunk.CThreadMessages, ChannelID: &testChannelID, SessionID: sess, Final: true, ThreadOnly: &threadOnly},
+		}
+		var cr chunkRepository
+		for i := range chunks {
+			if _, err := cr.Insert(ctx, conn, &chunks[i]); err != nil {
+				t.Fatalf("insert chunk: %v", err)
+			}
+		}
+
+		oldParent := slack.Message{Msg: slack.Msg{
+			Timestamp:       testThreadID,
+			ThreadTimestamp: testThreadID,
+			LatestReply:     "124.000",
+			Text:            "old",
+		}}
+		emptyParent := slack.Message{Msg: slack.Msg{
+			Timestamp:       testThreadID,
+			ThreadTimestamp: testThreadID,
+			LatestReply:     structures.LatestReplyNoReplies,
+			Text:            "new",
+		}}
+		threadChunkOnlyEmptyParent := slack.Message{Msg: slack.Msg{
+			Timestamp:       "124.456",
+			ThreadTimestamp: "124.456",
+			LatestReply:     structures.LatestReplyNoReplies,
+			Text:            "only",
+		}}
+
+		var mr messageRepository
+		if err := mr.Insert(ctx, conn,
+			must(NewDBMessage(1, 0, testChannelID, &oldParent)),
+			must(NewDBMessage(2, 0, testChannelID, &emptyParent)),
+			must(NewDBMessage(2, 1, testChannelID, &threadChunkOnlyEmptyParent)),
+		); err != nil {
+			t.Fatalf("insert message: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Fixes #730.

Thread parents fetched by `resume -threads` are now shown in the channel timeline, while replies remain thread-only. Adds regression coverage for resumed thread chunks.